### PR TITLE
[GL-1575] Samtools specific docker images

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,7 @@ jobs:
         - dockers/broad/genomes_on_the_cloud
         - dockers/broad/illumina_iaap_autocall
         - dockers/broad/verify_bam_id
+        - dockers/broad/samtools
         - dockers/broad/zcall
     steps:
       - uses: actions/checkout@v2

--- a/dockers/broad/samtools/Dockerfile
+++ b/dockers/broad/samtools/Dockerfile
@@ -1,37 +1,28 @@
-# Samtools requires lots of Debian only native packages
-# This also acts as a base image for many other images that require the JDK
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:8-debian
+FROM alpine:3.8
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>"
 
 ARG SAMTOOLS_VERSION=1.11
 
 ENV TERM=xterm-256color \
-    TINI_VERSION=v0.19.0 \
     SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/$SAMTOOLS_VERSION/samtools-$SAMTOOLS_VERSION.tar.bz2
 
 WORKDIR /usr/gitc
 
 # Install dependencies
-RUN apt-get update && \
-    apt-get -y install wget r-base && \
+RUN apk add --no-cache \
+    wget autoconf automake make gcc musl-dev perl bash zlib-dev bzip2-dev xz-dev curl-dev libressl-dev ncurses-dev tini && \
     \
     # Install samtools
+    mkdir temp && \
+    cd temp && \
     wget $SAMTOOLS_URL && \
     tar xf samtools-$SAMTOOLS_VERSION.tar.bz2 && \
-    rm samtools-$SAMTOOLS_VERSION.tar.bz2 && \
     cd samtools-$SAMTOOLS_VERSION && \
     ./configure && \
     make && \
     make install && \
-    cd ../ && \
-    rm -r samtools-$SAMTOOLS_VERSION && \
-    \
-    # Install tini
-    wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini && \
-    chmod +x /sbin/tini && \
-    # Clean up cached files
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -r /usr/gitc/temp
 
 # Set tini as default entrypoint
 ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/dockers/broad/samtools/Dockerfile
+++ b/dockers/broad/samtools/Dockerfile
@@ -1,43 +1,47 @@
 FROM alpine:3.8
 
-LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
-        SAMTOOLS_VERSION=${SAMTOOLS_VERSION}
-
 ARG SAMTOOLS_VERSION=1.11
 
 ENV TERM=xterm-256color \
     SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2
 
+LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
+        SAMTOOLS_VERSION=${SAMTOOLS_VERSION}
+
 WORKDIR /usr/gitc
 
 # Install dependencies
-RUN apk add --no-cache \
-    autoconf \
-    automake \ 
-    bash \
-    bzip2-dev \
-    curl-dev \
-    gcc \
-    libressl-dev \
-    make \ 
-    musl-dev \
-    ncurses-dev \
-    perl \
-    tini \ 
-    wget \ 
-    xz-dev \
-    zlib-dev && \
-    \
-    # Install samtools
-    mkdir temp && \
-    cd temp && \
-    wget ${SAMTOOLS_URL} && \
-    tar xf samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
-    cd samtools-${SAMTOOLS_VERSION} && \
-    ./configure && \
-    make && \
-    make install && \
-    rm -r /usr/gitc/temp
+RUN set -eux; \
+        apk add --no-cache \
+            autoconf \
+            automake \ 
+            bash \
+            bzip2-dev \
+            curl-dev \
+            gcc \
+            libressl-dev \
+            make \ 
+            musl-dev \
+            ncurses-dev \
+            perl \
+            tini \ 
+            wget \ 
+            xz-dev \
+            zlib-dev \
+        ; \
+# Install samtools
+        mkdir temp; \
+        cd temp; \
+        \
+        wget ${SAMTOOLS_URL}; \
+        tar xf samtools-${SAMTOOLS_VERSION}.tar.bz2; \
+        cd samtools-${SAMTOOLS_VERSION}; \
+        \
+        ./configure; \
+        make; \
+        make install; \
+        \
+        rm -r /usr/gitc/temp;
 
 # Set tini as default entrypoint
 ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/dockers/broad/samtools/Dockerfile
