### PR TITLE
[GL-1592] small docker README fix 

### DIFF
--- a/dockers/broad/illumina_iaap_autocall/README.md
+++ b/dockers/broad/illumina_iaap_autocall/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/illumina-iaap-autocall:1.0.2-1.1.0-1625852425`
+#### `docker pull us.gcr.io/broad-gotc-prod/illumina-iaap-autocall:1.0.2-1.1.0-1626361770`
 
 - __What is this image:__ This image is a lightweight alpine-based image for running the Illumina Iaap CLI.
 - __What is the Illumina IAAP CLI:__ Illumina Iaap CLI is a tool for reporting genotype calls and sample-level quality metrics in various formats (Illumina GTC and PED files). See [here](https://emea.support.illumina.com/downloads/iaap-genotyping-cli.html) more information.


### PR DESCRIPTION
Updating the image URL for `illumina-iaap-autocall` to be the current version.