### PR TITLE
releasing SS2 with loom bug fix (#105)

### DIFF
--- a/dockers/skylab/loom-output/create_loom_ss2.py
+++ b/dockers/skylab/loom-output/create_loom_ss2.py
@@ -51,9 +51,9 @@ def generate_col_attr(args):
     col_attrs["cell_names"] = [cell_id]
 
     if args.input_id_metadata_field:
-        col_attrs["input_id_metadata_field"] = args.input_id_metadata_field
+        col_attrs["input_id_metadata_field"] = [args.input_id_metadata_field]
     if args.input_name_metadata_field:
-            col_attrs["input_name_metadata_field"] = args.input_name_metadata_field
+            col_attrs["input_name_metadata_field"] = [args.input_name_metadata_field]
 
     numeric_field_names = np.array(sorted_numeric_labels[:])
     for i in range(0, numeric_field_names.shape[0]):

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/README.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/README.md
@@ -1,6 +1,6 @@
 | Pipeline Version | Date Updated | Documentation Author | Questions or Feedback |
 | :----: | :---: | :----: | :--------------: |
-| [WholeGenomeGermlineSingleSample_v2.0](https://github.com/broadinstitute/warp/releases) | June 22, 2020 | [Elizabeth Kiernan](mailto:ekiernan@broadinstitute.org) | Please file GitHub issues in WARP or contact [Kylee Degatano](mailto:kdegatano@broadinstitute.org) |
+| [WholeGenomeGermlineSingleSample_v2.0](https://github.com/broadinstitute/warp/releases) | October 02, 2020 | [Elizabeth Kiernan](mailto:ekiernan@broadinstitute.org) | Please file GitHub issues in WARP or contact [Kylee Degatano](mailto:kdegatano@broadinstitute.org) |
 
 # Introduction to the Whole Genome Germline Single Sample Pipeline
 
@@ -18,7 +18,7 @@ The [Whole Genome Germline Single Sample workflow](WholeGenomeGermlineSingleSamp
 * Samtools 1.3.1
 * Python 2.7 and 3.0
 * Cromwell version support 
-    * Successfully tested on v47
+    * Tested on Cromwell 52
     * Does not work on versions < v23 due to output syntax
 
 
@@ -48,6 +48,7 @@ You can read more about the software tools implemented in these tasks by reading
 
 # Important Notes
 * The accompanying JSON is a generic, ready to use, example template for the workflow. It is the user’s responsibility to correctly set the reference and resource variables for their own particular test case using the [GATK Tool and Tutorial Documentations](https://gatk.broadinstitute.org/hc/en-us/categories/360002310591).
+* By default, HaplotypeCaller will perform variant calling using GATK 3.5, which is what is used in Broad Production. To use GATK4, specify `use_gatk3_haplotype_caller=false` in the inputs.json.
 * Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
 * For help running workflows on the Google Cloud Platform or locally please
 view the following tutorial [(How to) Execute Workflows from the gatk-workflows Git Organization](https://gatk.broadinstitute.org/hc/en-us/articles/360035530952).

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,9 @@
+# 4.1.2
+
+2020-10-13 (Date of Last Commit)
+
+* Added a new docker in LoomUtils.wdl
+
 # 4.1.1
 
 2020-10-07 (Date of Last Commit)

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -56,7 +56,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "4.1.1"
+  String pipeline_version = "4.1.2"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -1,3 +1,10 @@
+# 2.1.2
+
+2020-10-13 (Date of Last Commit)
+
+* Fixed a bug in the loom file generation script that appeared when using optional input `input_id_metadata_field`
+* Updated the docker in LoomUtils.wdl task to v0.0.3
+
 # 2.1.1
 
 2020-10-01 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl
@@ -34,7 +34,7 @@ workflow MultiSampleSmartSeq2 {
       Boolean paired_end
   }
   # Version of this pipeline
-  String pipeline_version = "2.1.1"
+  String pipeline_version = "2.1.2"
 
   if (false) {
      String? none = "None"

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -1,3 +1,10 @@
+# 5.0.2
+
+2020-10-13 (Date of Last Commit)
+
+* Fixed a bug in the loom file generation script that appeared when using optional input `input_id_metadata_field`
+* Updated the docker in LoomUtils.wdl task to v0.0.3
+
 # 5.0.1
 
 2020-10-01 (Date of Last Commit)
@@ -88,6 +95,5 @@
 2018-06-14 (Date of Last Commit)
 
 * No release note available
-
 
 

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -38,7 +38,7 @@ workflow SmartSeq2SingleCell {
   }
   
   # version of this pipeline
-  String pipeline_version = "5.0.1"
+  String pipeline_version = "5.0.2"
 
   parameter_meta {
     genome_ref_fasta: "Genome reference in fasta format"

--- a/tasks/skylab/LoomUtils.wdl
+++ b/tasks/skylab/LoomUtils.wdl
@@ -3,7 +3,7 @@ version 1.0
 task SmartSeq2LoomOutput {
   input {
     #runtime values
-    String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3-fk-2"
+    String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3"
     # the gene count file "<input_id>_rsem.genes.results" in the task results folder call-RSEMExpression
     File rsem_gene_results
     # file named "<input_id>_QCs.csv" in the folder  "call-GroupQCOutputs/glob-*" of the the SS2  output
@@ -58,7 +58,7 @@ task OptimusLoomGeneration {
 
   input {
     #runtime values
-    String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3-fk-2"
+    String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3"
     # name of the sample
     String input_id
     # user provided id
@@ -143,7 +143,7 @@ task AggregateSmartSeq2Loom {
         String batch_id
         String? batch_name
         String pipeline_version
-        String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3-fk-2"
+        String docker = "quay.io/humancellatlas/secondary-analysis-loom-output:0.0.3"
         Int disk = 100
     }
 


### PR DESCRIPTION
* Adding a note about haplotype caller version (#95)

* Adding a note about haplotype caller version

In this pipeline, by default the variant calling is done with GATK3.5 unless the user specifies an input parameter to use GATK4. We don't explain that anywhere and our example inputs use the defaults. 

I would suggest to put more documentation / example inputs but my hope is we will be going to DRAGEN-GATK genome pipeline soon and this will be deprecated so maybe not worth it. 

Other side question - I thought we updated documentation about the cromwell version support but at least develop seems to still note it was successfully tested on cromwell 47 - should we say it's now tested on cromwell 52 and newer? @ekiernan

* Update README.md

* Update README.md

Co-authored-by: ekiernan <55763654+ekiernan@users.noreply.github.com>

* changed metadata string to a list (#103)

* changed metadata string to a list

* version update

* reverted docker change for Optimus

* Update pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md

Co-authored-by: Kylee Degatano <kdegatano@broadinstitute.org>

* Update pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md

Co-authored-by: Kylee Degatano <kdegatano@broadinstitute.org>

* Changed Optimus version

Co-authored-by: Kylee Degatano <kdegatano@broadinstitute.org>

Co-authored-by: Kylee Degatano <kdegatano@broadinstitute.org>
Co-authored-by: ekiernan <55763654+ekiernan@users.noreply.github.com>