+++ b/dockers/broad/samtools/Dockerfile
@@ -1,0 +1,37 @@
+# Samtools requires lots of Debian only native packages
+# This also acts as a base image for many other images that require the JDK
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:8-debian
+
+LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>"
+
+ARG SAMTOOLS_VERSION=1.11
+
+ENV TERM=xterm-256color \
+    TINI_VERSION=v0.19.0 \
+    SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/$SAMTOOLS_VERSION/samtools-$SAMTOOLS_VERSION.tar.bz2
+
+WORKDIR /usr/gitc
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get -y install wget r-base && \
+    \
+    # Install samtools
+    wget $SAMTOOLS_URL && \
+    tar xf samtools-$SAMTOOLS_VERSION.tar.bz2 && \
+    rm samtools-$SAMTOOLS_VERSION.tar.bz2 && \
+    cd samtools-$SAMTOOLS_VERSION && \
+    ./configure && \
+    make && \
+    make install && \
+    cd ../ && \
+    rm -r samtools-$SAMTOOLS_VERSION && \
+    \
+    # Install tini
+    wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini && \
+    chmod +x /sbin/tini && \
+    # Clean up cached files
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set tini as default entrypoint
+ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/dockers/broad/samtools/Dockerfile
+++ b/dockers/broad/samtools/Dockerfile
@@ -1,30 +1,39 @@
-<<<<<<< HEAD
 FROM alpine:3.8
-=======
-# Samtools requires lots of Debian specific packages
-# This also acts as a base image for many other images that require the JDK
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:8-debian
->>>>>>> c757d709e2a554a605b606eb896c23b1c63691ca
 
-LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>"
+LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
+        SAMTOOLS_VERSION=${SAMTOOLS_VERSION}
 
 ARG SAMTOOLS_VERSION=1.11
 
 ENV TERM=xterm-256color \
-    SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/$SAMTOOLS_VERSION/samtools-$SAMTOOLS_VERSION.tar.bz2
+    SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2
 
 WORKDIR /usr/gitc
 
 # Install dependencies
 RUN apk add --no-cache \
-    wget autoconf automake make gcc musl-dev perl bash zlib-dev bzip2-dev xz-dev curl-dev libressl-dev ncurses-dev tini && \
+    autoconf \
+    automake \ 
+    bash \
+    bzip2-dev \
+    curl-dev \
+    gcc \
+    libressl-dev \
+    make \ 
+    musl-dev \
+    ncurses-dev \
+    perl \
+    tini \ 
+    wget \ 
+    xz-dev \
+    zlib-dev && \
     \
     # Install samtools
     mkdir temp && \
     cd temp && \
-    wget $SAMTOOLS_URL && \
-    tar xf samtools-$SAMTOOLS_VERSION.tar.bz2 && \
-    cd samtools-$SAMTOOLS_VERSION && \
+    wget ${SAMTOOLS_URL} && \
+    tar xf samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
+    cd samtools-${SAMTOOLS_VERSION} && \
     ./configure && \
     make && \
     make install && \

--- a/dockers/broad/samtools/docker_build.sh
+++ b/dockers/broad/samtools/docker_build.sh
@@ -19,7 +19,7 @@ HELP="$(basename "$0") [-h|--help] [-v|--version] [-t|tools] -- script to build 
 
 where:
     -h|--help Show help text
-    -v|--version Version of Samtools to use (default: $ZCALL_VERSION)
+    -v|--version Version of Samtools to use (default: $SAMTOOLS_VERSION)
     -t|--tools Show tools needed to run script
     "
 

--- a/dockers/broad/samtools/docker_build.sh
+++ b/dockers/broad/samtools/docker_build.sh
@@ -19,7 +19,7 @@ HELP="$(basename "$0") [-h|--help] [-v|--version] [-t|tools] -- script to build 
 
 where:
     -h|--help Show help text
