### PR TITLE
Change Tester to use build_pipeline_release.sh script

### DIFF
--- a/scripts/build_workflow_release.sh
+++ b/scripts/build_workflow_release.sh
@@ -23,7 +23,7 @@ function deploy_dependencies() {
     for file in $(find ${ZIP_DIRS[@]} -type f -name '*.wdl'); do
       flattened_name=$(basename ${file})
       sed -E 's/import "(.*)\/(.*\.wdl)"/import "\2"/g' ${file} > ${working_dir}/${flattened_name}
-      zip -u -j ${target_dir}/${versioned_dependencies_zip} ${working_dir}/${flattened_name}
+      zip -u -j -v ${target_dir}/${versioned_dependencies_zip} ${working_dir}/${flattened_name}
     done
     rm -rf ${working_dir}
   fi

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/AllOfUsTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/AllOfUsTester.scala
@@ -21,11 +21,10 @@ class AllOfUsTester(testerConfig: GermlineCloudWorkflowConfig)(
 
   override val workflowName: String = "AllOfUsWholeGenome"
 
-  override lazy val workflowDir: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "projects" / "all_of_us"
+  override protected val validationWorkflowName: String = "VerifyAllOfUs"
 
-  override lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyAllOfUs.wdl"
+  override lazy val workflowDir: File =
+    CromwellWorkflowTester.WarpRoot / "projects" / "all_of_us"
 
   override lazy val resultsPrefix: URI =
     URI.create(

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/AnnotationFiltrationTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/AnnotationFiltrationTester.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsp.pipelines.batch.{
   WorkflowRunParameters,
   WorkflowTest
 }
+import org.broadinstitute.dsp.pipelines.tester.CromwellWorkflowTester.WarpGitHash
 
 import scala.concurrent.Future
 import scala.sys.process._
@@ -37,7 +38,7 @@ class AnnotationFiltrationTester(testConfig: AnnotationFiltrationConfig)(
     )
 
   override lazy val wdlContents: String =
-    (releaseDir / workflowName / s"$workflowName.wdl").contentAsString
+    (releaseDir / workflowName / s"${workflowName}_${WarpGitHash}.wdl").contentAsString
 
   val testInputs: String = (workflowDir / "test_inputs" / {
     testConfig.category.entryName
@@ -45,7 +46,7 @@ class AnnotationFiltrationTester(testConfig: AnnotationFiltrationConfig)(
 
   override def runTest: Future[Unit] = {
     val workflowOptions =
-      (releaseDir / workflowName / s"$workflowName.options.json").contentAsString
+      (releaseDir / workflowName / s"${workflowName}_${WarpGitHash}.options.json").contentAsString
     val workflowRuns = Seq(
       WorkflowRunParameters(
         id = s"${envString}_${testConfig.category.entryName}",
@@ -60,7 +61,7 @@ class AnnotationFiltrationTester(testConfig: AnnotationFiltrationConfig)(
       submittedWorkflows <- submitBatchWorkflows(
         workflowRuns,
         Some(workflowOptions),
-        Some(dependenciesZipFromReleaseDir(releaseDir))
+        dependenciesZipFromReleaseDir(releaseDir, workflowName)
       )
       finishedSamples <- awaitBatchCromwellWorkflowCompletion(
         submittedWorkflows)
@@ -99,7 +100,7 @@ class AnnotationFiltrationTester(testConfig: AnnotationFiltrationConfig)(
       } yield {
         tempFile.overwrite(value)
         val cost =
-          s"${CromwellWorkflowTester.DsdePipelinesRoot}/scripts/calculate_cost.py --only_total --metadata $tempFile"
+          s"${CromwellWorkflowTester.WarpRoot}/scripts/calculate_cost.py --only_total --metadata $tempFile"
             .!!
         (workflow, cost)
       }

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ArraysTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ArraysTester.scala
@@ -28,8 +28,7 @@ class ArraysTester(testerConfig: ArraysConfig)(
   protected val vaultTokenPath: String =
     s"gs://broad-dsp-gotc-arrays-$envString-tokens/arrayswdl.token"
 
-  lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / s"Verify$workflowName.wdl"
+  override protected val validationWorkflowName: String = s"Verify$workflowName"
 
   override protected lazy val googleProject: String = {
     if (env.picardEnv.equals("dev")) {
@@ -37,11 +36,6 @@ class ArraysTester(testerConfig: ArraysConfig)(
     } else {
       s"broad-arrays-${env.picardEnv}"
     }
-  }
-
-  // Validation uses the same options as the arrays workflow
-  override protected lazy val validationWdlOptions: String = {
-    readTestOptions(releaseDir, env)
   }
 
   protected lazy val resultsPrefix: URI = {

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/CramToUnmappedBamsTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/CramToUnmappedBamsTester.scala
@@ -24,12 +24,10 @@ class CramToUnmappedBamsTester(testerConfig: CramToUnmappedBamsConfig)(
   override val workflowName: String = s"CramToUnmappedBams"
 
   val workflowDir
-    : File = CromwellWorkflowTester.DsdePipelinesRoot / "pipelines" / "broad" / "reprocessing" / "cram_to_unmapped_bams"
+    : File = CromwellWorkflowTester.WarpRoot / "pipelines" / "broad" / "reprocessing" / "cram_to_unmapped_bams"
 
-  lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyCramToUnmappedBams.wdl"
-
-  private val verifyWorkflowName = "VerifyCramToUnmappedBams"
+  override protected val validationWorkflowName: String =
+    "VerifyCramToUnmappedBams"
 
   protected lazy val resultsPrefix: URI = {
     URI.create(
@@ -63,7 +61,7 @@ class CramToUnmappedBamsTester(testerConfig: CramToUnmappedBamsConfig)(
       workflowTest.runParameters.resultsCloudPath
     val validationInputs = CramToUnmappedBamsValidationInputs.marshall(
       CramToUnmappedBamsValidationInputs(),
-      verifyWorkflowName
+      validationWorkflowName
     )
 
     val revertedBams = ioUtil
@@ -79,7 +77,7 @@ class CramToUnmappedBamsTester(testerConfig: CramToUnmappedBamsConfig)(
 
     val added = validationInputs.asObject.fold(JsonObject.empty)(
       _.add(
-        s"$verifyWorkflowName.bam_pairs",
+        s"$validationWorkflowName.bam_pairs",
         Json.arr(
           revertedBams
             .zip(truthBams)

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/CromwellWorkflowTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/CromwellWorkflowTester.scala
@@ -33,6 +33,7 @@ import org.broadinstitute.dsp.pipelines.commandline.{
   CromwellEnvironment,
   WorkflowTestType
 }
+import org.broadinstitute.dsp.pipelines.tester.CromwellWorkflowTester.WarpGitHash
 import org.broadinstitute.dsp.pipelines.util.{CromwellUtils, VaultUtil}
 
 import scala.collection.immutable.Iterable
@@ -45,15 +46,15 @@ import scala.util.{Failure, Success, Try}
 object CromwellWorkflowTester {
   class TestFailedException(msg: String) extends RuntimeException(msg)
 
-  lazy val DsdePipelinesRoot: File =
+  lazy val WarpRoot: File =
     File(Process(Seq("git", "rev-parse", "--show-toplevel")).!!.trim)
 
-  lazy val DsdePipelinesGitHash: String =
+  lazy val WarpGitHash: String =
     Process(Seq("git", "rev-parse", "--short", "HEAD")).!!.trim
 
-  lazy val GotcRoot: File = DsdePipelinesRoot / "genomes_in_the_cloud"
+  lazy val GotcRoot: File = WarpRoot / "genomes_in_the_cloud"
 
-  lazy val PipelineRoot: File = DsdePipelinesRoot / "pipelines"
+  lazy val PipelineRoot: File = WarpRoot / "pipelines"
 
   def apply(config: Config)(
       implicit system: ActorSystem,
@@ -96,16 +97,20 @@ object CromwellWorkflowTester {
   }
 
   private lazy val pipelinesReleaseScript: File =
-    DsdePipelinesRoot / "scripts" / "build_workflow_release.sh"
+    WarpRoot / "scripts" / "build_pipeline_release.sh"
 
   def runReleaseWorkflow(wdlPath: File, env: CromwellEnvironment): File = {
     val tmp = File.newTemporaryDirectory().deleteOnExit()
     Process(
       pipelinesReleaseScript.pathAsString,
       Seq(
+        "-w",
         wdlPath.pathAsString,
+        "-o",
         tmp.pathAsString,
-        DsdePipelinesGitHash,
+        "-v",
+        WarpGitHash,
+        "-e",
         env.picardEnv
       )
     ).!!
@@ -768,17 +773,23 @@ abstract class CromwellWorkflowTester(
     * @param releaseDir The release dir with WDLs and dependencies
     * @return The WDL contents
     */
-  protected def readWdlFromReleaseDir(releaseDir: File): String =
-    (releaseDir / workflowName / s"$workflowName.wdl").contentAsString
+  protected def readWdlFromReleaseDir(releaseDir: File,
+                                      workflowName: String): String =
+    (releaseDir / workflowName / s"${workflowName}_${WarpGitHash}.wdl").contentAsString
 
   /**
     * Get the dependencies zip from the provided release dir
     *
     * @param releaseDir The release dir with WDLs and dependencies
+    * @param workflowName The name of the workflow
     * @return A File of the dependencies ZIP
     */
-  protected def dependenciesZipFromReleaseDir(releaseDir: File): File =
-    releaseDir / "dependencies" / "workflow_dependencies.zip"
+  protected def dependenciesZipFromReleaseDir(
+      releaseDir: File,
+      workflowName: String): Option[File] = {
+    val zipFile = releaseDir / workflowName / s"${workflowName}_${WarpGitHash}.zip"
+    if (zipFile.exists) Option(zipFile) else None
+  }
 
   /**
     * Get the data type string prefix from the DataType enum

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ExternalReprocessingTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ExternalReprocessingTester.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsp.pipelines.batch.{
 import org.broadinstitute.dsp.pipelines.commandline.CromwellEnvironment
 import org.broadinstitute.dsp.pipelines.config._
 import org.broadinstitute.dsp.pipelines.inputs.ReprocessingInputs
+import org.broadinstitute.dsp.pipelines.tester.CromwellWorkflowTester.WarpGitHash
 
 import scala.concurrent.Future
 
@@ -71,7 +72,7 @@ class ExternalReprocessingTester(testerConfig: GermlineCloudWorkflowConfig)(
     val optionsJson = defaultOptions ++ environment.environmentOptions
 
     parse(
-      (releaseDir / workflowName / s"$workflowName.options.json").contentAsString)
+      (releaseDir / workflowName / s"${workflowName}_${WarpGitHash}.options.json").contentAsString)
       .fold(
         e => throw new RuntimeException("Could not create options json", e),
         _.deepMerge(Json.obj(optionsJson: _*)).noSpaces

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GDCWholeGenomeSomaticSingleSampleTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GDCWholeGenomeSomaticSingleSampleTester.scala
@@ -24,10 +24,10 @@ class GDCWholeGenomeSomaticSingleSampleTester(
   override val workflowName: String = s"GDC${dataTypePrefix}SomaticSingleSample"
 
   val workflowDir
-    : File = CromwellWorkflowTester.DsdePipelinesRoot / "beta-pipelines" / "broad" / "somatic" / "single_sample" / dataTypeString / "gdc_genome"
+    : File = CromwellWorkflowTester.WarpRoot / "beta-pipelines" / "broad" / "somatic" / "single_sample" / dataTypeString / "gdc_genome"
 
-  lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyGDCSomaticSingleSample.wdl"
+  override protected val validationWorkflowName: String =
+    "VerifyGDCSomaticSingleSample"
 
   protected lazy val resultsPrefix: URI = {
     URI.create(

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GenotypeConcordanceTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GenotypeConcordanceTester.scala
@@ -236,7 +236,7 @@ class GenotypeConcordanceTester(testerConfig: GenotypeConcordanceConfig)(
           singleSampleTest.readTestOptions(tmpReleaseDir, env)
         ),
         None,
-        Some(dependenciesZipFromReleaseDir(tmpReleaseDir)),
+        dependenciesZipFromReleaseDir(tmpReleaseDir, workflowName),
         singleSampleTest.workflowName
       )
       _ <- awaitCromwellWorkflowCompletion(submission)

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GermlineSingleSampleTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/GermlineSingleSampleTester.scala
@@ -27,8 +27,8 @@ class GermlineSingleSampleTester(testerConfig: GermlineCloudWorkflowConfig)(
   override lazy val workflowDir: File =
     CromwellWorkflowTester.PipelineRoot / "broad" / "dna_seq" / "germline" / "single_sample" / dataTypeString
 
-  override lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyGermlineSingleSample.wdl"
+  override protected val validationWorkflowName: String =
+    "VerifyGermlineSingleSample"
 
   protected lazy val resultsPrefix: URI =
     URI.create(

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/IlluminaGenotypingArrayTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/IlluminaGenotypingArrayTester.scala
@@ -22,8 +22,7 @@ class IlluminaGenotypingArrayTester(testerConfig: IlluminaGenotypingArrayConfig)
   val workflowDir
     : File = CromwellWorkflowTester.PipelineRoot / "broad" / "genotyping" / "illumina"
 
-  lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / s"VerifyArrays.wdl"
+  override protected val validationWorkflowName: String = "VerifyArrays"
 
   override protected lazy val googleProject: String = {
     if (env.picardEnv.equals("dev")) {

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/JointGenotypingTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/JointGenotypingTester.scala
@@ -52,8 +52,8 @@ class JointGenotypingTester(testerConfig: GermlineCloudWorkflowConfig)(
     }
   }
 
-  override protected def localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyJointGenotyping.wdl"
+  override protected val validationWorkflowName: String =
+    "VerifyJointGenotyping"
 
   override protected def buildValidationWdlInputs(
       workflowTest: WorkflowTest

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ReblockGvcfTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ReblockGvcfTester.scala
@@ -25,6 +25,8 @@ class ReblockGvcfTester(testerConfig: GermlineCloudWorkflowConfig)(
 
   override def workflowName: String = "ReblockGVCF"
 
+  override protected val validationWorkflowName: String = s"Verify$workflowName"
+
   override protected def workflowInputRoot: File =
     workflowDir / "test_inputs" / dataTypeString / testerConfig.category.entryName
 
@@ -55,9 +57,6 @@ class ReblockGvcfTester(testerConfig: GermlineCloudWorkflowConfig)(
       )
     }
   }
-
-  override protected def localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyReblockGVCF.wdl"
 
   override protected def buildValidationWdlInputs(
       workflowTest: WorkflowTest

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ReprocessingTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ReprocessingTester.scala
@@ -26,8 +26,7 @@ class ReprocessingTester(testerConfig: GermlineCloudWorkflowConfig)(
   override lazy val workflowDir: File =
     CromwellWorkflowTester.PipelineRoot / "broad" / "reprocessing" / dataTypeString
 
-  override lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyReprocessing.wdl"
+  override protected val validationWorkflowName: String = "VerifyReprocessing"
 
   override protected lazy val resultsPrefix: URI =
     URI.create(
@@ -37,8 +36,6 @@ class ReprocessingTester(testerConfig: GermlineCloudWorkflowConfig)(
     URI.create(
       s"gs://broad-gotc-test-storage/reprocessing/$dataTypeString/$testTypeString/truth/${testerConfig.truthBranch}/"
     )
-
-  private val verifyWorkflowName = "VerifyReprocessing"
 
   override def generateRunParameters: Seq[WorkflowRunParameters] = {
     super.generateRunParameters.map(
@@ -77,7 +74,7 @@ class ReprocessingTester(testerConfig: GermlineCloudWorkflowConfig)(
         testGvcf = resultsCloudPath.resolve(s"$gvcfBaseName.g.vcf.gz"),
         truthGvcf = truthCloudPath.resolve(s"$gvcfBaseName.g.vcf.gz")
       ),
-      verifyWorkflowName
+      validationWorkflowName
     )
 
     val revertedBams = ioUtil
@@ -93,7 +90,7 @@ class ReprocessingTester(testerConfig: GermlineCloudWorkflowConfig)(
 
     val added = validationInputs.asObject.fold(JsonObject.empty)(
       _.add(
-        s"$verifyWorkflowName.bam_pairs",
+        s"$validationWorkflowName.bam_pairs",
         Json.arr(
           revertedBams
             .zip(truthBams)

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/SomaticSingleSampleTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/SomaticSingleSampleTester.scala
@@ -23,10 +23,10 @@ class SomaticSingleSampleTester(testerConfig: SomaticCloudWorkflowConfig)(
   override val workflowName: String = s"${dataTypePrefix}SomaticSingleSample"
 
   val workflowDir
-    : File = CromwellWorkflowTester.DsdePipelinesRoot / "beta_pipelines" / "broad" / "somatic" / "single_sample" / dataTypeString
+    : File = CromwellWorkflowTester.WarpRoot / "beta_pipelines" / "broad" / "somatic" / "single_sample" / dataTypeString
 
-  lazy val localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifySomaticSingleSample.wdl"
+  override protected val validationWorkflowName: String =
+    "VerifySomaticSingleSample"
 
   protected lazy val resultsPrefix: URI = {
     URI.create(

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ValidateChipTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ValidateChipTester.scala
@@ -29,8 +29,7 @@ class ValidateChipTester(testerConfig: ValidateChipConfig)(
     s"gs://broad-gotc-test-storage/validate_chip/$testTypeString/truth/${testerConfig.truthBranch}/"
   )
 
-  override protected def localValidationWdlPath: File =
-    CromwellWorkflowTester.DsdePipelinesRoot / "verification" / "VerifyValidateChip.wdl"
+  override protected val validationWorkflowName: String = "VerifyValidateChip"
 
   override protected lazy val googleProject: String = {
     if (env.picardEnv.equals("dev")) {


### PR DESCRIPTION
This PR does a number of things (kind of mushroomed…)
- Change Tester to use build_pipeline_release.sh script
- Separately build workflow and validation workflow releases
- Use discrete dependencies zips for each.
- Made dependencies optional
- Change usage of dsde-pipelines to warp
- Change defaults for validation wdls to call-cache.