### PR TITLE
Switch NA12878 samples for scientific testing

### DIFF
--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
@@ -1,0 +1,9 @@
+{
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/G96830.NA12878/NA12878.cram",
+  "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/G96830.NA12878/readgroupid_to_bamfilename_map.txt",
+
+  "CramToUnmappedBams.base_file_name": "G96830.NA12878",
+  "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",
+  "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "CramToUnmappedBams.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+}

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/RP-518.NA12878.WGS.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/RP-518.NA12878.WGS.json
@@ -1,9 +1,0 @@
-{
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/RP-518.NA12878/NA12878.huge-ubam.cram",
-  "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/RP-518.NA12878/readgroupid_to_bamfilename_map.txt",
-
-  "CramToUnmappedBams.base_file_name": "RP-518.NA12878.WGS",
-  "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",
-  "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-  "CramToUnmappedBams.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-}


### PR DESCRIPTION
RP-518.NA12878 creates a single 55 GB unmapped bam that takes 12+ hours to compare. This switches to a different NA12878 sample (also used for reprocessing tests) for scientific verification