### PR TITLE
[GL-1488] better wording for SmartSeq2 update changelogs

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,7 +1,7 @@
 # 4.2.6
 2021-07-19 (Date of Last Commit)
 
-* Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes
+* Updated SmartSeq2 to accommodate spaces in input_name
 
 # 4.2.5
 

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -1,7 +1,7 @@
 # 2.2.3
 2021-07-19 (Date of Last Commit)
 
-* Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes
+* Updated SmartSeq2 to accommodate spaces in input_name
 
 # 2.2.2
 

--- a/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.1
 2021-07-19 (Date of Last Commit)
 
-* Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes
+* Updated SmartSeq2 to accommodate spaces in input_name
 
 # 1.0.0
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.1
 2021-07-19 (Date of Last Commit)
 
-* Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes
+* Updated SmartSeq2 to accommodate spaces in input_name
 
 # 1.0.0
 

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -1,7 +1,7 @@
 # 5.1.3
 2021-07-19 (Date of Last Commit)
 
-* Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes
+* Updated SmartSeq2 to accommodate spaces in input_name
 
 # 5.1.2
 


### PR DESCRIPTION
Updating changelog from "Updated LoomUtils SmartSeq2LoomOutput task to wrap input_name in quotes" to "Updated SmartSeq2 to accommodate spaces in input_name" to better describe user input.