### PR TITLE
 Find imputation reference panel files based on file path and contig

### DIFF
--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -4,4 +4,7 @@
 
 * Initial public release of the Imputation pipeline. Read more in the [Imputation pipeline overview](https://broadinstitute.github.io/warp/docs/Pipelines/Imputation_Pipeline/README).
 
-  * The Imputation pipeline imputes missing genotypes from either a multi-sample VCF or an array of single sample VCFs using a large genomic reference panel. It is based on the Michigan Imputation Server pipeline. Overall, the pipeline filters, phases, and performs imputation on a multi-sample VCF. It outputs the imputed VCF along with key imputation metrics.
+  * The Imputation pipeline imputes missing genotypes from either a multi-sample VCF or an array of single sample VCFs 
+  using a large genomic reference panel. It is based on the Michigan Imputation Server pipeline. Overall, the pipeline 
+  filters, phases, and performs imputation on a multi-sample VCF. It outputs the imputed VCF along with key imputation 
+  metrics.

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -104,7 +104,7 @@ workflow ImputationPipeline {
       "vcf_index": reference_filename + ".vcf.gz.tbi",
       "bcf": reference_filename + ".bcf",
       "bcf_index": reference_filename + ".bcf.csi",
-      "m3vcf": reference_filename + ".m3vcf.gz",
+      "m3vcf": reference_filename + ".cleaned.m3vcf.gz",
       "contig": contig
     }
 

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -27,7 +27,8 @@ workflow ImputationPipeline {
     Float? optional_qc_max_missing
     Float? optional_qc_hwe
     File ref_dict # for reheadering / adding contig lengths in the header of the ouptut VCF, and calculating contig lengths
-    Array[ReferencePanelContig] referencePanelContigs
+    Array[String] contigs
+    String reference_panel_path # path to the bucket where the reference panel files are stored for all contigs
     File genetic_maps_eagle
     String output_callset_name # the output callset name
     Boolean split_output_to_single_sample = false
@@ -94,7 +95,19 @@ workflow ImputationPipeline {
       bcftools_docker = bcftools_docker_tag
   }
 
-  scatter (referencePanelContig in referencePanelContigs) {
+  scatter (contig in contigs) {
+
+    String reference_filename = reference_panel_path + "ALL.chr" + contig + ".phase3_integrated.20130502.genotypes.cleaned"
+
+    ReferencePanelContig referencePanelContig = {
+      "vcf": reference_filename + ".vcf.gz",
+      "vcf_index": reference_filename + ".vcf.gz.tbi",
+      "bcf": reference_filename + ".bcf",
+      "bcf_index": reference_filename + ".bcf.csi",
+      "m3vcf": reference_filename + ".m3vcf.gz",
+      "contig": contig
+    }
+
     call tasks.CalculateChromosomeLength {
       input:
         ref_dict = ref_dict,

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -37,6 +37,12 @@ workflow ImputationPipeline {
 
     Float frac_well_imputed_threshold = 0.9 # require fraction of sites well imputed to be greater than this to pass
     Int chunks_fail_threshold = 1 # require fewer than this many chunks to fail in order to pass
+
+    String vcf_suffix = ".vcf.gz"
+    String vcf_index_suffix = ".vcf.gz.tbi"
+    String bcf_suffix = ".bcf"
+    String bcf_index_suffix =  ".bcf.csi"
+    String m3vcf_suffix = ".cleaned.m3vcf.gz"
   }
   # Docker images here
   String bcftools_docker_tag = "us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0"
@@ -100,11 +106,11 @@ workflow ImputationPipeline {
     String reference_filename = reference_panel_path + "ALL.chr" + contig + ".phase3_integrated.20130502.genotypes.cleaned"
 
     ReferencePanelContig referencePanelContig = {
-      "vcf": reference_filename + ".vcf.gz",
-      "vcf_index": reference_filename + ".vcf.gz.tbi",
-      "bcf": reference_filename + ".bcf",
-      "bcf_index": reference_filename + ".bcf.csi",
-      "m3vcf": reference_filename + ".cleaned.m3vcf.gz",
+      "vcf": reference_filename + vcf_suffix,
+      "vcf_index": reference_filename + vcf_index_suffix,
+      "bcf": reference_filename + bcf_suffix,
+      "bcf_index": reference_filename + bcf_index_suffix,
+      "m3vcf": reference_filename + m3vcf_suffix,
       "contig": contig
     }
 

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -38,6 +38,7 @@ workflow ImputationPipeline {
     Float frac_well_imputed_threshold = 0.9 # require fraction of sites well imputed to be greater than this to pass
     Int chunks_fail_threshold = 1 # require fewer than this many chunks to fail in order to pass
 
+    # file extensions used to find reference panel files
     String vcf_suffix = ".vcf.gz"
     String vcf_index_suffix = ".vcf.gz.tbi"
     String bcf_suffix = ".bcf"

--- a/pipelines/broad/arrays/imputation/example_inputs.json
+++ b/pipelines/broad/arrays/imputation/example_inputs.json
@@ -11,24 +11,8 @@
   ],
 
   "ImputationPipeline.ref_dict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "ImputationPipeline.referencePanelContigs": [
-    {
-      "vcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr21.phase3_integrated.20130502.genotypes.cleaned.vcf.gz",
-      "vcf_index": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr21.phase3_integrated.20130502.genotypes.cleaned.vcf.gz.tbi",
-      "bcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr21.phase3_integrated.20130502.genotypes.cleaned.bcf",
-      "bcf_index":"gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr21.phase3_integrated.20130502.genotypes.cleaned.bcf.csi",
-      "m3vcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr21.phase3_integrated.20130502.genotypes.cleaned.cleaned.m3vcf.gz",
-      "contig": "21"
-    }, 
-    {
-      "vcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr22.phase3_integrated.20130502.genotypes.cleaned.vcf.gz",
-      "vcf_index": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr22.phase3_integrated.20130502.genotypes.cleaned.vcf.gz.tbi",
-      "bcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr22.phase3_integrated.20130502.genotypes.cleaned.bcf",
-      "bcf_index": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr22.phase3_integrated.20130502.genotypes.cleaned.bcf.csi", 
-      "m3vcf": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/ALL.chr22.phase3_integrated.20130502.genotypes.cleaned.cleaned.m3vcf.gz",
-      "contig": "22"
-    }
-  ],
+  "ImputationPipeline.reference_panel_path": "gs://broad-gotc-test-storage/imputation/1000G_reference_panel/",
+  "ImputationPipeline.contigs": [ "21", "22" ],
   "ImputationPipeline.genetic_maps_eagle": "gs://broad-gotc-test-storage/imputation/eagle_genetic_map/genetic_map_hg19_withX.txt.gz",
   "ImputationPipeline.output_callset_name": "plumbing_test",
   "ImputationPipeline.split_output_to_single_sample": false,


### PR DESCRIPTION
The first iteration of the imputation pipeline had an `Array[ReferencePanelContig]` as an input. This array of structs requires specification of 5 files and 1 contig for each contig that you want to run. This results in a very long list of structs that cannot be set gracefully in Terra. 

Since all the files follow the same naming convention, we can use the contig information and a path to the reference panel bucket to build the file paths and the `ReferencePanelContig` struct for each contig. 