### PR TITLE
Updating Germline Genome Single Sample Pipeline plumbing data to use broad-public-datasets

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/input_files/WholeGenomeGermlineSingleSample.inputs.plumbing.json
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/input_files/WholeGenomeGermlineSingleSample.inputs.plumbing.json
@@ -3,9 +3,9 @@
     "sample_name": "NA12878 PLUMBING",
     "base_file_name": "NA12878_PLUMBING",
     "flowcell_unmapped_bams": [
-      "gs://broad-gotc-test-storage/single_sample/plumbing/bams/G96830.NA12878/H06HDADXX130110.1.ATCACGAT.20k_reads.bam",
-      "gs://broad-gotc-test-storage/single_sample/plumbing/bams/G96830.NA12878/H06HDADXX130110.2.ATCACGAT.20k_reads.bam",
-      "gs://broad-gotc-test-storage/single_sample/plumbing/bams/G96830.NA12878/H06JUADXX130110.1.ATCACGAT.20k_reads.bam"
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.1.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.2.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam"
     ],
     "final_gvcf_base_name": "NA12878_PLUMBING",
     "unmapped_bam_suffix": ".bam"

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/test_inputs/Plumbing/G96830.NA12878.json
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/test_inputs/Plumbing/G96830.NA12878.json
@@ -3,9 +3,9 @@
     "sample_name": "NA12878 PLUMBING",
     "base_file_name": "NA12878_PLUMBING",
     "flowcell_unmapped_bams": [
-      "gs://broad-gotc-test-storage/germline_single_sample/wgs/plumbing/bams/G96830.NA12878/H06HDADXX130110.1.ATCACGAT.20k_reads.unmapped.bam",
-      "gs://broad-gotc-test-storage/germline_single_sample/wgs/plumbing/bams/G96830.NA12878/H06HDADXX130110.2.ATCACGAT.20k_reads.unmapped.bam",
-      "gs://broad-gotc-test-storage/germline_single_sample/wgs/plumbing/bams/G96830.NA12878/H06JUADXX130110.1.ATCACGAT.20k_reads.unmapped.bam"
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.1.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.2.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam"
     ],
     "final_gvcf_base_name": "NA12878_PLUMBING",
     "unmapped_bam_suffix": ".unmapped.bam"

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/test_inputs/Plumbing/G96830.NA12878.json
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/test_inputs/Plumbing/G96830.NA12878.json
@@ -8,7 +8,7 @@
       "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam"
     ],
     "final_gvcf_base_name": "NA12878_PLUMBING",
-    "unmapped_bam_suffix": ".unmapped.bam"
+    "unmapped_bam_suffix": ".bam"
   },
 
   "WholeGenomeGermlineSingleSample.references": {


### PR DESCRIPTION
Trying out changing the plumbing test data for genomes to the equivalent files in broad public datasets.

Tests should confirm if they are in fact the same samples given their name is the same.