### PR TITLE
Fixed minor issues in minor issues in BuildIndices

### DIFF
--- a/pipelines/skylab/build_indices/mouse_inputs.json
+++ b/pipelines/skylab/build_indices/mouse_inputs.json
@@ -3,5 +3,5 @@
   "BuildIndices.organism": "mouse",
   "BuildIndices.organism_prefix": "m",
   "BuildIndices.genome_short_string": "mm10",
-  "BuildIndices.dbsnp_version": "150"
+  "BuildIndices.dbsnp_version": "142"
 }


### PR DESCRIPTION
1) the output file names for two tasks was identical causing errors when running cromwell with the "final_workflow_outputs_dir" option.

2) the task "BuildHisat2SnpHaplotypeSplicing" pointed to scripts not found in the container. This is now fixed and _seems_ to work.

3) Minor: the example "mouse_inputs.json" input file points to version 150 of dbsnp but the latest version on UCSC (https://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/) seems to be 142. 