### PR TITLE
GL-1594. Change default threshold to pass Hapmap control genotype concordance

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,11 +1,8 @@
-# 2.4.2
-2021-09-07
-
-* Modified pipeline to automatically generate the analysis_version_number if it is not supplied as an input.
-
 # 2.4.1
-2021-08-30
+2021-09-09
 
+* Changed default threshold for passing control (HapMap) genotype concordance from 0.98 to 0.95
+* Modified pipeline to automatically generate the analysis_version_number if it is not supplied as an input.
 * Modified pipeline to make several inputs optional:
     * sample_id
     * participant_id

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -22,7 +22,7 @@ import "../../../../tasks/broad/InternalTasks.wdl" as InternalTasks
 
 workflow Arrays {
 
-  String pipeline_version = "2.4.2"
+  String pipeline_version = "2.4.1"
 
   input {
 
@@ -41,7 +41,7 @@ workflow Arrays {
     String? participant_id
 
     Float call_rate_threshold = 0.98
-    Float genotype_concordance_threshold = 0.98
+    Float genotype_concordance_threshold = 0.95
 
     File red_idat_cloud_path
     File green_idat_cloud_path

--- a/pipelines/broad/arrays/single_sample/ExampleWorkflow.inputs.json
+++ b/pipelines/broad/arrays/single_sample/ExampleWorkflow.inputs.json
@@ -3,7 +3,6 @@
   "Arrays.sample_lsid": "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
   "Arrays.analysis_version_number": 1,
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
   "Arrays.reported_gender": "Female",
   "Arrays.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Plumbing/SimpleInput.json
@@ -19,7 +19,6 @@
   "Arrays.research_project_id": "RP-45",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1014",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R02C01/101342370027_R02C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1014",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370027_R12C02/101342370027_R12C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/101342370134_R12C02_NA12891.json
@@ -11,7 +11,6 @@
   "Arrays.research_project_id": "RP-1014",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/101342370134_R12C02/101342370134_R12C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumImmunoArray-24v2-0_A/idats/200246060179_R09C02/200246060179_R09C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PullFPFromMercury.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PullFPFromMercury.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PullNoFPFromMercury.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PullNoFPFromMercury.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PushFPToMercury.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557060038_R10C02_PRISM_7032_PushFPToMercury.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557060038_R10C02/200557060038_R10C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070005_R06C01/200557070005_R06C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070028_R10C01/200557070028_R10C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070028_R10C01/200557070028_R10C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R05C02/200557070035_R05C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-30",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Broad_GWAS_supplemental_15061359_A1/idats/200557070035_R06C01/200557070035_R06C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -17,7 +17,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R01C01/200598830050_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R04C01/200598830050_R04C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R06C02/200598830050_R06C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R06C02/200598830050_R06C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R07C01/200598830050_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R07C01/200598830050_R07C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1244",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201004840016_R01C01/201004840016_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1244",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R01C01/201008710016_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1244",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/Multi-EthnicGlobal_A1/idats/201008710016_R05C01/201008710016_R05C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-755",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201096140037_R07C01/201096140037_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201096140037_R07C01/201096140037_R07C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R05C01/201138240147_R05C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201138240147_R08C01/201138240147_R08C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-755",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020059_R07C01/201145020059_R07C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-755",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020068_R12C01/201145020068_R12C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201145020068_R12C01/201145020068_R12C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-755",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201148280144_R12C01/201148280144_R12C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R06C01/201159110147_R06C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201159110147_R09C01/201159110147_R09C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-518",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R01C01/201179310001_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-518",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R09C01/201179310001_R09C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-518",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSA-24v1-0_A1/idats/201179310001_R12C02/201179310001_R12C02_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-48",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v1-0_20011747_A1/idats/201179320110_R01C01/201179320110_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201490040272_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201490040272_R01C01/201490040272_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070002_R01C01/201651070002_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651070043_R06C01/201651070043_R06C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY_PullFPFromMercury.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY_PullFPFromMercury.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY_PullFPFromMercuryClinical.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY_PullFPFromMercuryClinical.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R05C01/201651080129_R05C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R06C01/201651080129_R06C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R06C01/201651080129_R06C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1169",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-4_A1/idats/201651080129_R07C01/201651080129_R07C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1729",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/InfiniumOmniExpressExome-8v1-6_A1/idats/202871110118_R01C01/202871110118_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-1710",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/MEG_AllofUs_20002558X351448_A2/idats/203078500006_R01C01/203078500006_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878.json
@@ -19,7 +19,6 @@
   "Arrays.research_project_id": "RP-1710",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
@@ -19,7 +19,6 @@
   "Arrays.research_project_id": "RP-1710",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GDA-8v1-0_A5/idats/204126290052_R01C01/204126290052_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/205346990020_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-2365",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/GSAMD-24v3-0-EA_20034606_A1/idats/205346990020_R01C01/205346990020_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/7991775143_R01C01_NA12878.json
@@ -3,7 +3,6 @@
   "Arrays.sample_lsid": "broadinstitute.org:bsp.prod.sample:3S2IV",
   "Arrays.analysis_version_number": 1,
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
   "Arrays.reported_gender": "Female",
   "Arrays.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -18,7 +18,6 @@
   "Arrays.research_project_id": "RP-45",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmniExpress-12v1_H/idats/8925008101_R01C01/8925008101_R01C01_Red.idat",

--- a/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
+++ b/pipelines/broad/arrays/single_sample/test_inputs/Scientific/9216473070_R01C01_NA12878.json
@@ -19,7 +19,6 @@
   "Arrays.research_project_id": "RP-131",
 
   "Arrays.call_rate_threshold": 0.98,
-  "Arrays.genotype_concordance_threshold": 0.98,
 
   "Arrays.green_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Grn.idat",
   "Arrays.red_idat_cloud_path": "gs://broad-gotc-test-storage/arrays/HumanOmni2.5-8v1_A/idats/9216473070_R01C01/9216473070_R01C01_Red.idat",

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
@@ -1,10 +1,5 @@
-# 1.13.4
-2021-09-07
-
-* Task wdls used by Validate chip were updated with changes that don't affect ValidateChip wdl
-
 # 1.13.3
-2021-08-31
+2021-09-09
 
 * Set the volatile=true flag for several internal tasks so they will not use call-caching
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow ValidateChip {
 
-  String pipeline_version = "1.13.4"
+  String pipeline_version = "1.13.3"
 
   input {
     String sample_alias

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,3 +1,8 @@
+# 1.11.5
+2021-09-08
+
+* Changed default threshold for passing control (HapMap) genotype concordance from 0.98 to 0.95
+
 # 1.11.4
 2021-08-10
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
@@ -20,7 +20,7 @@ import "../../../../tasks/broad/IlluminaGenotypingArrayTasks.wdl" as GenotypingT
 
 workflow IlluminaGenotypingArray {
 
-  String pipeline_version = "1.11.4"
+  String pipeline_version = "1.11.5"
 
   input {
 
@@ -76,7 +76,7 @@ workflow IlluminaGenotypingArray {
     Int disk_size
     Int preemptible_tries
 
-    Float genotype_concordance_threshold = 0.98
+    Float genotype_concordance_threshold = 0.95
   }
 
   call GenotypingTasks.AutoCall {

--- a/pipelines/broad/genotyping/illumina/example.json
+++ b/pipelines/broad/genotyping/illumina/example.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Plumbing/SimpleInput.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Plumbing/SimpleInput.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R02C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R02C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "101342370027_R02C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R12C02_NA12892.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370027_R12C02_NA12892.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12892",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "101342370027_R12C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370134_R12C02_NA12891.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/101342370134_R12C02_NA12891.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12891",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "101342370134_R12C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200246060179_R09C02_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200246060179_R09C02_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "200246060179_R09C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557060038_R10C02_PRISM_7032.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "PRISM_7032",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "200557060038_R10C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070005_R06C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070005_R06C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "200557070005_R06C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070028_R10C01_PRI_SM_7241.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "PRI SM_7241",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "200557070028_R10C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R05C02_PRI_SM_8643.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "PRI SM_8643",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "200557070035_R05C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200557070035_R06C01_PRISM_7289.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "PRISM_7289",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "200557070035_R06C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R01C01_90C04566.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R01C01_90C04566.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "90C04566",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "200598830050_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R04C01_07C6_2854.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "07C6 2854",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "200598830050_R04C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R06C02_01C05949.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R06C02_01C05949.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "01C05949",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "200598830050_R06C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/200598830050_R07C01_03C_17319.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "03C 17319",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "200598830050_R07C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201004840016_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201004840016_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201004840016_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R01C01_AA484383.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R01C01_AA484383.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "AA484383",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "201008710016_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201008710016_R05C01_BMS_000637780.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "BMS 000637780",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "201008710016_R05C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201096140037_R07C01_20055_118477.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "20055 11847",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "201096140037_R07C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R05C01_05C49266.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R05C01_05C49266.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "05C49266",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "201138240147_R05C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201138240147_R08C01_MH_0188385.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "MH 0188385",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "201138240147_R08C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020059_R07C01_2004_713547.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "2004 713547",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "201145020059_R07C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020068_R12C01_2004826455.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201145020068_R12C01_2004826455.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "2004826455",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201145020068_R12C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201148280144_R12C01_2005492094.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "2005492094",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "201148280144_R12C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R06C01_MH0158716.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "MH0158716",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "201159110147_R06C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201159110147_R09C01_MH_0178994.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "MH 0178994",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201159110147_R09C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201179310001_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R09C01_NA12892.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R09C01_NA12892.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12892",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201179310001_R09C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R12C02_NA12891.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179310001_R12C02_NA12891.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12891",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Male",
   "IlluminaGenotypingArray.chip_well_barcode": "201179310001_R12C02",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179320110_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201179320110_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201179320110_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/20149004072_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/20149004072_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201490040272_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070002_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070002_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201651070002_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651070043_R06C01_SLH_39O71.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "SLH 39O71",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "201651070043_R06C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R05C01_S8_N4B3GY.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "S8 N4B3GY",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "201651080129_R05C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R06C01_SPT3TC2T.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "SPT3TC2T",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "NotReported",
   "IlluminaGenotypingArray.chip_well_barcode": "201651080129_R06C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/201651080129_R07C01_S3QG3651.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "S3QG3651",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Unknown",
   "IlluminaGenotypingArray.chip_well_barcode": "201651080129_R07C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/202871110118_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/202871110118_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "202871110118_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/203078500006_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/203078500006_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "203078500006_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "204126290052_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/204126290052_R01C01_NA12878_2.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "204126290052_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/205346990020_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/205346990020_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "205346990020_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/7991775143_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/7991775143_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "7991775143_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8925008101_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/8925008101_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "8925008101_R01C01",
 

--- a/pipelines/broad/genotyping/illumina/test_inputs/Scientific/9216473070_R01C01_NA12878.json
+++ b/pipelines/broad/genotyping/illumina/test_inputs/Scientific/9216473070_R01C01_NA12878.json
@@ -2,7 +2,6 @@
   "IlluminaGenotypingArray.sample_alias": "NA12878",
   "IlluminaGenotypingArray.analysis_version_number": 1,
   "IlluminaGenotypingArray.call_rate_threshold": 0.98,
-  "IlluminaGenotypingArray.genotype_concordance_threshold": 0.98,
   "IlluminaGenotypingArray.reported_gender": "Female",
   "IlluminaGenotypingArray.chip_well_barcode": "9216473070_R01C01",
 


### PR DESCRIPTION
Change default threshold to pass Hapmap control genotype concordance from 0.98 to 0.95