### PR TITLE
Use default truth for Joint Genotyping and reprocessing tests

### DIFF
--- a/scripts/get_changed_pipeline_worklow_test_args.sh
+++ b/scripts/get_changed_pipeline_worklow_test_args.sh
@@ -28,13 +28,13 @@ function pipeline_to_args() {
       echo Reprocessing -d Exome ${common_args};;
     JointGenotyping)
       echo JointGenotyping -d Exome ${common_args};
-      echo JointGenotyping -d WGS --env ${env} -t Plumbing -b develop ${uncached};;
+      echo JointGenotyping -d WGS --env ${env} -t Plumbing -b ${truth} ${uncached};;
     IlluminaGenotypingArray)
       echo IlluminaGenotypingArray ${common_args};;
     ExternalExomeReprocessing)
-      echo ExternalReprocessing -d Exome --env ${env} -t Plumbing -b develop ${uncached};;
+      echo ExternalReprocessing -d Exome --env ${env} -t Plumbing -b ${truth} ${uncached};;
     ExternalWholeGenomeReprocessing)
-      echo ExternalReprocessing -d WGS --env ${env} -t Plumbing -b develop ${uncached};;
+      echo ExternalReprocessing -d WGS --env ${env} -t Plumbing -b ${truth} ${uncached};;
     WholeGenomeGermlineSingleSample)
       echo GermlineSingleSample -d WGS ${common_args};;
     WholeGenomeReprocessing)


### PR DESCRIPTION
A couple of the pipeline tests do not have scientific test inputs available, we have hard-coded these tests to run plumbing data. These were also always specifying the develop branch of truth. Since we recently switched to a default master branch for truth, some of the tests are failing. 
These changes allow all tests (that use truth branches) to use the truth branch specified when the test is initiated. 