### PR TITLE
Fix bash if space syntax

### DIFF
--- a/tasks/broad/Alignment.wdl
+++ b/tasks/broad/Alignment.wdl
@@ -54,7 +54,7 @@ task SamToFastqAndBwaMemAndMba {
     set -o pipefail
     set -e
 
-    if [-z ${BWA_VERSION}]; then
+    if [ -z ${BWA_VERSION}]; then
         exit 1;
     fi
 

--- a/tasks/broad/Alignment.wdl
+++ b/tasks/broad/Alignment.wdl
@@ -54,7 +54,7 @@ task SamToFastqAndBwaMemAndMba {
     set -o pipefail
     set -e
 
-    if [ -z ${BWA_VERSION}]; then
+    if [ -z ${BWA_VERSION} ]; then
         exit 1;
     fi
 


### PR DESCRIPTION
Currently this error is produced

```
/cromwell_root/script: line 31: [-z: command not found
```