### PR TITLE
Remove custom entrypoint Picard Docker image

### DIFF
--- a/beta-pipelines/broad/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl
+++ b/beta-pipelines/broad/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl
@@ -400,8 +400,12 @@ task picard_markduplicates {
         File bam = "~{outbam}"
     }
 
+# We are using a non-standard docker image here because we currently run this WDL on Cromwell v52 which cannot support
+# the custom entrypoint in the picard-cloud:2.18.11 docker image. Cromwell v53 and newer can support the
+# us.gcr.io/broad-gotc-prod/picard-cloud:2.18.11 docker image
+
     runtime {
-        docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.18.11"
+        docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.18.11_NoCustomEntryPoint"
         memory: mem + " GB"
         disks: "local-disk " + disk_space + " HDD"
         preemptible: preemptible


### PR DESCRIPTION
Picard:2.18.11 docker image has a custom entrypoint which Terra cromwell just ignores, but older versions of Cromwell cannot support. So that we can run this pipeline on GOTC which is Cromwell52 quickly, we are changing to a new docker image without a custom entrypoint.