### PR TITLE
added the --soloBarcodeReadLength 0 to the STARSolo task

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,7 +1,7 @@
 # 5.1.0
 2021-09-10 (Date of Last Commit)
 
-* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length
+* Added the option "--soloBarcodeReadLength 0" to STARsoloFastq task to ignore Barcode + UBI read of incorrect length
 
 # 5.0.0
 2021-08-30 (Date of Last Commit)

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.1.0
+2021-09-10 (Date of Last Commit)
+
+* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length
+
 # 5.0.0
 2021-08-30 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -51,7 +51,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "5.0.0"
+  String pipeline_version = "5.1.0"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays

--- a/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.3
 2021-09-10 (Date of Last Commit)
 
-* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length and has no impact on the current workflow
+* Added the option "--soloBarcodeReadLength 0" STARsoloFastq task to support alignment in Optimus. This change has no impact on SmartSeq2SingleNucleus
 
 # 1.0.2
 2021-09-02 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.3
+2021-09-10 (Date of Last Commit)
+
+* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length and has no impact on the current workflow
+
 # 1.0.2
 2021-09-02 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus/SmartSeq2SingleNucleus.wdl
@@ -36,7 +36,7 @@ workflow SmartSeq2SingleNucleus {
     File fastq2
   }
   # version of this pipeline
-  String pipeline_version = "1.0.2"
+  String pipeline_version = "1.0.3"
 
   parameter_meta {
     input_id: "Sample name or cell_names"

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.4
+2021-09-10 (Date of Last Commit)
+
+* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length and has no impact on the current workflow
+
 # 1.0.3
 2021-09-02 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.4
 2021-09-10 (Date of Last Commit)
 
-* Added the option "--soloBarcodeReadLength 0" to ignore Barcode + UBI read of incorrect length and has no impact on the current workflow
+Added the option "--soloBarcodeReadLength 0" STARsoloFastq task to support alignment in Optimus. This change has no impact on MultiSampleSmartSeq2SingleNucleus
 
 # 1.0.3
 2021-09-02 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -37,7 +37,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.0.3"
+  String pipeline_version = "1.0.4"
 
   if (false) {
      String? none = "None"

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -224,7 +224,8 @@ task STARsoloFastq {
       --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts \
       --soloUMIdedup 1MM_Directional_UMItools \
       --outSAMtype BAM SortedByCoordinate \
-      --outSAMattributes UB UR UY CR CB CY NH GX GN
+      --outSAMattributes UB UR UY CR CB CY NH GX GN \
+      --soloBarcodeReadLength 0
 
     if [ $COUNTING_MODE == "GeneFull" ]
     then


### PR DESCRIPTION
The goal is to ignore R1 that are too short or longer than expected  barcode + UMI length