### PR TITLE
Azure specific changes for exome and wgs pipeline

### DIFF
--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
@@ -221,8 +221,9 @@ task MergeBamouts {
   runtime {
     docker: "biocontainers/samtools:1.3.1"
     memory: "4 GiB"
-    disks: "local-disk ~{disk_size} HDD"
-    preemptible: 3
+    disk: "~{disk_size} GB"
+    preemptible: true
+    maxRetries:  3
     cpu: 1
   }
 }

--- a/tasks/broad/Alignment.wdl
+++ b/tasks/broad/Alignment.wdl
@@ -110,10 +110,11 @@ task SamToFastqAndBwaMemAndMba {
   >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/samtools-picard-bwa:1.0.0-0.7.15-2.23.8-1626449438"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "14 GiB"
     cpu: "16"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File output_bam = "~{output_bam_basename}.bam"
@@ -151,8 +152,9 @@ task SamSplitter {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/samtools-picard-bwa:1.0.0-0.7.15-2.23.8-1626449438"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3.75 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 }

--- a/tasks/broad/GermlineVariantDiscovery.wdl
+++ b/tasks/broad/GermlineVariantDiscovery.wdl
@@ -36,7 +36,9 @@ task HaplotypeCaller_GATK35_GVCF {
   }
 
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
-  Int disk_size = ceil(((size(input_bam, "GiB") + 30) / hc_scatter) + ref_size) + 20
+# Temporary solution, return hc_scatter when NIO is supported
+#  Int disk_size = ceil(((size(input_bam, "GiB") + 30) / hc_scatter) + ref_size) + 20
+  Int disk_size = ceil(size(input_bam, "GiB") + 30 + size(input_bam_index, "GB") + ref_size) + 20
 
   # We use interval_padding 500 below to make sure that the HaplotypeCaller has context on both sides around
   # the interval because the assembly uses them.
@@ -67,10 +69,11 @@ task HaplotypeCaller_GATK35_GVCF {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "10 GiB"
     cpu: "1"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File output_gvcf = "~{gvcf_basename}.vcf.gz"
@@ -106,7 +109,9 @@ task HaplotypeCaller_GATK4_VCF {
   String output_file_name = vcf_basename + output_suffix
 
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
-  Int disk_size = ceil(((size(input_bam, "GiB") + 30) / hc_scatter) + ref_size) + 20
+# Temporary solution, return hc_scatter when NIO is supported
+#  Int disk_size = ceil(((size(input_bam, "GiB") + 30) / hc_scatter) + ref_size) + 20
+  Int disk_size = ceil(size(input_bam, "GiB") + 30  + size(input_bam_index, "GB") + ref_size) + 20
 
   String bamout_arg = if make_bamout then "-bamout ~{vcf_basename}.bamout.bam" else ""
 
@@ -149,11 +154,11 @@ task HaplotypeCaller_GATK4_VCF {
 
   runtime {
     docker: gatk_docker
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "~{memory_size_gb} GiB"
     cpu: "2"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 
   output {
@@ -184,9 +189,10 @@ task MergeVCFs {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
-    disks: "local-disk ~{disk_size} HDD"
+    disk: "~{disk_size} GB"
   }
   output {
     File output_vcf = "~{output_vcf_name}"
@@ -222,10 +228,10 @@ task HardFilterVcf {
   }
   runtime {
     docker: gatk_docker
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 }
 
@@ -259,10 +265,10 @@ task DragenHardFilterVcf {
   }
   runtime {
     docker: gatk_docker
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 }
 
@@ -308,11 +314,11 @@ task CNNScoreVariants {
 
   runtime {
     docker: gatk_docker
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "15 GiB"
     cpu: "2"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 }
 
@@ -367,9 +373,9 @@ task FilterVariantTranches {
   runtime {
     memory: "7 GiB"
     cpu: "2"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
+    disk: disk_size + " GB"
+    preemptible: true
+    maxRetries:  preemptible_tries
     docker: gatk_docker
   }
 }

--- a/tasks/broad/Qc.wdl
+++ b/tasks/broad/Qc.wdl
@@ -34,9 +34,10 @@ task CollectQualityYieldMetrics {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
     memory: "3.5 GiB"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
   output {
     File quality_yield_metrics = "~{metrics_filename}"
@@ -73,8 +74,9 @@ task CollectUnsortedReadgroupBamQualityMetrics {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
     memory: "7 GiB"
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
+    disk: disk_size + " GB"
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
   output {
     File base_distribution_by_cycle_pdf = "~{output_bam_prefix}.base_distribution_by_cycle.pdf"
@@ -125,8 +127,9 @@ task CollectReadgroupBamQualityMetrics {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
     memory: "7 GiB"
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
+    disk: disk_size + " GB"
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
   output {
     File alignment_summary_metrics = "~{output_bam_prefix}.alignment_summary_metrics"
@@ -179,8 +182,9 @@ task CollectAggregationMetrics {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
     memory: "7 GiB"
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
+    disk: disk_size + " GB"
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
   output {
     File alignment_summary_metrics = "~{output_bam_prefix}.alignment_summary_metrics"
@@ -229,8 +233,9 @@ task ConvertSequencingArtifactToOxoG {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
     memory: "~{memory_size} GiB"
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
+    disk: disk_size + " GB"
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
   output {
     File oxog_metrics = "~{base_name}.oxog_metrics"
@@ -266,9 +271,10 @@ task CrossCheckFingerprints {
   >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3.5 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File cross_check_fingerprints_metrics = "~{metrics_filename}"
@@ -310,9 +316,10 @@ task CheckFingerprint {
   >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3.5 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File summary_metrics = summary_metrics_location
@@ -358,7 +365,8 @@ task CheckPreValidation {
 >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/python:2.7"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "2 GiB"
   }
   output {
@@ -404,9 +412,10 @@ task ValidateSamFile {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "~{memory_size} GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File report = "~{report_filename}"
@@ -443,9 +452,10 @@ task CollectWgsMetrics {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File metrics = "~{metrics_filename}"
@@ -487,9 +497,10 @@ task CollectRawWgsMetrics {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "~{memory_size} GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File metrics = "~{metrics_filename}"
@@ -535,9 +546,10 @@ task CollectHsMetrics {
 
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "~{memory_size} GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 
   output {
@@ -564,9 +576,10 @@ task CalculateReadGroupChecksum {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "4 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File md5_file = "~{read_group_md5_filename}"
@@ -604,10 +617,10 @@ task ValidateVCF {
   }
   runtime {
     docker: gatk_docker
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "7 GiB"
-    bootDiskSizeGb: 15
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
 }
 
@@ -639,9 +652,10 @@ task CollectVariantCallingMetrics {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File summary_metrics = "~{metrics_basename}.variant_calling_summary_metrics"

--- a/tasks/broad/Utilities.wdl
+++ b/tasks/broad/Utilities.wdl
@@ -61,7 +61,8 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     docker: "us.gcr.io/broad-gotc-prod/python:2.7"
     memory: "2 GiB"
   }
@@ -146,10 +147,11 @@ task ConvertToCram {
   >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
     memory: "3 GiB"
     cpu: "1"
-    disks: "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB"
   }
   output {
     File output_cram = "~{output_basename}.cram"
@@ -177,10 +179,11 @@ task ConvertToBam {
   >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
-    preemptible: 3
+    preemptible: true
+    maxRetries:  3
     memory: "3 GiB"
     cpu: "1"
-    disks: "local-disk 200 HDD"
+    disk: "200 GB"
   }
   output {
     File output_bam = "~{output_basename}.bam"
@@ -203,7 +206,8 @@ task SumFloats {
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/python:2.7"
-    preemptible: preemptible_tries
+    preemptible: true
+    maxRetries:  preemptible_tries
   }
 }
 


### PR DESCRIPTION
1. Made azure specific changes to runtime attributes:
a.  _disks: "local-disk " + disk_size + " HDD"_ converted to  _disk: disk_size + " GB"_
b.  _preemptible: preemptible_tries_  converted to _preemptible: true    maxRetries:  preemptible_tries_. With TES the _preemptible_ attribute is a boolean (not an integer). You can specify preemptible as true or false for each task, when set to true Cromwell on Azure will use a low-priority batch VM to run the task; consider adding _maxRetries_ to keep the retry functionality
c.  _bootDiskSizeGb: "15"_ removed, since attribute _bootDiskSizeGb_ is not supported by the TES backend. Attribute _zones_ is not supported too.
2. Removed scatter coefficient in disk_size calculation in HaplotypeCaller, BaseRecalibrator and ApplyBQSR (we expect that this change will be reverted when NIO is available).

Runtime attribute changes are needed due to different Cromwell backends, you can find more info about them here https://cromwell.readthedocs.io/en/develop/backends/TES/ and https://cromwell.readthedocs.io/en/develop/RuntimeAttributes/

With changes described above exome and wgs pipelines ran on Azure for earlier version (before Dragen components were added),  Similar changes will be required in DragenTasks.wdl and DragmapAlignment.wdl