### PR TITLE
Add the broad folder to the task path

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
@@ -28,12 +28,12 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../../../../../tasks/UnmappedBamToAlignedBam.wdl" as ToBam
-import "../../../../../../tasks/AggregatedBamQC.wdl" as AggregatedQC
-import "../../../../../../tasks/Qc.wdl" as QC
-import "../../../../../../tasks/BamProcessing.wdl" as Processing
-import "../../../../../../tasks/BamToCram.wdl" as ToCram
-import "../../../../../../tasks/VariantCalling.wdl" as ToGvcf
+import "../../../../../../tasks/broad/UnmappedBamToAlignedBam.wdl" as ToBam
+import "../../../../../../tasks/broad/AggregatedBamQC.wdl" as AggregatedQC
+import "../../../../../../tasks/broad/Qc.wdl" as QC
+import "../../../../../../tasks/broad/BamProcessing.wdl" as Processing
+import "../../../../../../tasks/broad/BamToCram.wdl" as ToCram
+import "../../../../../../tasks/broad/VariantCalling.wdl" as ToGvcf
 import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/README.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/README.md
@@ -39,7 +39,7 @@ The Exome Germline Single Sample workflow is written in the Workflow Description
 
 # Workflow Tasks and Tools
 
-The Exome Germline Single Sample [workflow](ExomeGermlineSingleSample.wdl) imports a series of tasks from the dsde-pipelines [tasks library](../../../../../../tasks/) and a DNASeq struct ([DNASeqStructs.wdl](../../../../../../structs/dna_seq/DNASeqStructs.wdl)) containing reference files from the [structs library](../../../../../../structs/).
+The Exome Germline Single Sample [workflow](ExomeGermlineSingleSample.wdl) imports a series of tasks from the dsde-pipelines [tasks library](../../../../../../tasks/broad/) and a DNASeq struct ([DNASeqStructs.wdl](../../../../../../structs/dna_seq/DNASeqStructs.wdl)) containing reference files from the [structs library](../../../../../../structs/).
 
 You can read more about the software tools implemented in these tasks by reading the GATK [data pre-processing](https://gatk.broadinstitute.org/hc/en-us/articles/360035535912) and [germline short variant discovery](https://gatk.broadinstitute.org/hc/en-us/articles/360035535932) documentation.
 

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/README.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/README.md
@@ -35,7 +35,7 @@ The [Whole Genome Germline Single Sample workflow](WholeGenomeGermlineSingleSamp
 
 # Workflow Tasks and Tools
 
-The Whole Genome Germline Single Sample [workflow](WholeGenomeGermlineSingleSample.wdl) imports a series of tasks from the DSDE-Pipelines [tasks library](../../../../../../tasks/) and a DNASeq struct ([DNASeqStructs.wdl](../../../../../../structs/dna_seq/DNASeqStructs.wdl)) containing reference files from the [structs library](../../../../../../structs/).
+The Whole Genome Germline Single Sample [workflow](WholeGenomeGermlineSingleSample.wdl) imports a series of tasks from the DSDE-Pipelines [tasks library](../../../../../../tasks/broad/) and a DNASeq struct ([DNASeqStructs.wdl](../../../../../../structs/dna_seq/DNASeqStructs.wdl)) containing reference files from the [structs library](../../../../../../structs/).
 
 You can read more about the software tools implemented in these tasks by reading the GATK [data pre-processing](https://gatk.broadinstitute.org/hc/en-us/articles/360035535912) and [germline short variant discovery](https://gatk.broadinstitute.org/hc/en-us/articles/360035535932) documentation.
 

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -28,11 +28,11 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../../../../../tasks/UnmappedBamToAlignedBam.wdl" as ToBam
-import "../../../../../../tasks/AggregatedBamQC.wdl" as AggregatedQC
-import "../../../../../../tasks/Qc.wdl" as QC
-import "../../../../../../tasks/BamToCram.wdl" as ToCram
-import "../../../../../../tasks/VariantCalling.wdl" as ToGvcf
+import "../../../../../../tasks/broad/UnmappedBamToAlignedBam.wdl" as ToBam
+import "../../../../../../tasks/broad/AggregatedBamQC.wdl" as AggregatedQC
+import "../../../../../../tasks/broad/Qc.wdl" as QC
+import "../../../../../../tasks/broad/BamToCram.wdl" as ToCram
+import "../../../../../../tasks/broad/VariantCalling.wdl" as ToGvcf
 import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION

--- a/tasks/broad/AggregatedBamQC.wdl
+++ b/tasks/broad/AggregatedBamQC.wdl
@@ -15,7 +15,7 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/Qc.wdl" as QC
+import "../../tasks/broad/Qc.wdl" as QC
 import "../../structs/dna_seq/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION

--- a/tasks/broad/BamToCram.wdl
+++ b/tasks/broad/BamToCram.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../../tasks/Utilities.wdl" as Utils
-import "../../tasks/Qc.wdl" as QC
+import "../../tasks/broad/Utilities.wdl" as Utils
+import "../../tasks/broad/Qc.wdl" as QC
 
 workflow BamToCram {
 

--- a/tasks/broad/SplitLargeReadGroup.wdl
+++ b/tasks/broad/SplitLargeReadGroup.wdl
@@ -15,9 +15,9 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/Alignment.wdl" as Alignment
-import "../../tasks/BamProcessing.wdl" as Processing
-import "../../tasks/Utilities.wdl" as Utils
+import "../../tasks/broad/Alignment.wdl" as Alignment
+import "../../tasks/broad/BamProcessing.wdl" as Processing
+import "../../tasks/broad/Utilities.wdl" as Utils
 import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
 
 workflow SplitLargeReadGroup {

--- a/tasks/broad/UnmappedBamToAlignedBam.wdl
+++ b/tasks/broad/UnmappedBamToAlignedBam.wdl
@@ -16,11 +16,11 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/Alignment.wdl" as Alignment
-import "../../tasks/SplitLargeReadGroup.wdl" as SplitRG
-import "../../tasks/Qc.wdl" as QC
-import "../../tasks/BamProcessing.wdl" as Processing
-import "../../tasks/Utilities.wdl" as Utils
+import "../../tasks/broad/Alignment.wdl" as Alignment
+import "../../tasks/broad/SplitLargeReadGroup.wdl" as SplitRG
+import "../../tasks/broad/Qc.wdl" as QC
+import "../../tasks/broad/BamProcessing.wdl" as Processing
+import "../../tasks/broad/Utilities.wdl" as Utils
 import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
 
 # WORKFLOW DEFINITION

--- a/tasks/broad/VariantCalling.wdl
+++ b/tasks/broad/VariantCalling.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
-import "../../tasks/GermlineVariantDiscovery.wdl" as Calling
-import "../../tasks/Qc.wdl" as QC
-import "../../tasks/Utilities.wdl" as Utils
-import "../../tasks/BamProcessing.wdl" as BamProcessing
+import "../../tasks/broad/GermlineVariantDiscovery.wdl" as Calling
+import "../../tasks/broad/Qc.wdl" as QC
+import "../../tasks/broad/Utilities.wdl" as Utils
+import "../../tasks/broad/BamProcessing.wdl" as BamProcessing
 
 workflow VariantCalling {
 


### PR DESCRIPTION
In recent PRs. to copy over wdls, I used the wrong path to the tasks. This corrects that error. 

I do not think these changes warrant a version increase or changelog entry.