### PR TITLE
Standardizing adapter tasks

### DIFF
--- a/projects/tasks/AdapterTasks.wdl
+++ b/projects/tasks/AdapterTasks.wdl
@@ -67,8 +67,8 @@ task GetCromwellMetadata {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil((size(output_path, "Mi")))
-    Int disk_size_gb = ceil((size(output_path, "Gi")))
+    Int memory_mb = ceil((size(output_path, "MiB")))
+    Int disk_size_gb = ceil((size(output_path, "GiB")))
   }
 
   command {
@@ -108,8 +108,8 @@ task MergeLooms {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil(size(output_looms, "Mi")) * length(output_looms)
-    Int disk_size_gb = ceil((size(output_looms, "Gi") * 2)) + 5
+    Int memory_mb = ceil(size(output_looms, "MiB")) * length(output_looms)
+    Int disk_size_gb = ceil((size(output_looms, "GiB") * 2)) + 5
   }
 
   command {
@@ -148,8 +148,8 @@ task GetAnalysisFileMetadata {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = if defined(input_file) then ceil(size(input_file, "Mi")) else 2000
-    Int disk_size_gb = if defined(input_file) then ceil(size(input_file, "Gi")) else 5
+    Int memory_mb = if defined(input_file) then ceil(size(input_file, "MiB")) else 2000
+    Int disk_size_gb = if defined(input_file) then ceil(size(input_file, "GiB")) else 5
   }
 
   # For Optimus, if we are doing an intermediate level run, then we pass in the metadata.json
@@ -202,8 +202,8 @@ task GetAnalysisProcessMetadata {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil((size(input_file, "Mi"))) + 2000
-    Int disk_size_gb = ceil((size(input_file, "Gi"))) + 3
+    Int memory_mb = ceil((size(input_file, "MiB"))) + 2000
+    Int disk_size_gb = ceil((size(input_file, "GiB"))) + 3
   }
 
   command {
@@ -287,8 +287,8 @@ task GetLinksFileMetadata {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil(size(output_file_path, "Mi"))
-    Int disk_size_gb = ceil(size(output_file_path, "Gi"))
+    Int memory_mb = ceil(size(output_file_path, "MiB"))
+    Int disk_size_gb = ceil(size(output_file_path, "GiB"))
   }
 
   command
@@ -370,8 +370,8 @@ task GetFileDescriptor {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil(size(file_path, "Mi")) + 2000
-    Int disk_size_gb = ceil(size(file_path, "Gi")) + 5
+    Int memory_mb = ceil(size(file_path, "MiB")) + 2000
+    Int disk_size_gb = ceil(size(file_path, "GiB")) + 5
   }
 
   command
@@ -481,8 +481,8 @@ task ParseCromwellMetadata {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil((size(cromwell_metadata, "Mi")))
-    Int disk_size_gb = ceil(size(cromwell_metadata, "Gi"))
+    Int memory_mb = ceil((size(cromwell_metadata, "MiB")))
+    Int disk_size_gb = ceil(size(cromwell_metadata, "GiB"))
   }
 
   command {
@@ -512,8 +512,8 @@ task GetReferenceDetails {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil((size(ref_fasta, "Mi")) * 2) + 1000
-    Int disk_size_gb = ceil((size(ref_fasta, "Gi") * 2)) + 5
+    Int memory_mb = ceil((size(ref_fasta, "MiB")) * 2) + 1000
+    Int disk_size_gb = ceil((size(ref_fasta, "GiB") * 2)) + 5
   }
 
   command {
@@ -544,8 +544,8 @@ task GetProjectLevelInputIds {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil((size(intermediate_analysis_files, "Mi")) * 2) + 1000
-    Int disk_size_gb = ceil((size(intermediate_analysis_files, "Gi") * 2)) + 5
+    Int memory_mb = ceil((size(intermediate_analysis_files, "MiB")) * 2) + 1000
+    Int disk_size_gb = ceil((size(intermediate_analysis_files, "GiB") * 2)) + 5
   }
 
   command {
@@ -580,8 +580,8 @@ task CopyToStagingBucket {
 
     String docker = "us.gcr.io/broad-gotc-prod/pipeline-tools:latest"
     Int cpu = 1
-    Int memory_mb = ceil(size(data_objects, "Mi"))
-    Int disk_size_gb = ceil(size(data_objects, "Gi"))
+    Int memory_mb = ceil(size(data_objects, "MiB"))
+    Int disk_size_gb = ceil(size(data_objects, "GiB"))
   }
 
   command


### PR DESCRIPTION
Criteria defined by the team: 
- disk should always be in GiB, variable name disk_size_gb
- always dynamically size disk off of one value
- memory should always be in MiB, variable name memory_mb
- disk is always in GiB, variable type is an Int (not Float), and always use local-disk and HDD as seen in disk string
- runtime block example: ```  runtime {
    docker: docker
    cpu: cpu
    memory: "${memory_mb} MiB"
    disks: "local-disk ${disk_size_gb} HDD"
  }```
- make sure cpu is always defined with default set to 1
- input block has a blank line separating runtime inputs from task inputs

I have a different branch set up with these optimizations to run it in terra without messing anything up: https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/optimize-optimus-adapters/job_history