### PR TITLE
UploadFingerprintToMercury is not a volatile task

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -9,6 +9,7 @@
 * Enabled pipeline to lookup the genotype control data using an alternate method (using the arrays_control_data_path and control_sample_name)
 * Modified pipeline to NOT write fingerprints for control samples to the Mercury Fingerprint Store.
 * Change outputs of Arrays and pipeline to use python_file_naming_convention instead of CamelCase
+* Removed the volatile=true flag from UploadFingerprintToMercury
 
 # 2.4.2
 2021-09-22

--- a/tasks/broad/InternalTasks.wdl
+++ b/tasks/broad/InternalTasks.wdl
@@ -133,10 +133,6 @@ task UploadFingerprintToMercury {
     Int preemptible_tries
   }
 
-  meta {
-    volatile: true
-  }
-
   command <<<
     set -eo pipefail
 


### PR DESCRIPTION
This task does not need to be volatile.