-    -v|--version Zip version of Zcall to use (default: $ZCALL_VERSION)
+    -v|--version Version of Samtools to use (default: $ZCALL_VERSION)
     -t|--tools Show tools needed to run script
     "
 

--- a/dockers/broad/samtools/docker_build.sh
+++ b/dockers/broad/samtools/docker_build.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Update version when changes to Dockerfile are made
+DOCKER_IMAGE_VERSION=1.0.0
+TIMESTAMP=$(date +"%s")
+DIR=$(cd $(dirname $0) && pwd)
+
+# Registries and tags
+GCR_URL="us.gcr.io/broad-gotc-prod/samtools"
+IMAGE_TAG="$DOCKER_IMAGE_VERSION-$TIMESTAMP"
+
+# ZCall Version
+SAMTOOLS_VERSION="1.11"
+
+# Necessary tools and help text
+TOOLS=(docker gcloud)
+HELP="$(basename "$0") [-h|--help] [-v|--version] [-t|tools] -- script to build the samtools image and push to GCR & Dockerhub
+
+where:
+    -h|--help Show help text
+    -v|--version Zip version of Zcall to use (default: $ZCALL_VERSION)
+    -t|--tools Show tools needed to run script
+    "
+
+function main(){
+    for t in "${TOOLS[@]}"; do which $t >/dev/null || ok=no; done
+        if [[ $ok == no ]]; then
+            echo "Missing one of the following tools: "
+            for t in "${TOOLS[@]}"; do echo "$t"; done
+            exit 1
+        fi
+
+    while [[ $# -gt 0 ]]
+    do 
+    key="$1"
+    case $key in
+        -v|--version)
+        SAMTOOLS_VERSION="$2"
+        shift
+        shift
+        ;;
+        -h|--help)
+        echo "$HELP"
+        exit 0
+        ;;
+        -t|--tools)
+        for t in "${TOOLS[@]}"; do echo $t; done
+        exit 0
+        ;;
+        *)
+        shift
+        ;;
+    esac
+    done
+
+    echo "building and pushing GCR Image - $GCR_URL:$IMAGE_TAG"
+    docker build --no-cache -t "$GCR_URL:$IMAGE_TAG" \
+        --build-arg SAMTOOLS_VERSION="$SAMTOOLS_VERSION" $DIR 
+    docker push "$GCR_URL:$IMAGE_TAG"
+
+    echo -e "$GCR_URL:$IMAGE_TAG" >> "$DIR/docker_versions.tsv"
+    echo "done"
+}
+
+main "$@"

--- a/dockers/broad/samtools/docker_versions.tsv
+++ b/dockers/broad/samtools/docker_versions.tsv
@@ -1,0 +1,2 @@
+DOCKER_VERSION
+us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384

--- a/dockers/broad/samtools/docker_versions.tsv
+++ b/dockers/broad/samtools/docker_versions.tsv
@@ -1,2 +1,2 @@
 DOCKER_VERSION
-us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384
+us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,8 +1,7 @@
 # 2.5.0
-2021-06-10
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.5

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,7 +1,7 @@
 # 2.5.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.5

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,7 +1,7 @@
 # 2.4.0
 2021-06-10
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 2.3.5

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,8 +1,7 @@
 # 2.4.0
 2021-06-10
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 2.3.5

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
@@ -1,7 +1,7 @@
 # 1.1.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 1.0.1

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
@@ -1,8 +1,7 @@
 # 1.1.0
-2021-06-10
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 1.0.1

--- a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.changelog.md
@@ -1,8 +1,7 @@
 # 1.2.0
-2021-06-09
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 
 # 1.1.0
 2021-03-23

