### PR TITLE
GL-1627.  Change the product_type input to be non-optional with a default

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,8 @@
+# 2.3.4
+2021-07-28
+
+* Set a default value for product_type so that it can be safely omitted from input file
+
 # 2.3.3
 2021-07-22
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow Arrays {
 
-  String pipeline_version = "2.3.3"
+  String pipeline_version = "2.3.4"
 
   input {
 
@@ -57,7 +57,7 @@ workflow Arrays {
     String? product_name
     String? product_order_id
     String? product_part_number
-    String? product_type  # careful!
+    String product_type = ""
     String? regulatory_designation
     String? research_project_id
 
@@ -142,7 +142,7 @@ workflow Arrays {
         product_name = select_first([product_name]),
         product_order_id = select_first([product_order_id]),
         product_part_number = select_first([product_part_number]),
-        product_type = select_first([product_type]),
+        product_type = product_type,
         regulatory_designation = select_first([regulatory_designation]),
         research_project_id = select_first([research_project_id]),
         sample_alias = sample_alias,

--- a/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Exome V1_A",
   "Arrays.product_order_id": "PDO-15923",
   "Arrays.product_part_number": "P-WG-0094",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-45",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych (High Volume >10,000 sample) Array Processing",
   "Arrays.product_order_id": "PDO-6743",
   "Arrays.product_part_number": "P-WG-0036",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1014",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych (High Volume >10,000 sample) Array Processing",
   "Arrays.product_order_id": "PDO-6743",
   "Arrays.product_part_number": "P-WG-0036",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1014",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium ImmunoArray",
   "Arrays.product_order_id": "PDO-7336",
   "Arrays.product_part_number": "P-WG-0057",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
   "Arrays.product_order_id": "PDO-11233",
   "Arrays.product_part_number": "P-EX-0021",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
   "Arrays.product_order_id": "PDO-11233",
   "Arrays.product_part_number": "P-EX-0021",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
   "Arrays.product_order_id": "PDO-11233",
   "Arrays.product_part_number": "P-EX-0021",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
   "Arrays.product_order_id": "PDO-11233",
   "Arrays.product_part_number": "P-EX-0021",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Standard Germline Exome v5 Plus GWAS Supplement Array",
   "Arrays.product_order_id": "PDO-11233",
   "Arrays.product_part_number": "P-EX-0021",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-30",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych Array Processing v2",
   "Arrays.product_order_id": "PDO-9246",
   "Arrays.product_part_number": "P-WG-0055",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych Array Processing v2",
   "Arrays.product_order_id": "PDO-9246",
   "Arrays.product_part_number": "P-WG-0055",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych Array Processing v2",
   "Arrays.product_order_id": "PDO-9246",
   "Arrays.product_part_number": "P-WG-0055",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Psych Array Processing v2",
   "Arrays.product_order_id": "PDO-9246",
   "Arrays.product_part_number": "P-WG-0055",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
   "Arrays.product_order_id": "PDO-11363",
   "Arrays.product_part_number": "P-WG-0059",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1244",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
   "Arrays.product_order_id": "PDO-11363",
   "Arrays.product_part_number": "P-WG-0059",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1244",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium MEGA (High Volume >40,000 sample) Array Processing",
   "Arrays.product_order_id": "PDO-11363",
   "Arrays.product_part_number": "P-WG-0059",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1244",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11809",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-755",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11580",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11580",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11809",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-755",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11809",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-755",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11809",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-755",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array Processing",
   "Arrays.product_order_id": "PDO-11580",
   "Arrays.product_part_number": "P-WG-0066",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array Processing",
   "Arrays.product_order_id": "PDO-11580",
   "Arrays.product_part_number": "P-WG-0066",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array Processing",
   "Arrays.product_order_id": "PDO-10839",
   "Arrays.product_part_number": "P-WG-0066",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-518",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array Processing",
   "Arrays.product_order_id": "PDO-10839",
   "Arrays.product_part_number": "P-WG-0066",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-518",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array Processing",
   "Arrays.product_order_id": "PDO-10839",
   "Arrays.product_part_number": "P-WG-0066",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-518",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-11580",
   "Arrays.product_part_number": "P-WG-0073",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-48",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v2",
   "Arrays.product_order_id": "PDO-12280",
   "Arrays.product_part_number": "P-WG-0070",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1169",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express + Exome Array Processing v3",
   "Arrays.product_order_id": "PDO-16982",
   "Arrays.product_part_number": "P-WG-0092",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-1729",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "CLIA Infinium AoU Array",
   "Arrays.product_order_id": "PDO-16681",
   "Arrays.product_part_number": "P-CLA-0010",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "CLINICAL_DIAGNOSTICS",
   "Arrays.research_project_id": "RP-1710",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Global Screening v3 Array + Multi Disease Processing",
   "Arrays.product_order_id": "PDO-22611",
   "Arrays.product_part_number": "P-WG-0121",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-2365",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium Omni Express Array Processing v1_H",
   "Arrays.product_order_id": "PDO-15791",
   "Arrays.product_part_number": "P-WG-0093",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-45",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8942377043_R01C01_09C89876.json
@@ -14,7 +14,6 @@
   "Arrays.product_name": "Infinium 2.5M-8",
   "Arrays.product_order_id": "PDO-70",
   "Arrays.product_part_number": "P-WG-0007",
-  "Arrays.product_type": "",
   "Arrays.regulatory_designation": "RESEARCH_ONLY",
   "Arrays.research_project_id": "RP-131",
 


### PR DESCRIPTION
GL-1627.  Change the product_type input to be non-optional with a default
Did this because the tool that creates the message in Zamboni will omit product_type entirely where it is unset.
Tests cover both missing values, set to "" and set to a non-empty string.