### PR TITLE
GL-1157.  Update to GDA-8v1-0_A5

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,8 @@
+# 2.0.1
+2020-08-31
+
+* Fixed regression in the fix for VcfToMercuryFingerprintJson task
+
 # 2.0
 2020-07-31
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow Arrays {
 
-  String pipeline_version = "2.0"
+  String pipeline_version = "2.0.1"
 
   input {
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
@@ -7,13 +7,13 @@
   "Arrays.reported_gender": "Female",
   "Arrays.chip_well_barcode": "204126290052_R01C01",
 
-  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
-  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/inputs/204126290052_R01C01/params.txt",
+  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
+  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
+  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/inputs/204126290052_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.1.5.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.1.5.extended.csv",
+  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A1_ClusterFile.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
@@ -1,3 +1,7 @@
+# 1.9.1
+2020-08-31
+
+* Update name of extended Illumina manifest file to be commensurate with version used in picard-private.
 # 1.9
 2020-07-31
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
@@ -65,7 +65,7 @@ workflow ValidateChip {
   call InternalTasks.CreateExtendedIlluminaManifest {
     input:
       input_csv = chip_manifest_csv_file,
-      output_base_name = chip_type + ".1.4",
+      output_base_name = chip_type + ".1.5",
       cluster_file = cluster_file,
       dbSNP_vcf_file = dbSNP_vcf,
       dbSNP_vcf_index_file = dbSNP_vcf_index,

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GDA-8v1-0_A5.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GDA-8v1-0_A5.json
@@ -6,12 +6,12 @@
   "ValidateChip.reported_gender": "Female",
   "ValidateChip.chip_well_barcode": "204126290052_R01C01",
 
-  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
-  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
+  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
+  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.bpm",
+  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A1_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878.json
@@ -6,12 +6,12 @@
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "204126290052_R01C01",
 
-  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
-  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A1/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
+  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
+  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1.1.5.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A1/GDA-8v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.1.5.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/tasks/broad/InternalArraysTasks.wdl
+++ b/tasks/broad/InternalArraysTasks.wdl
@@ -143,9 +143,9 @@ task VcfToMercuryFingerprintJson {
     # Find the column number of AUTOCALL_PF and retrieve the value in the second line of the AUTOCALL_PF column
     # AUTOCALL_PF set to empty if file has more than 2 lines (should only have column headers and one data line)
     AUTOCALL_PF=$(sed '/#/d' ~{variant_calling_detail_metrics_file} |
-      sed /'^\s*$/d' |
+      sed '/^\s*$/d' |
       awk -v col=AUTOCALL_PF -F '\t' \
-      'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}}} NR==2{print $c} NR>2{exit 1}'')
+      'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}}} NR==2{print $c} NR>2{exit 1}')
 
     if [[ "$AUTOCALL_PF" == "Y" ]]
     then


### PR DESCRIPTION
Replace scientific test using GDA-8v1-0_A1 with GDA-8v1-0_A5 (new bpm and csv supplied by Illumina).

Also bump CreateExtendedIlluminaManifest version in wdl to 1.5 to be consistent with picard-private tool in use.