### PR TITLE
Have arrays test data use public arrays metadata

### DIFF
--- a/pipelines/broad/arrays/single_sample/ExampleWorkflow.inputs.json
+++ b/pipelines/broad/arrays/single_sample/ExampleWorkflow.inputs.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370027_R02C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370027_R12C02/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370134_R12C02/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/inputs/200246060179_R09C02/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070005_R06C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070035_R05C02/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070035_R06C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R04C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201004840016_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201008710016_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201008710016_R05C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201138240147_R05C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201138240147_R08C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201159110147_R06C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201159110147_R09C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.disk_size": 100,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R09C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R12C02/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201179320110_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201490040272_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651070002_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651070043_R06C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.disk_size": 100,
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.disk_size": 100,
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -14,9 +14,9 @@
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.disk_size": 100,
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R07C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.disk_size": 100,
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/inputs/202871110118_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/inputs/203078500006_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.1.4.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.1.4.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/inputs/8925008101_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
@@ -10,9 +10,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/8942377043_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/inputs/8942377043_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "Arrays.disk_size": 100,
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
@@ -11,9 +11,9 @@
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Red.idat",
   "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/inputs/9216473070_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Plumbing/HumanExome-12v1-1_A.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Plumbing/HumanExome-12v1-1_A.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/Broad_GWAS_supplemental_15061359_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/Broad_GWAS_supplemental_15061359_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSA-24v1-0_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSA-24v1-0_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSAMD-24v1-0_20011747_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSAMD-24v1-0_20011747_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanExome-12v1-1_A.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanExome-12v1-1_A.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanOmni2.5-8v1_A.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanOmni2.5-8v1_A.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.csv",
-  "ValidateChip.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "ValidateChip.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "ValidateChip.chip_manifest_csv_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.csv",
+  "ValidateChip.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "ValidateChip.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanOmniExpress-12v1_H.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanOmniExpress-12v1_H.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumImmunoArray-24v2-0_A.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumImmunoArray-24v2-0_A.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumOmniExpressExome-8v1-4_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumOmniExpressExome-8v1-4_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumOmniExpressExome-8v1-6_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/InfiniumOmniExpressExome-8v1-6_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/MEG_AllofUs_20002558X351448_A2.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/MEG_AllofUs_20002558X351448_A2.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
-  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/Multi-EthnicGlobal-8_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/Multi-EthnicGlobal-8_A1.json
@@ -9,9 +9,9 @@
   "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Grn.idat",
   "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.csv",
-  "ValidateChip.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "ValidateChip.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "ValidateChip.chip_manifest_csv_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.csv",
+  "ValidateChip.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "ValidateChip.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/genotyping/illumina/example.json
+++ b/pipelines/broad/genotyping/illumina/example.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-public-datasets/IlluminaGenotypingArrays/inputs/HumanExome-12v1-1_A/idats/7991775143_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-public-datasets/IlluminaGenotypingArrays/inputs/HumanExome-12v1-1_A/idats/7991775143_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-public-datasets/IlluminaGenotypingArrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-public-datasets/IlluminaGenotypingArrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-public-datasets/IlluminaGenotypingArrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-public-datasets/IlluminaGenotypingArrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-public-datasets/IlluminaGenotypingArrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Plumbing/SimpleInput.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370134_R12C02_NA12891.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370134_R12C02_NA12891.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/20149004072_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/20149004072_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -12,9 +12,9 @@
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz",
   "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.1.4.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.1.4.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/7991775143_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/7991775143_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
   "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8942377043_R01C01_09C89876.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8942377043_R01C01_09C89876.json
@@ -8,9 +8,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/8942377043_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/8942377043_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/9216473070_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/9216473070_R01C01_NA12878.json
@@ -9,9 +9,9 @@
   "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Grn.idat",
   "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Red.idat",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "IlluminaGenotypingArray.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
   "IlluminaGenotypingArray.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",


### PR DESCRIPTION
Arrays metadata was copied to Google-hosted bucket in PO-2843.