--- a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.changelog.md
@@ -1,7 +1,7 @@
 # 1.2.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 
 # 1.1.0
 2021-03-23

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.changelog.md
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.changelog.md
@@ -1,7 +1,7 @@
 # 1.1.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 
 # 1.0.1
 2021-02-08

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.changelog.md
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.changelog.md
@@ -1,8 +1,7 @@
-# 1.1.1
-2021-06-09
+# 1.1.0
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 
 # 1.0.1
 2021-02-08

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -9,7 +9,7 @@ version 1.0
 # If the file is not provided, the output names of the unmapped bams will be the read_group_id<unmapped_bam_suffix>
 workflow CramToUnmappedBams {
 
-  String pipeline_version = "1.1.1"
+  String pipeline_version = "1.1.0"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -158,7 +158,7 @@ task CramToBam {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616"
     cpu: 3
     memory: "~{memory_in_MiB} MiB"
     disks: "local-disk " + disk_size + " HDD"
@@ -194,7 +194,7 @@ task GenerateOutputMap {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616"
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory_in_MiB} MiB"
     preemptible: 3
@@ -252,7 +252,7 @@ task SplitOutUbamByReadGroup {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616"
     cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory_in_MiB} MiB"

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl
@@ -158,7 +158,7 @@ task CramToBam {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
     cpu: 3
     memory: "~{memory_in_MiB} MiB"
     disks: "local-disk " + disk_size + " HDD"
@@ -194,7 +194,7 @@ task GenerateOutputMap {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory_in_MiB} MiB"
     preemptible: 3
@@ -252,7 +252,7 @@ task SplitOutUbamByReadGroup {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
     cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory_in_MiB} MiB"

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -1,8 +1,7 @@
 # 2.5.0
 2021-06-10
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.7

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -1,7 +1,7 @@
 # 2.5.0
 2021-06-10
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.7

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -1,7 +1,7 @@
 # 2.5.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.7

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -1,8 +1,7 @@
 # 2.5.0
-2021-06-10
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 2.4.7

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,7 +1,7 @@
 # 1.4.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 1.3.7

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,8 +1,7 @@
 # 1.4.0
-2021-06-10
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 1.3.7

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -1,7 +1,7 @@
 # 2.4.0
 2021-06-28
 
-* Change GoTC image to Samtools specific image in CramToUnmappedBams
+* Change GoTC image to Samtools specific image in CramToUnmappedBams and Utilities
 * Updated VerifyBamID to use AppSec base image
 
 # 2.3.7

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -1,8 +1,7 @@
 # 2.4.0
-2021-06-10
+2021-06-28
 
-* Updated GoTC base image to AppSec approved 
-* Updated BWA version for GoTC image from 0.7.15.r1140 to 0.7.15
+* Change GoTC image to Samtools specific image in CramToUnmappedBams
 * Updated VerifyBamID to use AppSec base image
 
 # 2.3.7

--- a/tasks/broad/Utilities.wdl
+++ b/tasks/broad/Utilities.wdl
@@ -145,7 +145,7 @@ task ConvertToCram {
     samtools index ~{output_basename}.cram
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616"
     preemptible: preemptible_tries
     memory: "3 GiB"
     cpu: "1"
@@ -176,7 +176,7 @@ task ConvertToBam {
     samtools index ~{output_basename}.bam
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624651616"
     preemptible: 3
     memory: "3 GiB"
     cpu: "1"

--- a/tasks/broad/Utilities.wdl
+++ b/tasks/broad/Utilities.wdl
@@ -145,7 +145,7 @@ task ConvertToCram {
     samtools index ~{output_basename}.cram
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
     preemptible: preemptible_tries
     memory: "3 GiB"
     cpu: "1"
@@ -176,7 +176,7 @@ task ConvertToBam {
     samtools index ~{output_basename}.bam
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1624631384"
     preemptible: 3
     memory: "3 GiB"
     cpu: "1"


### PR DESCRIPTION
This PR creates a samtools specific docker image available at `us.gcr.io/broad-gotc-prod/samtools` and replaces tasks _(Utilities.wdl & CramToUnmappedBam.wdl)_ that were previously using the GoTC docker image while only needing samtools.