### PR TITLE
Fix scientific owner specification 

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -91,7 +91,7 @@ groups:
       request_order: given
     reviewers:
       users:
-        - chips2art # Chip Stewart
+        - chipstewart # Chip Stewart
 
   scientific_owners_cram_to_unmapped_bam:
     conditions:

--- a/pullapprove_template.yml
+++ b/pullapprove_template.yml
@@ -60,7 +60,7 @@ groups:
       request_order: given
     reviewers:
       users:
-        - chips2art # Chip Stewart
+        - chipstewart # Chip Stewart
 
   scientific_owners_cram_to_unmapped_bam:
     conditions:


### PR DESCRIPTION
Chip has 2 github accounts, we were using 1 to grant access to warp and the other to request approval from pull approve