### PR TITLE
Added DRAGEN-GATK features

### DIFF
--- a/structs/dna_seq/DNASeqStructs.wdl
+++ b/structs/dna_seq/DNASeqStructs.wdl
@@ -20,6 +20,12 @@ struct ReferenceFasta {
   File ref_pac
 }
 
+struct DragmapReference {
+  File reference_bin
+  File reference_index_bin
+  File hash_table_cmp
+}
+
 struct DNASeqSingleSampleReferences {
   File contamination_sites_ud
   File contamination_sites_bed

--- a/tasks/broad/Dragen.wdl
+++ b/tasks/broad/Dragen.wdl
@@ -1,0 +1,102 @@
+version 1.0
+
+## Copyright Broad Institute, 2020
+##
+## This WDL defines tasks to use Dragen's DRAGstr approach to STR sequencing artifacts 
+## Indel genotype priors in the DRAGEN-Gatk pipeline. 
+##
+## Runtime parameters are often optimized for Broad's Google Cloud Platform implementation.
+## For program versions, see docker containers.
+##
+## LICENSING :
+## This script is released under the WDL source code license (BSD-3) (see LICENSE in
+## https://github.com/broadinstitute/wdl). Note however that the programs it calls may
+## be subject to different licenses. Users are responsible for checking that they are
+## authorized to run all programs before running this script. Please see the docker
+## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
+## licensing information pertaining to the included programs.
+
+
+task ComposeSTRTableFile {
+    
+  input {
+    File ref_fasta
+    File ref_fasta_idx
+    File ref_dict
+    String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots/dragen_final_test_v2"
+    Int preemptible_tries = 3
+  }
+
+  String base_name = sub(basename(ref_fasta), ".fa(sta)$","")
+  String str_table_file_name = base_name + ".str"
+  Int disk_size_gb = ceil(size([ref_fasta, ref_fasta_idx], "GiB")) + 
+                        21 # 1gb for the output file (usually far less than that) and 20 for the rest of the fs.
+
+  command <<<
+
+    gatk --java-options "-Xmx2g" \
+      ComposeSTRTableFile \
+        -R ~{ref_fasta} \
+        -O ~{str_table_file_name}
+
+  >>>
+
+  runtime {
+    docker: docker 
+    disks: "local-disk " + disk_size_gb + " HDD"
+    memory: "3 GiB"
+    preemptible: preemptible_tries
+  }
+
+  output {
+    File str_table_file = "~{str_table_file_name}"
+  }
+}
+
+task CalibrateDragstrModel {
+
+  input {
+    File ref_fasta
+    File ref_fasta_idx
+    File ref_dict
+    File str_table_file
+    File alignment ## can handle cram or bam.
+    String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots/dragen_final_test_v2"
+    Int preemptible_tries = 3
+    Int threads = 4
+    Boolean use_ssd = true
+  }
+
+  String base_name = basename(alignment)
+  String out_file_name = base_name + ".dragstr"
+  Int disk_size_gb = ceil(size([ref_fasta, ref_fasta_idx, alignment, str_table_file], "GiB")) + 
+                        20 # 20 for the rest of the fs.
+
+  String parallel_args  = if (threads <= 1) then "" else "--parallel" 
+
+  command <<<
+    set -x
+    samtools index -@ ~{threads} ~{alignment}
+    gatk --java-options "-Xmx2g -DGATK_STACKTRACE_ON_USER_EXCEPTION=true" \
+      CalibrateDragstrModel \
+        -R ~{ref_fasta} \
+        -I ~{alignment} \
+        -str ~{str_table_file} \
+        -O ~{out_file_name} \
+        ~{parallel_args} \
+        --verbosity DEBUG
+
+  >>>
+
+  runtime {
+     docker: docker
+     disks: "local-disk " + disk_size_gb + (if use_ssd then " SSD" else " HDD")
+     memory: "3 GiB"
+     preemptible: preemptible_tries
+     cpu: threads
+  }
+
+  output {
+    File dragstr_model = "~{out_file_name}"
+  }
+}

--- a/tasks/broad/DragmapAlignment.wdl
+++ b/tasks/broad/DragmapAlignment.wdl
@@ -1,0 +1,109 @@
+version 1.0
+
+## Copyright Broad Institute, 2020
+##
+## This WDL defines tasks used for alignment of human whole-genome or exome sequencing data using Illumina's DRAGEN open source mapper.
+##
+## Runtime parameters are often optimized for Broad's Google Cloud Platform implementation.
+## For program versions, see docker containers.
+##
+## LICENSING :
+## This script is released under the WDL source code license (BSD-3) (see LICENSE in
+## https://github.com/broadinstitute/wdl). Note however that the programs it calls may
+## be subject to different licenses. Users are responsible for checking that they are
+## authorized to run all programs before running this script. Please see the docker
+## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
+## licensing information pertaining to the included programs.
+
+import "../../structs/dna_seq/DNASeqStructs.wdl"
+
+# Read unmapped BAM, convert on-the-fly to FASTQ and stream to BWA MEM for alignment, then stream to MergeBamAlignment
+task SamToFastqAndDragmapAndMba {
+  input {
+    File input_bam
+    String output_bam_basename
+
+    ReferenceFasta reference_fasta
+    DragmapReference dragmap_reference
+
+    File picard_jar = "gs://broad-dsde-methods-mgatzen/dragen_evaluation/alignment/picard-2.23.7-SNAPSHOT-all.jar"
+    File dragmap_binary
+
+    Int compression_level
+    Int preemptible_tries
+    Boolean hard_clip_reads = false
+  }
+
+  Float unmapped_bam_size = size(input_bam, "GiB")
+  Float ref_size = size(reference_fasta.ref_fasta, "GiB") + size(reference_fasta.ref_fasta_index, "GiB") + size(reference_fasta.ref_dict, "GiB")
+  Float bwa_ref_size = ref_size + size(reference_fasta.ref_alt, "GiB") + size(reference_fasta.ref_amb, "GiB") + size(reference_fasta.ref_ann, "GiB") + size(reference_fasta.ref_bwt, "GiB") + size(reference_fasta.ref_pac, "GiB") + size(reference_fasta.ref_sa, "GiB")
+  Float dragmap_ref_size = size(dragmap_reference.reference_bin, "GiB") + size(dragmap_reference.reference_index_bin, "GiB") + size(dragmap_reference.hash_table_cmp, "GiB")
+  Float disk_multiplier = 6
+  Int disk_size = ceil(unmapped_bam_size + bwa_ref_size + dragmap_ref_size + (disk_multiplier * unmapped_bam_size) + 20)
+
+  String dragmap_commandline = "-1 reads1.fastq.gz -2 reads2.fastq.gz -r dragen_reference"
+
+  command <<<
+
+
+    set -euxo pipefail
+
+
+    chmod +x ~{dragmap_binary}
+
+    DRAGMAP_VERSION=$(~{dragmap_binary} --version)
+
+    if [ -z ${DRAGMAP_VERSION} ]; then
+        exit 1;
+    fi
+
+    mkdir dragen_reference
+    mv ~{dragmap_reference.reference_bin} ~{dragmap_reference.reference_index_bin} ~{dragmap_reference.hash_table_cmp} dragen_reference
+
+    samtools fastq -1 reads1.fastq.gz -2 reads2.fastq.gz -0 /dev/null -s /dev/null -n ~{input_bam}
+
+    ~{dragmap_binary} ~{dragmap_commandline} 2> >(tee ~{output_bam_basename}.dragmap.stderr.log >&2) | \
+    java -Dsamjdk.compression_level=~{compression_level} -Xms1000m -Xmx1000m -jar ~{picard_jar} \
+      MergeBamAlignment \
+      VALIDATION_STRINGENCY=SILENT \
+      EXPECTED_ORIENTATIONS=FR \
+      ATTRIBUTES_TO_RETAIN=X0 \
+      ATTRIBUTES_TO_REMOVE=RG \
+      ATTRIBUTES_TO_REMOVE=NM \
+      ATTRIBUTES_TO_REMOVE=MD \
+      ALIGNED_BAM=/dev/stdin \
+      UNMAPPED_BAM=~{input_bam} \
+      OUTPUT=~{output_bam_basename}.bam \
+      REFERENCE_SEQUENCE=~{reference_fasta.ref_fasta} \
+      PAIRED_RUN=true \
+      SORT_ORDER="unsorted" \
+      IS_BISULFITE_SEQUENCE=false \
+      ALIGNED_READS_ONLY=false \
+      CLIP_ADAPTERS=false \
+      ~{true='CLIP_OVERLAPPING_READS=true' false="" hard_clip_reads} \
+      ~{true='CLIP_OVERLAPPING_READS_OPERATOR=H' false="" hard_clip_reads} \
+      MAX_RECORDS_IN_RAM=2000000 \
+      ADD_MATE_CIGAR=true \
+      MAX_INSERTIONS_OR_DELETIONS=-1 \
+      PRIMARY_ALIGNMENT_STRATEGY=MostDistant \
+      PROGRAM_RECORD_ID="dragen-os" \
+      PROGRAM_GROUP_VERSION="${DRAGMAP_VERSION}" \
+      PROGRAM_GROUP_COMMAND_LINE="dragen-os ~{dragmap_commandline}" \
+      PROGRAM_GROUP_NAME="dragen-os" \
+      UNMAPPED_READ_STRATEGY=COPY_TO_TAG \
+      ALIGNER_PROPER_PAIR_FLAGS=true \
+      UNMAP_CONTAMINANT_READS=true \
+      ADD_PG_TAG_TO_READS=false
+  >>>
+  runtime {
+    docker: "michaelgatzen/dragen_os"
+    preemptible: preemptible_tries
+    memory: "40 GiB"
+    cpu: "16"
+    disks: "local-disk " + disk_size + " HDD"
+  }
+  output {
+    File output_bam = "~{output_bam_basename}.bam"
+    File bwa_stderr_log = "~{output_bam_basename}.dragmap.stderr.log"
+  }
+}

--- a/tasks/broad/Qc.wdl
+++ b/tasks/broad/Qc.wdl
@@ -381,14 +381,14 @@ task ValidateSamFile {
     Array[String]? ignore
     Boolean? is_outlier_data
     Int preemptible_tries
-    Int memory_multiplier = 1
+    Int memory_multiplier = 2
     Int additional_disk = 20
   }
 
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
   Int disk_size = ceil(size(input_bam, "GiB") + ref_size) + additional_disk
 
-  Int memory_size = ceil(7 * memory_multiplier)
+  Int memory_size = ceil(10 * memory_multiplier)
   Int java_memory_size = (memory_size - 1) * 1000
 
   command {
@@ -406,6 +406,7 @@ task ValidateSamFile {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
     preemptible: preemptible_tries
+    maxRetries: 3
     memory: "~{memory_size} GiB"
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -491,6 +492,7 @@ task CollectRawWgsMetrics {
     preemptible: preemptible_tries
     memory: "~{memory_size} GiB"
     disks: "local-disk " + disk_size + " HDD"
+    maxReplies: 3
   }
   output {
     File metrics = "~{metrics_filename}"

--- a/tasks/broad/SplitLargeReadGroup.wdl
+++ b/tasks/broad/SplitLargeReadGroup.wdl
@@ -16,6 +16,7 @@ version 1.0
 ## licensing information pertaining to the included programs.
 
 import "../../tasks/broad/Alignment.wdl" as Alignment
+import "../../tasks/broad/DragmapAlignment.wdl" as DragmapAlignment
 import "../../tasks/broad/BamProcessing.wdl" as Processing
 import "../../tasks/broad/Utilities.wdl" as Utils
 import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
@@ -32,11 +33,15 @@ workflow SplitLargeReadGroup {
     # (https://github.com/lh3/bwa/tree/master/bwakit),
     # listing the reference contigs that are "alternative".
     ReferenceFasta reference_fasta
+    DragmapReference? dragmap_reference
+
+    File? dragmap_binary
 
     Int compression_level
     Int preemptible_tries
     Int reads_per_file = 48000000
     Boolean hard_clip_reads = false
+    Boolean use_bwa_mem = true
   }
 
   call Alignment.SamSplitter as SamSplitter {
@@ -51,18 +56,37 @@ workflow SplitLargeReadGroup {
     Float current_unmapped_bam_size = size(unmapped_bam, "GiB")
     String current_name = basename(unmapped_bam, ".bam")
 
-    call Alignment.SamToFastqAndBwaMemAndMba as SamToFastqAndBwaMemAndMba {
-      input:
-        input_bam = unmapped_bam,
-        bwa_commandline = bwa_commandline,
-        output_bam_basename = current_name,
-        reference_fasta = reference_fasta,
-        compression_level = compression_level,
-        preemptible_tries = preemptible_tries,
-        hard_clip_reads = hard_clip_reads
+    if (use_bwa_mem) {
+      call Alignment.SamToFastqAndBwaMemAndMba as SamToFastqAndBwaMemAndMba {
+        input:
+          input_bam = unmapped_bam,
+          bwa_commandline = bwa_commandline,
+          output_bam_basename = current_name,
+          reference_fasta = reference_fasta,
+          compression_level = compression_level,
+          preemptible_tries = preemptible_tries,
+          hard_clip_reads = hard_clip_reads
+      }
+    }
+    if (!use_bwa_mem) {
+      # select_first will fail if no dragmap_reference is provided.
+      # TODO Maybe call an error task to give a more descriptive error message?
+      call DragmapAlignment.SamToFastqAndDragmapAndMba as SamToFastqAndDragmapAndMba {
+        input:
+          input_bam = unmapped_bam,
+          dragmap_binary = select_first([dragmap_binary]),
+          output_bam_basename = current_name,
+          reference_fasta = reference_fasta,
+          dragmap_reference = select_first([dragmap_reference]),
+          compression_level = compression_level,
+          preemptible_tries = preemptible_tries,
+          hard_clip_reads = hard_clip_reads
+      }
     }
 
-    Float current_mapped_size = size(SamToFastqAndBwaMemAndMba.output_bam, "GiB")
+    File output_bam = select_first([SamToFastqAndBwaMemAndMba.output_bam, SamToFastqAndDragmapAndMba.output_bam])
+
+    Float current_mapped_size = size(output_bam, "GiB")
   }
 
   call Utils.SumFloats as SumSplitAlignedSizes {
@@ -73,7 +97,7 @@ workflow SplitLargeReadGroup {
 
   call Processing.GatherUnsortedBamFiles as GatherMonolithicBamFile {
     input:
-      input_bams = SamToFastqAndBwaMemAndMba.output_bam,
+      input_bams = output_bam,
       total_input_size = SumSplitAlignedSizes.total_size,
       output_bam_basename = output_bam_basename,
       preemptible_tries = preemptible_tries,

--- a/tasks/broad/UnmappedBamToAlignedBam.wdl
+++ b/tasks/broad/UnmappedBamToAlignedBam.wdl
@@ -17,6 +17,7 @@ version 1.0
 ## licensing information pertaining to the included programs.
 
 import "../../tasks/broad/Alignment.wdl" as Alignment
+import "../../tasks/broad/DragmapAlignment.wdl" as DragmapAlignment
 import "../../tasks/broad/SplitLargeReadGroup.wdl" as SplitRG
 import "../../tasks/broad/Qc.wdl" as QC
 import "../../tasks/broad/BamProcessing.wdl" as Processing
@@ -29,11 +30,14 @@ workflow UnmappedBamToAlignedBam {
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams
     DNASeqSingleSampleReferences references
+    DragmapReference? dragmap_reference
     PapiSettings papi_settings
 
     File contamination_sites_ud
     File contamination_sites_bed
     File contamination_sites_mu
+
+    File? dragmap_binary
 
     String cross_check_fingerprints_by
     File haplotype_database_file
@@ -42,6 +46,8 @@ workflow UnmappedBamToAlignedBam {
     Boolean hard_clip_reads = false
     Boolean bin_base_qualities = true
     Boolean somatic = false
+    Boolean perform_bqsr = true
+    Boolean use_bwa_mem = true
   }
 
   Float cutoff_for_large_rg_in_gb = 20.0
@@ -84,19 +90,36 @@ workflow UnmappedBamToAlignedBam {
 
     if (unmapped_bam_size <= cutoff_for_large_rg_in_gb) {
       # Map reads to reference
-      call Alignment.SamToFastqAndBwaMemAndMba as SamToFastqAndBwaMemAndMba {
-        input:
-          input_bam = unmapped_bam,
-          bwa_commandline = bwa_commandline,
-          output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
-          reference_fasta = references.reference_fasta,
-          compression_level = compression_level,
-          preemptible_tries = papi_settings.preemptible_tries,
-          hard_clip_reads = hard_clip_reads
+      if (use_bwa_mem) {
+        call Alignment.SamToFastqAndBwaMemAndMba as SamToFastqAndBwaMemAndMba {
+          input:
+            input_bam = unmapped_bam,
+            bwa_commandline = bwa_commandline,
+            output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
+            reference_fasta = references.reference_fasta,
+            compression_level = compression_level,
+            preemptible_tries = papi_settings.preemptible_tries,
+            hard_clip_reads = hard_clip_reads
+        }
+      }
+      if (!use_bwa_mem) {
+        # select_first will fail if no dragmap_reference is provided.
+        # TODO Maybe call an error task to give a more descriptive error message?
+        call DragmapAlignment.SamToFastqAndDragmapAndMba as SamToFastqAndDragmapAndMba {
+          input:
+            input_bam = unmapped_bam,
+            dragmap_binary = select_first([dragmap_binary]),
+            output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
+            reference_fasta = references.reference_fasta,
+            dragmap_reference = select_first([dragmap_reference]),
+            compression_level = compression_level,
+            preemptible_tries = papi_settings.preemptible_tries,
+            hard_clip_reads = hard_clip_reads
+        }
       }
     }
 
-    File output_aligned_bam = select_first([SamToFastqAndBwaMemAndMba.output_bam, SplitRG.aligned_bam])
+    File output_aligned_bam = select_first([SamToFastqAndBwaMemAndMba.output_bam, SamToFastqAndDragmapAndMba.output_bam, SplitRG.aligned_bam])
 
     Float mapped_bam_size = size(output_aligned_bam, "GiB")
 
@@ -190,59 +213,62 @@ workflow UnmappedBamToAlignedBam {
   Int bqsr_divisor = if potential_bqsr_divisor > 1 then potential_bqsr_divisor else 1
 
   # Perform Base Quality Score Recalibration (BQSR) on the sorted BAM in parallel
-  scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping) {
-    # Generate the recalibration model by interval
-    call Processing.BaseRecalibrator as BaseRecalibrator {
-      input:
-        input_bam = SortSampleBam.output_bam,
-        input_bam_index = SortSampleBam.output_bam_index,
-        recalibration_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
-        sequence_group_interval = subgroup,
-        dbsnp_vcf = references.dbsnp_vcf,
-        dbsnp_vcf_index = references.dbsnp_vcf_index,
-        known_indels_sites_vcfs = references.known_indels_sites_vcfs,
-        known_indels_sites_indices = references.known_indels_sites_indices,
-        ref_dict = references.reference_fasta.ref_dict,
-        ref_fasta = references.reference_fasta.ref_fasta,
-        ref_fasta_index = references.reference_fasta.ref_fasta_index,
-        bqsr_scatter = bqsr_divisor,
-        preemptible_tries = papi_settings.agg_preemptible_tries
+
+  if (perform_bqsr) {
+    scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping) {
+      # Generate the recalibration model by interval
+      call Processing.BaseRecalibrator as BaseRecalibrator {
+        input:
+          input_bam = SortSampleBam.output_bam,
+          input_bam_index = SortSampleBam.output_bam_index,
+          recalibration_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
+          sequence_group_interval = subgroup,
+          dbsnp_vcf = references.dbsnp_vcf,
+          dbsnp_vcf_index = references.dbsnp_vcf_index,
+          known_indels_sites_vcfs = references.known_indels_sites_vcfs,
+          known_indels_sites_indices = references.known_indels_sites_indices,
+          ref_dict = references.reference_fasta.ref_dict,
+          ref_fasta = references.reference_fasta.ref_fasta,
+          ref_fasta_index = references.reference_fasta.ref_fasta_index,
+          bqsr_scatter = bqsr_divisor,
+          preemptible_tries = papi_settings.agg_preemptible_tries
+      }
     }
-  }
 
-  # Merge the recalibration reports resulting from by-interval recalibration
-  # The reports are always the same size
-  call Processing.GatherBqsrReports as GatherBqsrReports {
-    input:
-      input_bqsr_reports = BaseRecalibrator.recalibration_report,
-      output_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
-      preemptible_tries = papi_settings.preemptible_tries
-  }
-
-  scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping_with_unmapped) {
-    # Apply the recalibration model by interval
-    call Processing.ApplyBQSR as ApplyBQSR {
+    # Merge the recalibration reports resulting from by-interval recalibration
+    # The reports are always the same size
+    call Processing.GatherBqsrReports as GatherBqsrReports {
       input:
-        input_bam = SortSampleBam.output_bam,
-        input_bam_index = SortSampleBam.output_bam_index,
-        output_bam_basename = recalibrated_bam_basename,
-        recalibration_report = GatherBqsrReports.output_bqsr_report,
-        sequence_group_interval = subgroup,
-        ref_dict = references.reference_fasta.ref_dict,
-        ref_fasta = references.reference_fasta.ref_fasta,
-        ref_fasta_index = references.reference_fasta.ref_fasta_index,
-        bqsr_scatter = bqsr_divisor,
-        compression_level = compression_level,
-        preemptible_tries = papi_settings.agg_preemptible_tries,
-        bin_base_qualities = bin_base_qualities,
-        somatic = somatic
+        input_bqsr_reports = BaseRecalibrator.recalibration_report,
+        output_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
+        preemptible_tries = papi_settings.preemptible_tries
+    }
+
+    scatter (subgroup in CreateSequenceGroupingTSV.sequence_grouping_with_unmapped) {
+      # Apply the recalibration model by interval
+      call Processing.ApplyBQSR as ApplyBQSR {
+        input:
+          input_bam = SortSampleBam.output_bam,
+          input_bam_index = SortSampleBam.output_bam_index,
+          output_bam_basename = recalibrated_bam_basename,
+          recalibration_report = GatherBqsrReports.output_bqsr_report,
+          sequence_group_interval = subgroup,
+          ref_dict = references.reference_fasta.ref_dict,
+          ref_fasta = references.reference_fasta.ref_fasta,
+          ref_fasta_index = references.reference_fasta.ref_fasta_index,
+          bqsr_scatter = bqsr_divisor,
+          compression_level = compression_level,
+          preemptible_tries = papi_settings.agg_preemptible_tries,
+          bin_base_qualities = bin_base_qualities,
+          somatic = somatic
+      }
     }
   }
 
   # Merge the recalibrated BAM files resulting from by-interval recalibration
   call Processing.GatherSortedBamFiles as GatherBamFiles {
     input:
-      input_bams = ApplyBQSR.recalibrated_bam,
+      input_bams = select_first([ApplyBQSR.recalibrated_bam, [SortSampleBam.output_bam]]),
       output_bam_basename = sample_and_unmapped_bams.base_file_name,
       total_input_size = agg_bam_size,
       compression_level = compression_level,
@@ -268,7 +294,7 @@ workflow UnmappedBamToAlignedBam {
     Float contamination = CheckContamination.contamination
 
     File duplicate_metrics = MarkDuplicates.duplicate_metrics
-    File output_bqsr_reports = GatherBqsrReports.output_bqsr_report
+    File? output_bqsr_reports = GatherBqsrReports.output_bqsr_report
 
     File output_bam = GatherBamFiles.output_bam
     File output_bam_index = GatherBamFiles.output_bam_index

--- a/tasks/broad/VariantCalling.wdl
+++ b/tasks/broad/VariantCalling.wdl
@@ -4,10 +4,12 @@ import "../../tasks/broad/GermlineVariantDiscovery.wdl" as Calling
 import "../../tasks/broad/Qc.wdl" as QC
 import "../../tasks/broad/Utilities.wdl" as Utils
 import "../../tasks/broad/BamProcessing.wdl" as BamProcessing
+import "../../tasks/broad/Dragen.wdl" as Dragen
 
 workflow VariantCalling {
 
   input {
+    Boolean run_dragen_mode = false
     File calling_interval_list
     File evaluation_interval_list
     Int haplotype_scatter_count
@@ -30,7 +32,26 @@ workflow VariantCalling {
 
   parameter_meta {
     make_bamout: "For CNNScoreVariants to run with a 2D model, a bamout must be created by HaplotypeCaller. The bamout is a bam containing information on how HaplotypeCaller remapped reads while it was calling variants. See https://gatkforums.broadinstitute.org/gatk/discussion/5484/howto-generate-a-bamout-file-showing-how-haplotypecaller-has-remapped-sequence-reads for more details."
+    run_dragen_mode: "Run variant calling using the DRAGEN-GATK pipeline, false by default."
   }
+
+  if (run_dragen_mode) {
+    call Dragen.ComposeSTRTableFile as ComposeSTRTableFile {
+       input:
+         ref_fasta = ref_fasta,
+         ref_fasta_idx = ref_fasta_index,
+         ref_dict = ref_dict,
+    }
+    call Dragen.CalibrateDragstrModel as DragstrAutoCalibration {
+       input:
+         ref_fasta = ref_fasta,
+         ref_fasta_idx = ref_fasta_index,
+         ref_dict = ref_dict,
+         alignment = input_bam,
+         str_table_file = ComposeSTRTableFile.str_table_file
+    }
+  }
+
 
   # Break the calling interval_list into sub-intervals
   # Perform variant calling on the sub-intervals, and then gather the results
@@ -67,7 +88,6 @@ workflow VariantCalling {
     }
 
     if (!use_gatk3_haplotype_caller) {
-
       # Generate GVCF by interval
       call Calling.HaplotypeCaller_GATK4_VCF as HaplotypeCallerGATK4 {
         input:
@@ -82,6 +102,8 @@ workflow VariantCalling {
           hc_scatter = hc_divisor,
           make_gvcf = make_gvcf,
           make_bamout = make_bamout,
+          run_dragen_mode = run_dragen_mode,
+          dragstr_model = DragstrAutoCalibration.dragstr_model,
           preemptible_tries = agg_preemptible_tries
        }
 
@@ -171,11 +193,11 @@ task MergeBamouts {
 
   Int disk_size = ceil(size(bams, "GiB") * 2) + 10
 
-  command {
+  command <<<
     samtools merge ~{output_base_name}.bam ~{sep=" " bams}
     samtools index ~{output_base_name}.bam
     mv ~{output_base_name}.bam.bai ~{output_base_name}.bai
-  }
+  >>>
 
   output {
     File output_bam = "~{output_base_name}.bam"


### PR DESCRIPTION
- Added WholeGenomeGermlineSingleSample.wdl with optional DRAGEN arguments to beta-pipelines/
    - Pipeline version -> 3.0.0
    - New workflow arguments
        - run_dragen_mode = false
        - perform_bqsr = true
        - Optional File dragmap_binary
        - Optional DragmapReference dragmap_reference
- Added new struct DragmapReference
- Changes to WholeGenomeGermlineSingleSample.wdl in pipelines/
    - Made output output_bqsr_reports optional as BQSR becomes optional
- Changes to several task WDLs
    - New file: Dragen.wdl
        - contains two tasks: ComposeSTRTableFile and CalibrateDragstrModel
    - New file: DragmapAlignment.wdl
        - Analog to Alignment.wdl for alignment with the open source version of the DRAGEN aligner
    - GermlineVariantDiscovery
        - HaplotypeCaller_GATK4_VCF
            - Arguments:
                - run_dragen_mode = false
                - Optional argument File dragstr_model, required when running dragen mode, however there is no check
                - gatk_docker made an optional argument with no default value. If not set and run_dragen_mode is false, it defaults to "us.gcr.io/broad-gatk/gatk:4.1.8.0". If run_dragen_mode is true, it is set to a docker containing the DRAGEN-GATK changes.
            - **Memory increased from 6.5 GiB to 10 GiB**
            - **maxRetries: 3**
    - Qc
        - ValidateSamFile
            - **Memory increased from 7 to 20 GiB**
            - **maxRetries: 3**
        - CollectRawWgsMetrics
            - **maxRetries: 3**
    - SplitLargeReadGroup
        - Included logic to choose between BWA mem and DragMap for alignment
        - Added (optional) respective arguments
    - UnmappedBamToAlignedBam
        - Workflow argument: perform_bqsr = true
        - (Optional) arguments for DragMap alignment
        - Included logic to choose between BWA mem and DragMap for alignment
        - Made BQSR and its output output_bqsr_reports optional
    - VariantCalling
        - Workflow arguments
            - run_dragen_mode = true
        - if running dragen mode, ComposeSTRTableFile and DragstrAutoCalibration is called
        - run_dragen_mode and dragstr_model passed on to HaplotypeCaller_GATK4_VCF
        - Task MergeBamouts
          - Command block using `<<< >>>` instead of `{ }`