### PR TITLE
Optimus merged matrix adapter bug fix

### DIFF
--- a/dockers/skylab/HCA_post_processing/HCA_create_adapter_json.py
+++ b/dockers/skylab/HCA_post_processing/HCA_create_adapter_json.py
@@ -168,8 +168,12 @@ def main():
                                #                          # example: NONE;
                                #                          # gs://hca-dcp-mint-test-data/../gencode_v27_primary.tar"
                                # }  # Input parameters used in the pipeline run.
-                             ],
-                              "analysis_run_type": analysis_type
+                              ],
+                              "analysis_run_type": analysis_type,
+                              "provenance": {
+                                "document_id": process_id,
+                                "submission_date": file_version,
+                              },
                             }
 
     analysis_protocol_dict = {


### PR DESCRIPTION
Although the official schema does not include provenance as a required field in the analysis_process object, azul relies on this field. This PR adds it. 