### PR TITLE
GL-1627.  Make Params Inputs Top Level Inputs to Arrays WDL.

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,10 @@
+# 2.3.3
+2021-07-22
+
+* Have pipeline take the values supplied in 'params.txt' input file as optional top-level inputs. First step towards removal
+* Provide params.txt file as output of pipeline.
+* Set default call rate threshold of pipeline to 0.98
+
 # 2.3.2
 2021-07-13
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -21,20 +21,27 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow Arrays {
 
-  String pipeline_version = "2.3.2"
+  String pipeline_version = "2.3.3"
 
   input {
 
     # This is the autocall_version, needed for the case where autocall fails (likely due to normalization errors)
     # In this case it no longer emits the version in its output, so we store it here.
     String autocall_version = "3.0.0"
-    String sample_alias
-    String sample_lsid
-    Int analysis_version_number
-    Float call_rate_threshold
-    String reported_gender
 
     String chip_well_barcode
+    Int analysis_version_number
+
+    String sample_alias
+    String? sample_id
+    String sample_lsid
+    String reported_gender
+    String? collaborator_participant_id
+    String? participant_id
+
+    Float call_rate_threshold = 0.98
+    Float genotype_concordance_threshold = 0.98
+
     File red_idat_cloud_path
     File green_idat_cloud_path
     File ref_fasta
@@ -44,7 +51,15 @@ workflow Arrays {
     File dbSNP_vcf
     File dbSNP_vcf_index
 
-    File params_file
+    File? params_file
+    String? lab_batch
+    String? product_family
+    String? product_name
+    String? product_order_id
+    String? product_part_number
+    String? product_type  # careful!
+    String? regulatory_designation
+    String? research_project_id
 
     File bead_pool_manifest_file
     String chip_type = basename(bead_pool_manifest_file, ".bpm")
@@ -82,8 +97,6 @@ workflow Arrays {
     Int preemptible_tries
     String environment
     File vault_token_path
-
-    Float genotype_concordance_threshold = 0.98
   }
 
   String service_account_filename = "service-account.json"
@@ -114,9 +127,34 @@ workflow Arrays {
   "fi",
   "vault read --format=json $key | jq .data > ~{service_account_filename}"]
 
+  if (!defined(params_file)) {
+    # If the params_file is not provided, we will generate it from the (currently optional) bunch of parameters.
+    # This is to allow for backwards-compatibility.  When we remove params_file as an (optional) input, this will be
+    # made a required step and all the inputs will become non-optional
+    call InternalTasks.CreateChipWellBarcodeParamsFile {
+      input:
+        chip_type_name = chip_type,
+        chip_well_barcode = chip_well_barcode,
+        collaborator_participant_id = select_first([collaborator_participant_id]),
+        lab_batch = select_first([lab_batch]),
+        participant_id = select_first([participant_id]),
+        product_family = select_first([product_family]),
+        product_name = select_first([product_name]),
+        product_order_id = select_first([product_order_id]),
+        product_part_number = select_first([product_part_number]),
+        product_type = select_first([product_type]),
+        regulatory_designation = select_first([regulatory_designation]),
+        research_project_id = select_first([research_project_id]),
+        sample_alias = sample_alias,
+        gender = reported_gender,
+        sample_id = select_first([sample_id]),
+        sample_lsid = sample_lsid,
+        preemptible_tries = preemptible_tries
+    }
+  }
   call InternalTasks.UpdateChipWellBarcodeIndex {
     input:
-      params_file = params_file,
+      params_file = select_first([CreateChipWellBarcodeParamsFile.params_file, params_file]),
       disk_size = disk_size,
       preemptible_tries = preemptible_tries,
       authentication = authentication_block,
@@ -290,6 +328,7 @@ workflow Arrays {
     File? GenotypeConcordanceSummaryMetricsFile = IlluminaGenotypingArray.genotype_concordance_summary_metrics
     File? GenotypeConcordanceDetailMetricsFile  = IlluminaGenotypingArray.genotype_concordance_detail_metrics
     File? GenotypeConcordanceContingencyMetricsFile = IlluminaGenotypingArray.genotype_concordance_contingency_metrics
+    File ChipWellBarcodeParamsFile = select_first([CreateChipWellBarcodeParamsFile.params_file, params_file])
   }
   meta {
     allowNestedInputs: true

--- a/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "7991775143_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-3S2IV",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:3S2IV",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-CO-5799466",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Exome V1_A",
+  "Arrays.product_order_id": "PDO-15923",
+  "Arrays.product_part_number": "P-WG-0094",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-45",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "7991775143_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
@@ -17,11 +30,10 @@
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -30,6 +42,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "101342370027_R02C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-A2ZQ7",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:A2ZQ7",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-Y2YY",
+
+  "Arrays.lab_batch": "ARRAY-4223",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych (High Volume >10,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-6743",
+  "Arrays.product_part_number": "P-WG-0036",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1014",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "101342370027_R02C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370027_R02C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12892",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12892",
+  "Arrays.chip_well_barcode": "101342370027_R12C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12892",
+  "Arrays.sample_id": "SM-A2ZQL",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:A2ZQL",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12892",
+  "Arrays.participant_id": "PT-97GO",
+
+  "Arrays.lab_batch": "ARRAY-4223",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych (High Volume >10,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-6743",
+  "Arrays.product_part_number": "P-WG-0036",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1014",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "101342370027_R12C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370027_R12C02/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.interval_list",
-  "Arrays.control_sample_name" : "NA12892",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12892",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12891",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12891",
+  "Arrays.chip_well_barcode": "101342370134_R12C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12891",
+  "Arrays.sample_id": "SM-A2ZNU",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:A2ZNU",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "NA12891",
+  "Arrays.participant_id": "PT-97GN",
+
+  "Arrays.lab_batch": "ARRAY-4222",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych (High Volume >10,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-6743",
+  "Arrays.product_part_number": "P-WG-0036",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1014",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "101342370134_R12C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/101342370134_R12C02/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.interval_list",
-  "Arrays.control_sample_name" : "NA12891",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12891",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "200246060179_R09C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-AM3PR",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:AM3PR",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-5151",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium ImmunoArray",
+  "Arrays.product_order_id": "PDO-7336",
+  "Arrays.product_part_number": "P-WG-0057",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "200246060179_R09C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/inputs/200246060179_R09C02/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumImmunoArray-24v2-0_A/InfiniumImmunoArray-24v2-0_A_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "PRISM_7032",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.PRISM7032",
+  "Arrays.chip_well_barcode": "200557060038_R10C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "PRISM_7032",
+  "Arrays.sample_id": "SM-DTY39",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DTY39",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "7032",
+  "Arrays.participant_id": "PT-KH7G",
+
+  "Arrays.lab_batch": "ARRAY-7976",
+  "Arrays.product_family": "Exome",
+  "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
+  "Arrays.product_order_id": "PDO-11233",
+  "Arrays.product_part_number": "P-EX-0021",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "200557060038_R10C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557060038_R10C02/200557060038_R10C02.PRISM_7032.reference.fingerprint.vcf.gz.tbi",
@@ -19,8 +32,6 @@
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -28,6 +39,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "200557070005_R06C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-DTXXF",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DTXXF",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-7975",
+  "Arrays.product_family": "Exome",
+  "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
+  "Arrays.product_order_id": "PDO-11233",
+  "Arrays.product_part_number": "P-EX-0021",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "200557070005_R06C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070005_R06C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "PRI SM_7241",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.PRISM_7241",
+  "Arrays.chip_well_barcode": "200557070028_R10C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "PRI SM_7241",
+  "Arrays.sample_id": "SM-DTY76",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DTY76",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "7241",
+  "Arrays.participant_id": "PT-KIGI",
+
+  "Arrays.lab_batch": "ARRAY-7978",
+  "Arrays.product_family": "Exome",
+  "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
+  "Arrays.product_order_id": "PDO-11233",
+  "Arrays.product_part_number": "P-EX-0021",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "200557070028_R10C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070028_R10C01/200557070028_R10C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070028_R10C01/200557070028_R10C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070028_R10C01/200557070028_R10C01.PRI_SM_7241.reference.fingerprint.vcf.gz.tbi",
@@ -19,8 +32,6 @@
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -28,6 +39,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "PRI SM_8643",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.PRISM_8643",
+  "Arrays.chip_well_barcode": "200557070035_R05C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "PRI SM_8643",
+  "Arrays.sample_id": "SM-DTXZB",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DTXZB",
+  "Arrays.reported_gender": "NotReported",
+  "Arrays.collaborator_participant_id": "8643",
+  "Arrays.participant_id": "PT-11H88",
+
+  "Arrays.lab_batch": "ARRAY-7975",
+  "Arrays.product_family": "Exome",
+  "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
+  "Arrays.product_order_id": "PDO-11233",
+  "Arrays.product_part_number": "P-EX-0021",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "NotReported",
-  "Arrays.chip_well_barcode": "200557070035_R05C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070035_R05C02/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "PRISM_7289",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.PRISM_7289",
+  "Arrays.chip_well_barcode": "200557070035_R06C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "PRISM_7289",
+  "Arrays.sample_id": "SM-DTXX9",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DTXX9",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "7289",
+  "Arrays.participant_id": "PT-KIHU",
+
+  "Arrays.lab_batch": "ARRAY-7975",
+  "Arrays.product_family": "Exome",
+  "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
+  "Arrays.product_order_id": "PDO-11233",
+  "Arrays.product_part_number": "P-EX-0021",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-30",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "200557070035_R06C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/inputs/200557070035_R06C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Broad_GWAS_supplemental_15061359_A1/Broad_GWAS_supplemental_15061359_A1.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Broad_GWAS_supplemental_15061359_A1/thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "90C04566",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.90C04566",
+  "Arrays.chip_well_barcode": "200598830050_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "90C04566",
+  "Arrays.sample_id": "SM-CMPZK",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:CMPZK",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "90C04566",
+  "Arrays.participant_id": "PT-164BW",
+
+  "Arrays.lab_batch": "ARRAY-6365",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych Array Processing v2",
+  "Arrays.product_order_id": "PDO-9246",
+  "Arrays.product_part_number": "P-WG-0055",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "200598830050_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "07C6 2854",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.07C62854",
+  "Arrays.chip_well_barcode": "200598830050_R04C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "07C6 2854",
+  "Arrays.sample_id": "SM-CMQ2Y",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:CMQ2Y",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "07C62854",
+  "Arrays.participant_id": "PT-1KJ8J",
+
+  "Arrays.lab_batch": "ARRAY-6365",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych Array Processing v2",
+  "Arrays.product_order_id": "PDO-9246",
+  "Arrays.product_part_number": "P-WG-0055",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "200598830050_R04C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R04C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "01C05949",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.01C05949",
+  "Arrays.chip_well_barcode": "200598830050_R06C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "01C05949",
+  "Arrays.sample_id": "SM-CMQ1Z",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:CMQ1Z",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "01C05949",
+  "Arrays.participant_id": "PT-1682O",
+
+  "Arrays.lab_batch": "ARRAY-6365",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych Array Processing v2",
+  "Arrays.product_order_id": "PDO-9246",
+  "Arrays.product_part_number": "P-WG-0055",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "200598830050_R06C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R06C02/200598830050_R06C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R06C02/200598830050_R06C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R06C02/200598830050_R06C02.01C05949.reference.fingerprint.vcf.gz.tbi",
@@ -19,8 +32,6 @@
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -28,6 +39,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "03C 17319",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.03C17319",
+  "Arrays.chip_well_barcode": "200598830050_R07C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "03C 17319",
+  "Arrays.sample_id": "SM-CMQ1L",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:CMQ1L",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "03C17319",
+  "Arrays.participant_id": "PT-1673S",
+
+  "Arrays.lab_batch": "ARRAY-6365",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Psych Array Processing v2",
+  "Arrays.product_order_id": "PDO-9246",
+  "Arrays.product_part_number": "P-WG-0055",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "200598830050_R07C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R07C01/200598830050_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R07C01/200598830050_R07C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/inputs/200598830050_R07C01/200598830050_R07C01.03C_17319.reference.fingerprint.vcf.gz.tbi",
@@ -19,8 +32,6 @@
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/PsychChip_v1-1_15073391_A1/PsychChip_v1-1_15073391_A1_ClusterFile.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/PsychChip_v1-1_15073391_A1/thresholds.7.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -28,6 +39,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -1,27 +1,39 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "201004840016_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-G6VVH",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G6VVH",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-8847",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-11363",
+  "Arrays.product_part_number": "P-WG-0059",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1244",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201004840016_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201004840016_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
-  "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
-  "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
+  "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -30,6 +42,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -1,23 +1,34 @@
 {
-  "Arrays.sample_alias": "AA484383",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.AA484383",
+  "Arrays.chip_well_barcode": "201008710016_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "AA484383",
+  "Arrays.sample_id": "SM-G6VYC",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G6VYC",
+  "Arrays.reported_gender": "NotReported",
+  "Arrays.collaborator_participant_id": "AA484383",
+  "Arrays.participant_id": "PT-237YD",
+
+  "Arrays.lab_batch": "ARRAY-8848",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-11363",
+  "Arrays.product_part_number": "P-WG-0059",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1244",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "NotReported",
-  "Arrays.chip_well_barcode": "201008710016_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201008710016_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
-  "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
-  "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
+  "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -26,6 +37,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -1,23 +1,34 @@
 {
-  "Arrays.sample_alias": "BMS_000637780",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.BMS_000637780",
+  "Arrays.chip_well_barcode": "201008710016_R05C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "BMS 000637780",
+  "Arrays.sample_id": "SM-G6VZP",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G6VZP",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "BMS000637780",
+  "Arrays.participant_id": "PT-239TI",
+
+  "Arrays.lab_batch": "ARRAY-8848",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
+  "Arrays.product_order_id": "PDO-11363",
+  "Arrays.product_part_number": "P-WG-0059",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1244",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "201008710016_R05C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/inputs/201008710016_R05C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
-  "Arrays.gender_cluster_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
-  "Arrays.zcall_thresholds_file" : "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_ClusterFile.egt",
+  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal_A1_Gentrain_Genderest_ClusterFile_highmafX.egt",
+  "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/Multi-EthnicGlobal-8_A1/Multi-EthnicGlobal-8_A1.thresholds.7.txt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -26,6 +37,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "20055 11847",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.2005511847",
+  "Arrays.chip_well_barcode": "201096140037_R07C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "20055 11847",
+  "Arrays.sample_id": "SM-EXT5R",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EXT5R",
+  "Arrays.reported_gender": "NotReported",
+  "Arrays.collaborator_participant_id": "8002117365",
+  "Arrays.participant_id": "PT-23DDH",
+
+  "Arrays.lab_batch": "ARRAY-8363",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11809",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-755",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "NotReported",
-  "Arrays.chip_well_barcode": "201096140037_R07C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201096140037_R07C01/201096140037_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201096140037_R07C01/201096140037_R07C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201096140037_R07C01/201096140037_R07C01.20055_11847.reference.fingerprint.vcf.gz.tbi",
@@ -20,8 +33,6 @@
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -29,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -1,23 +1,34 @@
 {
-  "Arrays.sample_alias": "05C49266",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.05C49266",
+  "Arrays.chip_well_barcode": "201138240147_R05C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "05C49266",
+  "Arrays.sample_id": "SM-EUXSU",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EUXSU",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "05C49266",
+  "Arrays.participant_id": "PT-1SK79",
+
+  "Arrays.lab_batch": "ARRAY-8214",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11580",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "201138240147_R05C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201138240147_R05C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -26,6 +37,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -1,23 +1,34 @@
 {
-  "Arrays.sample_alias": "MH 0188385",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.MH0188385",
+  "Arrays.chip_well_barcode": "201138240147_R08C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "MH 0188385",
+  "Arrays.sample_id": "SM-EUXSJ",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EUXSJ",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "MH0188385",
+  "Arrays.participant_id": "PT-23XH1",
+
+  "Arrays.lab_batch": "ARRAY-8214",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11580",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "201138240147_R08C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201138240147_R08C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -26,6 +37,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "2004 713547",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.2004713547",
+  "Arrays.chip_well_barcode": "201145020059_R07C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "2004 713547",
+  "Arrays.sample_id": "SM-EXNAA",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EXNAA",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "13352",
+  "Arrays.participant_id": "PT-23Q4A",
+
+  "Arrays.lab_batch": "ARRAY-8354",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11809",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-755",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "201145020059_R07C01",
 
-  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201145020059_R07C01/201145020059_R07C01_Grn.idat",
-  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201145020059_R07C01/201145020059_R07C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/params.txt",
+  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Grn.idat",
+  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Red.idat",
 
-  "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
-  "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
+  "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
+  "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
-  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
+  "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "2004826455",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.2004826455",
+  "Arrays.chip_well_barcode": "201145020068_R12C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "2004826455",
+  "Arrays.sample_id": "SM-EXH5X",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EXH5X",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "19412",
+  "Arrays.participant_id": "PT-23TCZ",
+
+  "Arrays.lab_batch": "ARRAY-8336",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11809",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-755",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201145020068_R12C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020068_R12C01/201145020068_R12C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020068_R12C01/201145020068_R12C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020068_R12C01/201145020068_R12C01.2004826455.reference.fingerprint.vcf.gz.tbi",
@@ -20,8 +33,6 @@
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
-  "Arrays.disk_size": 100,
-
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "Arrays.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
@@ -29,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "2005492094",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.2005492094",
+  "Arrays.chip_well_barcode": "201148280144_R12C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "2005492094",
+  "Arrays.sample_id": "SM-EXN53",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EXN53",
+  "Arrays.reported_gender": "NotReported",
+  "Arrays.collaborator_participant_id": "8002107666",
+  "Arrays.participant_id": "PT-23KNN",
+
+  "Arrays.lab_batch": "ARRAY-8352",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11809",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-755",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "NotReported",
-  "Arrays.chip_well_barcode": "201148280144_R12C01",
 
-  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201148280144_R12C01/201148280144_R12C01_Grn.idat",
-  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201148280144_R12C01/201148280144_R12C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/params.txt",
+  "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Grn.idat",
+  "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Red.idat",
 
-  "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
-  "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
+  "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
+  "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
-  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
+  "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "MH0158716",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.MH0158716",
+  "Arrays.chip_well_barcode": "201159110147_R06C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "MH0158716",
+  "Arrays.sample_id": "SM-EUY2M",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EUY2M",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "MH0158716",
+  "Arrays.participant_id": "PT-2444W",
+
+  "Arrays.lab_batch": "ARRAY-8217",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array Processing",
+  "Arrays.product_order_id": "PDO-11580",
+  "Arrays.product_part_number": "P-WG-0066",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "201159110147_R06C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201159110147_R06C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -1,22 +1,33 @@
 {
-  "Arrays.sample_alias": "MH 0178994",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.MH0178994",
+  "Arrays.chip_well_barcode": "201159110147_R09C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "MH 0178994",
+  "Arrays.sample_id": "SM-EUY3Y",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EUY3Y",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "MH0178994",
+  "Arrays.participant_id": "PT-2416X",
+
+  "Arrays.lab_batch": "ARRAY-8217",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array Processing",
+  "Arrays.product_order_id": "PDO-11580",
+  "Arrays.product_part_number": "P-WG-0066",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201159110147_R09C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201159110147_R09C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
-
-  "Arrays.disk_size": 100,
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -25,6 +36,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "201179310001_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-DOKRN",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DOKRN",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-7836",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array Processing",
+  "Arrays.product_order_id": "PDO-10839",
+  "Arrays.product_part_number": "P-WG-0066",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-518",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201179310001_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,7 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12892",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12892",
+  "Arrays.chip_well_barcode": "201179310001_R09C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12892",
+  "Arrays.sample_id": "SM-DOKSC",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DOKSC",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12892",
+  "Arrays.participant_id": "PT-97GO",
+
+  "Arrays.lab_batch": "ARRAY-7836",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array Processing",
+  "Arrays.product_order_id": "PDO-10839",
+  "Arrays.product_part_number": "P-WG-0066",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-518",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201179310001_R09C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R09C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12892.interval_list",
-  "Arrays.control_sample_name" : "NA12892",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12892",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12892.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -1,26 +1,38 @@
 {
-  "Arrays.sample_alias": "NA12891",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12891",
+  "Arrays.chip_well_barcode": "201179310001_R12C02",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12891",
+  "Arrays.sample_id": "SM-DOKSW",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:DOKSW",
+  "Arrays.reported_gender": "Male",
+  "Arrays.collaborator_participant_id": "NA12891",
+  "Arrays.participant_id": "PT-97GN",
+
+  "Arrays.lab_batch": "ARRAY-7836",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array Processing",
+  "Arrays.product_order_id": "PDO-10839",
+  "Arrays.product_part_number": "P-WG-0066",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-518",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Male",
-  "Arrays.chip_well_barcode": "201179310001_R12C02",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201179310001_R12C02/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12891.interval_list",
-  "Arrays.control_sample_name" : "NA12891",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12891",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12891.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -1,15 +1,28 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "201179320110_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-EUXS3",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:EUXS3",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-8214",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-11580",
+  "Arrays.product_part_number": "P-WG-0073",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-48",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201179320110_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201179320110_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
@@ -17,11 +30,10 @@
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -30,6 +42,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "201490040272_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-G8OW9",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G8OW9",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-8946",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201490040272_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201490040272_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "201651070002_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-G7QPM",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G7QPM",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-8888",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201651070002_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651070002_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -1,21 +1,32 @@
 {
-  "Arrays.sample_alias": "SLH 39O71",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.SLH39071",
+  "Arrays.chip_well_barcode": "201651070043_R06C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "SLH 39O71",
+  "Arrays.sample_id": "SM-G7QQO",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G7QQO",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "S002-SANF-01782",
+  "Arrays.participant_id": "PT-25FNM",
+
+  "Arrays.lab_batch": "ARRAY-8888",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "201651070043_R06C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651070043_R06C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -24,6 +35,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -1,24 +1,35 @@
 {
-  "Arrays.sample_alias": "S8 N4B3GY",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.S8N4B3GY",
+  "Arrays.chip_well_barcode": "201651080129_R05C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "S8 N4B3GY",
+  "Arrays.sample_id": "SM-G7QQF",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G7QQF",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "RETR-BISH-008",
+  "Arrays.participant_id": "PT-25FMI",
+
+  "Arrays.lab_batch": "ARRAY-8888",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "201651080129_R05C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R05C01/201651080129_R05C01.S8_N4B3GY.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -27,6 +38,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -1,24 +1,35 @@
 {
-  "Arrays.sample_alias": "SPT3TC2T",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.SPT3TC2T",
+  "Arrays.chip_well_barcode": "201651080129_R06C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "SPT3TC2T",
+  "Arrays.sample_id": "SM-G7QQL",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G7QQL",
+  "Arrays.reported_gender": "NotReported",
+  "Arrays.collaborator_participant_id": "S002-BISH-05739",
+  "Arrays.participant_id": "PT-25FN8",
+
+  "Arrays.lab_batch": "ARRAY-8888",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "NotReported",
-  "Arrays.chip_well_barcode": "201651080129_R06C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R06C01/201651080129_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R06C01/201651080129_R06C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/params.txt",
 
   "Arrays.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz",
   "Arrays.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R06C01/201651080129_R06C01.SPT3TC2T.reference.fingerprint.vcf.gz.tbi",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -27,6 +38,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -1,21 +1,32 @@
 {
-  "Arrays.sample_alias": "S3QG3651",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.S3QG3651",
+  "Arrays.chip_well_barcode": "201651080129_R07C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "S3QG3651",
+  "Arrays.sample_id": "SM-G7QQR",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:G7QQR",
+  "Arrays.reported_gender": "Unknown",
+  "Arrays.collaborator_participant_id": "S002-BISH-05483-A",
+  "Arrays.participant_id": "PT-25FN6",
+
+  "Arrays.lab_batch": "ARRAY-8888",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
+  "Arrays.product_order_id": "PDO-12280",
+  "Arrays.product_part_number": "P-WG-0070",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1169",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Unknown",
-  "Arrays.chip_well_barcode": "201651080129_R07C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/inputs/201651080129_R07C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-4_A1/InfiniumOmniExpressExome-8v1-4_A1_ClusterFile.egt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -24,6 +35,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "202871110118_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-IG82T",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:IG82T",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-12490",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v3",
+  "Arrays.product_order_id": "PDO-16982",
+  "Arrays.product_part_number": "P-WG-0092",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-1729",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "202871110118_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/inputs/202871110118_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/InfiniumOmniExpressExome-8v1-6_A1/InfiniumOmniExpressExome-8v1-6_A1_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "203078500006_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-I59J7",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:I59J7",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-11911",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "CLIA Infinium AoU Array",
+  "Arrays.product_order_id": "PDO-16681",
+  "Arrays.product_part_number": "P-CLA-0010",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "CLINICAL_DIAGNOSTICS",
+  "Arrays.research_project_id": "RP-1710",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "203078500006_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/inputs/203078500006_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.bpm",
   "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_20002558X351448_A2.1.4.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/MEG_AllofUs_20002558X351448_A2/MEG_AllofUs_A1_Gentrain_1299_edited_prevalidation_081419update.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "204126290052_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-I59J7",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:I59J7",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-11911",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "CLIA Infinium AoU Array",
+  "Arrays.product_order_id": "PDO-16681",
+  "Arrays.product_part_number": "P-CLA-0010",
+  "Arrays.product_type": "aou_array",
+  "Arrays.regulatory_designation": "CLINICAL_DIAGNOSTICS",
+  "Arrays.research_project_id": "RP-1710",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "204126290052_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/inputs/204126290052_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.bpm",
   "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.1.5.extended.csv",
   "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A1_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
   "Arrays.minor_allele_frequency_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.MAF.txt",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "204126290052_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-I59J7",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:I59J7",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-11911",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "CLIA Infinium AoU Array",
+  "Arrays.product_order_id": "PDO-16681",
+  "Arrays.product_part_number": "P-CLA-0010",
+  "Arrays.product_type": "aou_array",
+  "Arrays.regulatory_designation": "CLINICAL_DIAGNOSTICS",
+  "Arrays.research_project_id": "RP-1710",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "204126290052_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/inputs/204126290052_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.bpm",
   "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.2.0.extended.csv",
   "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A1_ClusterFile.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -29,6 +41,8 @@
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
   "Arrays.minor_allele_frequency_file": "gs://broad-gotc-test-storage/arrays/metadata/GDA-8v1-0_A5/GDA-8v1-0_A5.MAF.txt",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "205346990020_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-KXQIP",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:KXQIP",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-KLZD",
+
+  "Arrays.lab_batch": "ARRAY-16700",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Global Screening v3 Array + Multi Disease Processing",
+  "Arrays.product_order_id": "PDO-22611",
+  "Arrays.product_part_number": "P-WG-0121",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-2365",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "205346990020_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/inputs/205346990020_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1.bpm",
   "Arrays.extended_chip_manifest_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1.2.0.extended.csv",
   "Arrays.cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v3-0-EA_20034606_A1/GSAMD-24v3-0-EA_20034606_A1_custom.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
@@ -1,6 +1,6 @@
 {
   "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:3S2IV",
   "Arrays.analysis_version_number": 1,
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
@@ -17,11 +17,10 @@
   "Arrays.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt",
   "Arrays.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
+  "Arrays.control_sample_name": "NA12878",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -30,6 +29,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "8925008101_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-3QGGM",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:3QGGM",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-CO-5729562",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium Omni Express Array Processing v1_H",
+  "Arrays.product_order_id": "PDO-15791",
+  "Arrays.product_part_number": "P-WG-0093",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-45",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "8925008101_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/inputs/8925008101_R01C01/params.txt",
 
   "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.1.3.extended.csv",
   "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmniExpress-12v1_H/HumanOmniExpress-12v1_H.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
@@ -1,20 +1,31 @@
 {
-  "Arrays.sample_alias": "09C89876",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.09C89876",
-  "Arrays.analysis_version_number": 2,
-  "Arrays.call_rate_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
   "Arrays.chip_well_barcode": "8942377043_R01C01",
+  "Arrays.analysis_version_number": 2,
+
+  "Arrays.sample_alias": "09C89876",
+  "Arrays.sample_id": "SM-3T9W6",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:3T9W6",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "09C89876",
+  "Arrays.participant_id": "PT-KL7R",
+
+  "Arrays.lab_batch": "ARRAY-CO-5852532",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium 2.5M-8",
+  "Arrays.product_order_id": "PDO-70",
+  "Arrays.product_part_number": "P-WG-0007",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-131",
+
+  "Arrays.call_rate_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/8942377043_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/8942377043_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/inputs/8942377043_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
-
-  "Arrays.disk_size": 100,
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -23,6 +34,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
@@ -1,25 +1,37 @@
 {
-  "Arrays.sample_alias": "NA12878",
-  "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
+  "Arrays.chip_well_barcode": "9216473070_R01C01",
   "Arrays.analysis_version_number": 1,
+
+  "Arrays.sample_alias": "NA12878",
+  "Arrays.sample_id": "SM-43V2O",
+  "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:43V2O",
+  "Arrays.reported_gender": "Female",
+  "Arrays.collaborator_participant_id": "NA12878",
+  "Arrays.participant_id": "PT-97GM",
+
+  "Arrays.lab_batch": "ARRAY-CO-6269982",
+  "Arrays.product_family": "Whole Genome Genotyping",
+  "Arrays.product_name": "Infinium 2.5M-8",
+  "Arrays.product_order_id": "PDO-70",
+  "Arrays.product_part_number": "P-WG-0007",
+  "Arrays.product_type": "",
+  "Arrays.regulatory_designation": "RESEARCH_ONLY",
+  "Arrays.research_project_id": "RP-131",
+
   "Arrays.call_rate_threshold": 0.98,
   "Arrays.genotype_concordance_threshold": 0.98,
-  "Arrays.reported_gender": "Female",
-  "Arrays.chip_well_barcode": "9216473070_R01C01",
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Red.idat",
-  "Arrays.params_file": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/inputs/9216473070_R01C01/params.txt",
 
-  "Arrays.bead_pool_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
-  "Arrays.extended_chip_manifest_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
-  "Arrays.cluster_file" : "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
+  "Arrays.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.bpm",
+  "Arrays.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.1.3.extended.csv",
+  "Arrays.cluster_file": "gs://gcp-public-data--broad-references/arrays/HumanOmni2.5-8v1_A/HumanOmni2.5-8v1_A.egt",
 
-  "Arrays.control_sample_vcf_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
-  "Arrays.control_sample_vcf_index_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
-  "Arrays.control_sample_intervals_file" : "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
-  "Arrays.control_sample_name" : "NA12878",
-  "Arrays.disk_size": 100,
+  "Arrays.control_sample_name": "NA12878",
+  "Arrays.control_sample_vcf_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz",
+  "Arrays.control_sample_vcf_index_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.vcf.gz.tbi",
+  "Arrays.control_sample_intervals_file": "gs://broad-gotc-test-storage/arrays/controldata/NA12878.interval_list",
 
   "Arrays.ref_fasta": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "Arrays.ref_fasta_index": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
@@ -28,6 +40,8 @@
   "Arrays.dbSNP_vcf_index": "gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi",
   "Arrays.haplotype_database_file": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt",
   "Arrays.variant_rsids_file": "gs://broad-references-private/hg19/v0/Homo_sapiens_assembly19.haplotype_database.snps.list",
+
+  "Arrays.disk_size": 100,
   "Arrays.preemptible_tries": 3,
   "Arrays.vault_token_path": "{VAULT_TOKEN_PATH}",
   "Arrays.environment": "{ENV}"

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
@@ -1,3 +1,8 @@
+# 1.13.1
+2021-07-23
+
+* Task wdls used by Validate chip were updated with changes that don't affect ValidateChip wdl
+
 # 1.13.0
 2021-05-19
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow ValidateChip {
 
-  String pipeline_version = "1.13.0"
+  String pipeline_version = "1.13.1"
 
   input {
     String sample_alias

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -1,5 +1,5 @@
 {
-  "IlluminaGenotypingArray.sample_alias": "BMS_000637780",
+  "IlluminaGenotypingArray.sample_alias": "BMS 000637780",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
   "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -6,16 +6,17 @@
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "201145020059_R07C01",
 
-  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201145020059_R07C01/201145020059_R07C01_Grn.idat",
-  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201145020059_R07C01/201145020059_R07C01_Red.idat",
+  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Grn.idat",
+  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Red.idat",
 
-  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
-  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
+  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz",
+  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201145020059_R07C01/201145020059_R07C01.2004_713547.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
-  "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
+  "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -6,16 +6,17 @@
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "201148280144_R12C01",
 
-  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201148280144_R12C01/201148280144_R12C01_Grn.idat",
-  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201148280144_R12C01/201148280144_R12C01_Red.idat",
+  "IlluminaGenotypingArray.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Grn.idat",
+  "IlluminaGenotypingArray.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Red.idat",
 
-  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
-  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
+  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz",
+  "IlluminaGenotypingArray.fingerprint_genotypes_vcf_index_file": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/inputs/201148280144_R12C01/201148280144_R12C01.2005492094.reference.fingerprint.vcf.gz.tbi",
 
-  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.bpm",
-  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1.1.3.extended.csv",
-  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSA-24v1-0_A1/GSA-24v1-0_A1_ClusterFile.egt",
-  "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSA-24v1-0_A1/GSA-24v1-0_A1_genderest.egt",
+  "IlluminaGenotypingArray.bead_pool_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.bpm",
+  "IlluminaGenotypingArray.extended_chip_manifest_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.1.3.extended.csv",
+  "IlluminaGenotypingArray.cluster_file": "gs://gcp-public-data--broad-references/arrays/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt",
+  "IlluminaGenotypingArray.gender_cluster_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1_genderest.egt",
+  "IlluminaGenotypingArray.zcall_thresholds_file": "gs://broad-gotc-test-storage/arrays/metadata/GSAMD-24v1-0_20011747_A1/GSAMD-24v1-0_20011747_A1.egt.thresholds.txt",
 
   "IlluminaGenotypingArray.disk_size": 100,
 

--- a/tasks/broad/InternalArraysTasks.wdl
+++ b/tasks/broad/InternalArraysTasks.wdl
@@ -230,6 +230,64 @@ task UploadArraysMetrics {
     }
 }
 
+task CreateChipWellBarcodeParamsFile {
+  input {
+    String chip_type_name
+    String chip_well_barcode
+    String collaborator_participant_id
+    String lab_batch
+    String participant_id
+    String product_family
+    String product_name
+    String product_order_id
+    String product_part_number
+    String product_type
+    String regulatory_designation
+    String research_project_id
+    String sample_alias
+    String gender
+    String sample_id
+    String sample_lsid
+    Int preemptible_tries
+  }
+
+  String params_filename = "params.txt"
+
+  command <<<
+    set -eo pipefail
+
+    echo "CHIP_TYPE_NAME=~{chip_type_name}" > ~{params_filename}
+    echo "CHIP_WELL_BARCODE=~{chip_well_barcode}" >> ~{params_filename}
+    echo "INDIVIDUAL_ALIAS=~{collaborator_participant_id}" >> ~{params_filename}
+    echo "LAB_BATCH=~{lab_batch}" >> ~{params_filename}
+    echo "PARTICIPANT_ID=~{participant_id}" >> ~{params_filename}
+    echo "PRODUCT_FAMILY=~{product_family}" >> ~{params_filename}
+    echo "PRODUCT_NAME=~{product_name}" >> ~{params_filename}
+    echo "PRODUCT_ORDER_ID=~{product_order_id}" >> ~{params_filename}
+    echo "PRODUCT_PART_NUMBER=~{product_part_number}" >> ~{params_filename}
+    echo "PRODUCT_TYPE=~{product_type}" >> ~{params_filename}
+    echo "REGULATORY_DESIGNATION=~{regulatory_designation}" >> ~{params_filename}
+    echo "RESEARCH_PROJECT_ID=~{research_project_id}" >> ~{params_filename}
+    echo "SAMPLE_ALIAS=~{sample_alias}" >> ~{params_filename}
+    echo "SAMPLE_GENDER=~{gender}" >> ~{params_filename}
+    echo "SAMPLE_ID=~{sample_id}" >> ~{params_filename}
+    echo "SAMPLE_LSID=~{sample_lsid}" >> ~{params_filename}
+
+  >>>
+
+  runtime {
+    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    disks: "local-disk 10 HDD"
+    memory: "2 GiB"
+    preemptible: preemptible_tries
+  }
+  output {
+    File params_file = params_filename
+  }
+}
+
+
+
 task UpdateChipWellBarcodeIndex {
   input {
     File params_file

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/inputs/IlluminaGenotypingArrayValidationInputs.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/inputs/IlluminaGenotypingArrayValidationInputs.scala
@@ -8,15 +8,17 @@ import io.circe.generic.extras.semiauto.{
   deriveConfiguredEncoder
 }
 
-object SingleSampleArraysValidationInputs
-    extends EncodableInputs[SingleSampleArraysValidationInputs] {
-  override def workflowNames: Seq[String] = Seq("VerifyArrays")
-  override implicit val decoder: Decoder[SingleSampleArraysValidationInputs] =
+object IlluminaGenotypingArrayValidationInputs
+    extends EncodableInputs[IlluminaGenotypingArrayValidationInputs] {
+  override def workflowNames: Seq[String] = Seq("VerifyIlluminaGenotypingArray")
+  override implicit val decoder
+    : Decoder[IlluminaGenotypingArrayValidationInputs] =
     deriveConfiguredDecoder
-  override implicit val encoder: Encoder[SingleSampleArraysValidationInputs] =
+  override implicit val encoder
+    : Encoder[IlluminaGenotypingArrayValidationInputs] =
     deriveConfiguredEncoder
 }
-case class SingleSampleArraysValidationInputs(
+case class IlluminaGenotypingArrayValidationInputs(
     truth_metrics: Seq[URI],
     test_metrics: Seq[URI],
     test_gtc: URI,
@@ -29,7 +31,5 @@ case class SingleSampleArraysValidationInputs(
     truth_green_idat_md5: URI,
     test_green_idat_md5: URI,
     truth_red_idat_md5: URI,
-    test_red_idat_md5: URI,
-    truth_params_file: URI,
-    test_params_file: URI
+    test_red_idat_md5: URI
 )

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ArraysTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/ArraysTester.scala
@@ -105,7 +105,9 @@ class ArraysTester(testerConfig: ArraysConfig)(
       truth_red_idat_md5 =
         truthCloudPath.resolve(s"${outputBaseName}_Red.idat.md5sum"),
       test_red_idat_md5 =
-        resultsCloudPath.resolve(s"${outputBaseName}_Red.idat.md5sum")
+        resultsCloudPath.resolve(s"${outputBaseName}_Red.idat.md5sum"),
+      truth_params_file = truthCloudPath.resolve("params.txt"),
+      test_params_file = resultsCloudPath.resolve("params.txt")
     )
     SingleSampleArraysValidationInputs
       .marshall(validationInputs)

--- a/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/IlluminaGenotypingArrayTester.scala
+++ b/tests/broad/scala_test/src/main/scala/org/broadinstitute/dsp/pipelines/tester/IlluminaGenotypingArrayTester.scala
@@ -8,8 +8,8 @@ import better.files.File
 import org.broadinstitute.dsp.pipelines.batch.WorkflowTest
 import org.broadinstitute.dsp.pipelines.config._
 import org.broadinstitute.dsp.pipelines.inputs.{
-  SingleSampleArraysInputs,
-  SingleSampleArraysValidationInputs
+  IlluminaGenotypingArrayValidationInputs,
+  SingleSampleArraysInputs
 }
 
 class IlluminaGenotypingArrayTester(testerConfig: IlluminaGenotypingArrayConfig)(
@@ -22,7 +22,8 @@ class IlluminaGenotypingArrayTester(testerConfig: IlluminaGenotypingArrayConfig)
   val workflowDir
     : File = CromwellWorkflowTester.PipelineRoot / "broad" / "genotyping" / "illumina"
 
-  override protected val validationWorkflowName: String = "VerifyArrays"
+  override protected val validationWorkflowName: String =
+    "VerifyIlluminaGenotypingArray"
 
   override protected lazy val googleProject: String = {
     if (env.picardEnv.equals("dev")) {
@@ -64,7 +65,7 @@ class IlluminaGenotypingArrayTester(testerConfig: IlluminaGenotypingArrayConfig)
       .listGoogleObjects(truthCloudPath)
       .filter(_.getPath.endsWith("metrics"))
       .map(uriToFilename)
-    val validationInputs = SingleSampleArraysValidationInputs(
+    val validationInputs = IlluminaGenotypingArrayValidationInputs(
       test_metrics = metricsFileNames.map(resultsCloudPath.resolve),
       truth_metrics = metricsFileNames.map(truthCloudPath.resolve),
       bead_pool_manifest_file =
@@ -86,7 +87,7 @@ class IlluminaGenotypingArrayTester(testerConfig: IlluminaGenotypingArrayConfig)
       test_red_idat_md5 =
         resultsCloudPath.resolve(s"${outputBaseName}_Red.idat.md5sum")
     )
-    SingleSampleArraysValidationInputs
+    IlluminaGenotypingArrayValidationInputs
       .marshall(validationInputs)
       .printWith(implicitly)
   }

--- a/verification/VerifyArrays.wdl
+++ b/verification/VerifyArrays.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../verification/VerifyMetrics.wdl" as MetricsVerification
-import "../verification/VerifyTasks.wdl" as Tasks
+import "../verification/VerifyIlluminaGenotypingArray.wdl" as VerifyIlluminaGenotypingArray
+import "../verification/VerifyTasks.wdl" as VerifyTasks
 
 ## Copyright Broad Institute, 2018
 ##
@@ -39,140 +39,38 @@ workflow VerifyArrays {
 
     File truth_green_idat_md5
     File test_green_idat_md5
+
+    File truth_params_file
+    File test_params_file
   }
 
-  call MetricsVerification.CompareTwoNumbers {
+  call VerifyIlluminaGenotypingArray.VerifyIlluminaGenotypingArray {
     input:
-      num1 = length(test_metrics),
-      num2 = length(truth_metrics),
-      error_msg = "Different number of metric files"
+      truth_metrics = truth_metrics,
+      test_metrics = test_metrics,
+      test_gtc = test_gtc,
+      truth_gtc = truth_gtc,
+      bead_pool_manifest_file = bead_pool_manifest_file,
+      truth_vcf = truth_vcf,
+      test_vcf = test_vcf,
+      truth_fp_vcf = truth_fp_vcf,
+      test_fp_vcf = test_fp_vcf,
+      truth_red_idat_md5 = truth_red_idat_md5,
+      test_red_idat_md5 = test_red_idat_md5,
+      truth_green_idat_md5 = truth_green_idat_md5,
+      test_green_idat_md5 = test_green_idat_md5
   }
 
-  String bafm_ext = ".bafregress_metrics"
-  String avcdm_ext = "arrays_variant_calling_detail_metrics"
-
-  scatter (idx in range(length(truth_metrics))) {
-    String metrics_basename = basename(truth_metrics[idx])
-    Boolean is_bafm_file = basename(metrics_basename, bafm_ext) != metrics_basename
-    if (!is_bafm_file) {
-      Boolean is_avcdm_file = basename(metrics_basename, avcdm_ext) != metrics_basename
-      Array[String] metrics_to_ignore = if (is_avcdm_file) then ["AUTOCALL_DATE", "ANALYSIS_VERSION", "PIPELINE_VERSION"] else []
-      call MetricsVerification.CompareMetricFiles {
-        input:
-          dependency_input = CompareTwoNumbers.output_file,
-          file1 = test_metrics[idx],
-          file2 = truth_metrics[idx],
-          output_file = "metric_~{idx}.txt",
-          metrics_to_ignore = metrics_to_ignore
-      }
-    }
-    if (is_bafm_file) {
-      # BAF metrics files are defined in picard-private.  The tool used by CompareMetricFiles (above) cannot
-      # instantiate them and so fails.  This is a hopefully short-term fix for that problem - just compare the metrics files as text files.
-      call CompareMetricFilesAsText {
-        input:
-          file1 = test_metrics[idx],
-          file2 = truth_metrics[idx]
-      }
-    }
-  }
-
-  call Tasks.CompareVcfs as CompareOutputVcfs {
+  call VerifyTasks.CompareTextFiles as CompareParamsFiles {
     input:
-      file1 = truth_vcf,
-      file2 = test_vcf
+      test_text_files = [test_params_file],
+      truth_text_files = [truth_params_file]
   }
 
-  call Tasks.CompareVcfs as CompareOutputFingerprintVcfs {
-    input:
-       file1 = truth_fp_vcf,
-       file2 = test_fp_vcf
-  }
-
-  call Tasks.CompareGtcs {
-    input:
-      file1 = test_gtc,
-      file2 = truth_gtc,
-      bead_pool_manifest_file = bead_pool_manifest_file
-  }
-
-  call CompareFiles as CompareGreenIdatMdf5Sum {
-    input:
-      file1 = test_green_idat_md5,
-      file2 = truth_green_idat_md5
-  }
-
-  call CompareFiles as CompareRedIdatMdf5Sum {
-    input:
-      file1 = test_red_idat_md5,
-      file2 = truth_red_idat_md5
+  output {
   }
   meta {
     allowNestedInputs: true
   }
 }
 
-task CompareGtcs {
-  input {
-    File file1
-    File file2
-    File illumina_normalization_manifest
-  }
-
-  command {
-    java -Xmx3g -Dpicard.useLegacyParser=false  -jar /usr/picard/picard.jar \
-      CompareGtcFiles \
-      --INPUT ~{file1} \
-      --INPUT ~{file2} \
-      --ILLUMINA_NORMALIZATION_MANIFEST ~{illumina_normalization_manifest}
-  }
-
-  runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
-    disks: "local-disk 10 HDD"
-    memory: "3.5 GiB"
-    preemptible: 3
-  }
-}
-
-task CompareFiles {
-
-  input {
-    File file1
-    File file2
-  }
-
-  command {
-    if ! diff ~{file1} ~{file2}; then
-       echo "Error: Files ~{file1} and ~{file2} differ" >&2
-       exit 1
-    fi
-  }
-
-  runtime {
-    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
-    disks: "local-disk 10 HDD"
-    memory: "2 GiB"
-    preemptible: 3
-  }
-}
-
-task CompareMetricFilesAsText {
-
-  input {
-    File file1
-    File file2
-  }
-
-  command {
-    # Compares two text files, ignoring lines that begin with a '#'
-    diff <(grep -v '# ' ~{file1}) <(grep -v '# ' ~{file2})
-  }
-
-  runtime {
-    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
-    disks: "local-disk 10 HDD"
-    memory: "2 GiB"
-    preemptible: 3
-  }
-}

--- a/verification/VerifyIlluminaGenotypingArray.wdl
+++ b/verification/VerifyIlluminaGenotypingArray.wdl
@@ -1,0 +1,181 @@
+version 1.0
+
+import "../verification/VerifyMetrics.wdl" as MetricsVerification
+import "../verification/VerifyTasks.wdl" as Tasks
+
+## Copyright Broad Institute, 2018
+##
+## This WDL script is designed to verify (compare) the outputs of an ArrayWf wdl.
+##
+##
+## Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
+## For program versions, see docker containers.
+##
+## LICENSING :
+## This script is released under the WDL source code license (BSD-3) (see LICENSE in
+## https://github.com/broadinstitute/wdl). Note however that the programs it calls may
+## be subject to different licenses. Users are responsible for checking that they are
+## authorized to run all programs before running this script. Please see the docker
+## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
+## licensing information pertaining to the included programs.
+
+workflow VerifyIlluminaGenotypingArray {
+  input {
+    Array[File] truth_metrics
+    Array[File] test_metrics
+
+    File test_gtc
+    File truth_gtc
+    File bead_pool_manifest_file
+
+    File truth_vcf
+    File test_vcf
+
+    File truth_fp_vcf
+    File test_fp_vcf
+
+    File truth_red_idat_md5
+    File test_red_idat_md5
+
+    File truth_green_idat_md5
+    File test_green_idat_md5
+  }
+
+  call MetricsVerification.CompareTwoNumbers {
+    input:
+      num1 = length(test_metrics),
+      num2 = length(truth_metrics),
+      error_msg = "Different number of metric files"
+  }
+
+  String bafm_ext = ".bafregress_metrics"
+  String avcdm_ext = "arrays_variant_calling_detail_metrics"
+
+  scatter (idx in range(length(truth_metrics))) {
+    String metrics_basename = basename(truth_metrics[idx])
+    Boolean is_bafm_file = basename(metrics_basename, bafm_ext) != metrics_basename
+    if (!is_bafm_file) {
+      Boolean is_avcdm_file = basename(metrics_basename, avcdm_ext) != metrics_basename
+      Array[String] metrics_to_ignore = if (is_avcdm_file) then ["AUTOCALL_DATE", "ANALYSIS_VERSION", "PIPELINE_VERSION"] else []
+      call MetricsVerification.CompareMetricFiles {
+        input:
+          dependency_input = CompareTwoNumbers.output_file,
+          file1 = test_metrics[idx],
+          file2 = truth_metrics[idx],
+          output_file = "metric_~{idx}.txt",
+          metrics_to_ignore = metrics_to_ignore
+      }
+    }
+    if (is_bafm_file) {
+      # TODO - is this still necessary??
+      # BAF metrics files are defined in picard-private.  The tool used by CompareMetricFiles (above) cannot
+      # instantiate them and so fails.  This is a hopefully short-term fix for that problem - just compare the metrics files as text files.
+      call CompareMetricFilesAsText {
+        input:
+          file1 = test_metrics[idx],
+          file2 = truth_metrics[idx]
+      }
+    }
+  }
+
+  call Tasks.CompareVcfs as CompareOutputVcfs {
+    input:
+      file1 = truth_vcf,
+      file2 = test_vcf
+  }
+
+  call Tasks.CompareVcfs as CompareOutputFingerprintVcfs {
+    input:
+       file1 = truth_fp_vcf,
+       file2 = test_fp_vcf
+  }
+
+  call Tasks.CompareGtcs {
+    input:
+      file1 = test_gtc,
+      file2 = truth_gtc,
+      bead_pool_manifest_file = bead_pool_manifest_file
+  }
+
+  call CompareFiles as CompareGreenIdatMdf5Sum {
+    input:
+      file1 = test_green_idat_md5,
+      file2 = truth_green_idat_md5
+  }
+
+  call CompareFiles as CompareRedIdatMdf5Sum {
+    input:
+      file1 = test_red_idat_md5,
+      file2 = truth_red_idat_md5
+  }
+  output {
+  }
+  meta {
+    allowNestedInputs: true
+  }
+}
+
+task CompareGtcs {
+  input {
+    File file1
+    File file2
+    File illumina_normalization_manifest
+  }
+
+  command {
+    java -Xmx3g -Dpicard.useLegacyParser=false  -jar /usr/picard/picard.jar \
+      CompareGtcFiles \
+      --INPUT ~{file1} \
+      --INPUT ~{file2} \
+      --ILLUMINA_NORMALIZATION_MANIFEST ~{illumina_normalization_manifest}
+  }
+
+  runtime {
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.0"
+    disks: "local-disk 10 HDD"
+    memory: "3.5 GiB"
+    preemptible: 3
+  }
+}
+
+task CompareFiles {
+
+  input {
+    File file1
+    File file2
+  }
+
+  command {
+    if ! diff ~{file1} ~{file2}; then
+       echo "Error: Files ~{file1} and ~{file2} differ" >&2
+       exit 1
+    fi
+  }
+
+  runtime {
+    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    disks: "local-disk 10 HDD"
+    memory: "2 GiB"
+    preemptible: 3
+  }
+}
+
+task CompareMetricFilesAsText {
+
+  input {
+    File file1
+    File file2
+  }
+
+  command {
+    # Compares two text files, ignoring lines that begin with a '#'
+    diff <(grep -v '# ' ~{file1}) <(grep -v '# ' ~{file2})
+  }
+
+  runtime {
+    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    disks: "local-disk 10 HDD"
+    memory: "2 GiB"
+    preemptible: 3
+  }
+}

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -72,11 +72,15 @@ task CompareTextFiles {
     while read -r a && read -r b <&3;
     do
       echo "Comparing File $a with $b"
-      diff $a $b
-      if [ $? -ne 0 ]; then
+      diff $a $b > diffs.txt
+      if [ $? -ne 0 ];
+      then
         exit_code=1
         echo "Error: Files $a and $b differ" >&2
+        cat diffs.txt >&2
       fi
+      # catting the diffs.txt on STDOUT as that's what's expected.
+      cat diffs.txt
     done < ~{write_lines(test_text_files)} 3<~{write_lines(truth_text_files)}
 
     exit $exit_code
@@ -89,6 +93,7 @@ task CompareTextFiles {
     preemptible: 3
   }
 }
+
 
 task CompareCrams {
 


### PR DESCRIPTION
Have pipeline take the values supplied in 'params.txt' input file as optional top-level inputs. First step towards removal
Provide params.txt file as output of pipeline.
Set default call rate threshold of pipeline to 0.98
Update test files to use top level inputs.
Update Scala Test to have a separate ArraysTester and IlluminaGenotypingArrayTester - use the former to test everything in the latter and the params.txt file generated by the Arrays Workflow.
Update version and changelog for ValidateChip.wdl