### PR TITLE
GL-600.  Add testing of new version of CreateExtendedIlluminaManifest

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,8 @@
+# 2.3.1
+2021-05-19
+
+* Update version of Picard to 2.25.5 in order to allow GtcToVcf (used in IlluminaGenotypingArray subworkflow) to support new enums in that buid (updated all picard tools to use this version)
+
 # 2.3.0
 2020-10-07
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow Arrays {
 
-  String pipeline_version = "2.3.0"
+  String pipeline_version = "2.3.1"
 
   input {
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
@@ -1,3 +1,9 @@
+# 1.13.0
+2021-05-19
+
+* Update to use publicly released version of CreateExtendedIlluminaManifest (in Picard 2.25.5)
+* Update version of Picard to 2.25.5 in order to allow GtcToVcf to support new enums in that buid (updated all picard tools to use this version)
+
 # 1.12.0
 2020-10-07
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow ValidateChip {
 
-  String pipeline_version = "1.12.0"
+  String pipeline_version = "1.13.0"
 
   input {
     String sample_alias
@@ -62,10 +62,10 @@ workflow ValidateChip {
     Int preemptible_tries
   }
 
-  call InternalTasks.CreateExtendedIlluminaManifest {
+  call GenotypingTasks.CreateExtendedIlluminaManifest {
     input:
       input_csv = chip_manifest_csv_file,
-      output_base_name = chip_type + ".1.5",
+      output_base_name = chip_type + ".2.0",
       cluster_file = cluster_file,
       dbSNP_vcf_file = dbSNP_vcf,
       dbSNP_vcf_index_file = dbSNP_vcf_index,

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSAMD-24v3-0-EA_20034606_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/GSAMD-24v3-0-EA_20034606_A1.json
@@ -2,16 +2,16 @@
   "ValidateChip.sample_alias": "NA12878",
   "ValidateChip.analysis_version_number": 1,
   "ValidateChip.call_rate_threshold": 0.98,
-  "ValidateChip.indel_genotype_concordance_threshold": 0.97,
+  "ValidateChip.indel_genotype_concordance_threshold": 0.99,
   "ValidateChip.reported_gender": "Female",
-  "ValidateChip.chip_well_barcode": "7991775143_R01C01",
+  "ValidateChip.chip_well_barcode": "205346990020_R01C01",
 
-  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
-  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
+  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Grn.idat",
+  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1.bpm",
+  "ValidateChip.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1_custom.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanExome-12v1-1_A.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/HumanExome-12v1-1_A.json
@@ -2,7 +2,7 @@
   "ValidateChip.sample_alias": "NA12878",
   "ValidateChip.analysis_version_number": 1,
   "ValidateChip.call_rate_threshold": 0.98,
-  "ValidateChip.indel_genotype_concordance_threshold": 0.99,
+  "ValidateChip.indel_genotype_concordance_threshold": 0.97,
   "ValidateChip.reported_gender": "Female",
   "ValidateChip.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/PsychChip_15048346_B.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/PsychChip_15048346_B.json
@@ -2,16 +2,16 @@
   "ValidateChip.sample_alias": "NA12878",
   "ValidateChip.analysis_version_number": 1,
   "ValidateChip.call_rate_threshold": 0.98,
-  "ValidateChip.indel_genotype_concordance_threshold": 0.97,
+  "ValidateChip.indel_genotype_concordance_threshold": 0.98,
   "ValidateChip.reported_gender": "Female",
-  "ValidateChip.chip_well_barcode": "7991775143_R01C01",
+  "ValidateChip.chip_well_barcode": "101025660090_R06C01",
 
-  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
-  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
+  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_15048346_B/idats/101025660090_R06C01/101025660090_R06C01_Grn.idat",
+  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_15048346_B/idats/101025660090_R06C01/101025660090_R06C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_15048346_B/PsychChip_15048346_B.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_15048346_B/PsychChip_15048346_B.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_15048346_B/PsychChip_B_1000samples_no-filters.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/PsychChip_v1-1_15073391_A1.json
+++ b/pipelines/broad/arrays/validate_chip/test_inputs/Scientific/PsychChip_v1-1_15073391_A1.json
@@ -2,16 +2,16 @@
   "ValidateChip.sample_alias": "NA12878",
   "ValidateChip.analysis_version_number": 1,
   "ValidateChip.call_rate_threshold": 0.98,
-  "ValidateChip.indel_genotype_concordance_threshold": 0.97,
+  "ValidateChip.indel_genotype_concordance_threshold": 0.98,
   "ValidateChip.reported_gender": "Female",
-  "ValidateChip.chip_well_barcode": "7991775143_R01C01",
+  "ValidateChip.chip_well_barcode": "101342370027_R02C01",
 
-  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
-  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
+  "ValidateChip.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Grn.idat",
+  "ValidateChip.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Red.idat",
 
-  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.csv",
-  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
-  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+  "ValidateChip.chip_manifest_csv_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.csv",
+  "ValidateChip.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
+  "ValidateChip.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
 
   "ValidateChip.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf",
   "ValidateChip.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878_NIST.vcf.idx",

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,3 +1,8 @@
+# 1.11.1
+2021-05-19
+
+* Update version of Picard to 2.25.5 in order to allow GtcToVcf to support new enums in that buid (updated all picard tools to use this version)
+
 # 1.11.0
 2020-10-01
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
@@ -20,7 +20,7 @@ import "../../../../tasks/broad/IlluminaGenotypingArrayTasks.wdl" as GenotypingT
 
 workflow IlluminaGenotypingArray {
 
-  String pipeline_version = "1.11.0"
+  String pipeline_version = "1.11.1"
 
   input {
 

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -71,7 +71,7 @@ task BpmToNormalizationManifestCsv {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk 10 HDD"
     memory: "7.5 GiB"
     cpu: 2
@@ -130,7 +130,7 @@ task GtcToVcf {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory} GiB"
     cpu: 2
@@ -195,7 +195,7 @@ task VcfToAdpc {
              --OUTPUT ~{output_adpc_filename}
   }
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -269,7 +269,7 @@ task CreateVerifyIDIntensityContaminationMetricsFile {
              --OUTPUT ~{output_metrics_basefilename}
   }
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -325,7 +325,7 @@ task CollectArraysVariantCallingMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -356,7 +356,7 @@ task VcfToIntervalList {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -410,7 +410,7 @@ task CheckFingerprint {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -581,7 +581,7 @@ task MergePedIntoVcf {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     memory: "3.5 GiB"
     cpu: "1"
     disks: "local-disk " + disk_size + " HDD"
@@ -680,7 +680,7 @@ task GenotypeConcordance {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
@@ -719,5 +719,62 @@ task ValidateVariants {
     disks: "local-disk " + disk_size + " HDD"
     memory: "3.5 GiB"
     preemptible: preemptible_tries
+  }
+}
+
+task CreateExtendedIlluminaManifest {
+  input {
+    File input_csv
+    String output_base_name
+    File cluster_file
+
+    File ref_fasta
+    File ref_fasta_index
+    File ref_dict
+
+    File dbSNP_vcf_file
+    File dbSNP_vcf_index_file
+
+    File supported_ref_fasta
+    File supported_ref_fasta_index
+    File supported_ref_dict
+
+    File chain_file
+
+    Int disk_size
+    Int preemptible_tries
+  }
+
+  String extended_illumina_manifest_filename = output_base_name + ".extended.csv"
+  String bad_assays_filename = output_base_name + ".bad_assays.csv"
+  String report_filename = output_base_name + ".report.txt"
+
+  command <<<
+    java -Xms13g -jar /usr/picard/picard.jar \
+    CreateExtendedIlluminaManifest \
+    --INPUT ~{input_csv} \
+    --OUTPUT ~{extended_illumina_manifest_filename} \
+    --BAD_ASSAYS_FILE ~{bad_assays_filename} \
+    --REPORT_FILE ~{report_filename} \
+    --CLUSTER_FILE ~{cluster_file} \
+    --DBSNP_FILE ~{dbSNP_vcf_file} \
+    --TARGET_BUILD 37 \
+    --REFERENCE_SEQUENCE ~{ref_fasta} \
+    --SUPPORTED_BUILD 36 \
+    --SUPPORTED_REFERENCE_FILE ~{supported_ref_fasta} \
+    --SUPPORTED_CHAIN_FILE ~{chain_file}
+  >>>
+
+  runtime {
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.25.5"
+    disks: "local-disk " + disk_size + " HDD"
+    memory: "14 GiB"
+    preemptible: preemptible_tries
+  }
+
+  output {
+    File output_csv = extended_illumina_manifest_filename
+    File output_bad_assays_file = bad_assays_filename
+    File report_file = report_filename
   }
 }

--- a/tasks/broad/InternalArraysTasks.wdl
+++ b/tasks/broad/InternalArraysTasks.wdl
@@ -1,56 +1,5 @@
 version 1.0
 
-task CreateExtendedIlluminaManifest {
-  input {
-    File input_csv
-    String output_base_name
-    File cluster_file
-
-    File ref_fasta
-    File ref_fasta_index
-    File ref_dict
-
-    File dbSNP_vcf_file
-    File dbSNP_vcf_index_file
-
-    File supported_ref_fasta
-    File supported_ref_fasta_index
-    File supported_ref_dict
-
-    File chain_file
-
-    Int disk_size
-    Int preemptible_tries
-  }
-
-  command <<<
-    java -Xms13g -Dpicard.useLegacyParser=false -jar /usr/gitc/picard-private.jar \
-            CreateExtendedIlluminaManifest \
-            --INPUT ~{input_csv} \
-            --OUTPUT_BASE_FILE ~{output_base_name} \
-            --CLUSTER_FILE ~{cluster_file} \
-            --DBSNP_FILE ~{dbSNP_vcf_file} \
-            --TARGET_BUILD 37 \
-            --TARGET_REFERENCE_FILE ~{ref_fasta} \
-            --SUPPORTED_BUILD 36 \
-            --SUPPORTED_REFERENCE_FILE ~{supported_ref_fasta} \
-            --SUPPORTED_CHAIN_FILE ~{chain_file}
-  >>>
-
-  runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1602016912"
-    disks: "local-disk " + disk_size + " HDD"
-    memory: "14 GiB"
-    preemptible: preemptible_tries
-  }
-
-  output {
-    File output_csv = "~{output_base_name}.extended.csv"
-    File output_bad_assays_file = "~{output_base_name}.bad_assays.csv"
-    File report_file = "~{output_base_name}.report.txt"
-  }
-}
-
 task GenerateEmptyVariantCallingMetricsFile {
   input {
     String chip_well_barcode


### PR DESCRIPTION
Add three more scientific tests
Update to use latest version of Picard
(2.25.5) for CreateExtendedIlluminaManifest and GtcToVcf