### PR TITLE
Fix base file name for new cram to unmapped scientific test input

### DIFF
--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
@@ -2,7 +2,7 @@
   "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/G96830.NA12878/NA12878.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/G96830.NA12878/readgroupid_to_bamfilename_map.txt",
 
-  "CramToUnmappedBams.base_file_name": "G96830.NA12878",
+  "CramToUnmappedBams.base_file_name": "G96830.NA12878.WGS",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",
   "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "CramToUnmappedBams.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"


### PR DESCRIPTION
The base file name did not match the truth path