### PR TITLE
Preparing BWA to be able to use masked reference

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -5,6 +5,8 @@
     * The ExomeGermlineSingleSample pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"ExomeGermlineSingleSample.BamToGvcf.skip_reblocking\": true' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 2.6.0
 2021-10-18

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -5,6 +5,8 @@
     * The WholeGenomeGermlineSingleSample pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"WholeGenomeGermlineSingleSample.BamToGvcf.skip_reblocking\": true' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 2.5.0
 2021-10-18

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -64,6 +64,7 @@ workflow WholeGenomeGermlineSingleSample {
     Boolean unmap_contaminant_reads = true
     Boolean perform_bqsr = true
     Boolean use_bwa_mem = true
+    Boolean allow_empty_ref_alt = false
     Boolean use_dragen_hard_filtering = false
   }
 
@@ -115,7 +116,8 @@ workflow WholeGenomeGermlineSingleSample {
       recalibrated_bam_basename   = recalibrated_bam_basename,
       perform_bqsr                = perform_bqsr_,
       use_bwa_mem                 = use_bwa_mem_,
-      unmap_contaminant_reads     = unmap_contaminant_reads_
+      unmap_contaminant_reads     = unmap_contaminant_reads_,
+      allow_empty_ref_alt         = allow_empty_ref_alt
   }
 
   call AggregatedQC.AggregatedBamQC {

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/input_files/WholeGenomeGermlineSingleSample.inputs.plumbing.masked_reference.json
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/input_files/WholeGenomeGermlineSingleSample.inputs.plumbing.masked_reference.json
@@ -1,0 +1,58 @@
+{
+  "WholeGenomeGermlineSingleSample.sample_and_unmapped_bams": {
+    "sample_name": "NA12878 PLUMBING",
+    "base_file_name": "NA12878_PLUMBING",
+    "flowcell_unmapped_bams": [
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.1.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06HDADXX130110.2.ATCACGAT.20k_reads.bam",
+      "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam"
+    ],
+    "final_gvcf_base_name": "NA12878_PLUMBING",
+    "unmapped_bam_suffix": ".bam"
+  },
+
+  "WholeGenomeGermlineSingleSample.references": {
+    "contamination_sites_ud": "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD",
+    "contamination_sites_bed": "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
+    "contamination_sites_mu": "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
+    "calling_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list",
+    "reference_fasta" : {
+        "ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.dict",
+        "ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta",
+        "ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.fai",
+        "ref_sa": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.64.sa",
+        "ref_alt": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.alt",
+        "ref_amb": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.64.amb",
+        "ref_bwt": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.64.bwt",
+        "ref_ann": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.64.ann",
+        "ref_pac": "gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta.64.pac"
+    },
+    "known_indels_sites_vcfs": [
+      "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+      "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
+    ],
+    "known_indels_sites_indices": [
+      "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+      "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
+    ],
+    "dbsnp_vcf": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
+    "dbsnp_vcf_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
+    "evaluation_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list",
+    "haplotype_database_file": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt"
+  },
+
+  "WholeGenomeGermlineSingleSample.scatter_settings": {
+    "haplotype_scatter_count": 10,
+    "break_bands_at_multiples_of": 100000
+  },
+
+  "WholeGenomeGermlineSingleSample.allow_empty_ref_alt": true,
+  "WholeGenomeGermlineSingleSample.fingerprint_genotypes_file": "gs://broad-gotc-test-storage/single_sample/plumbing/bams/G96830.NA12878/G96830.NA12878.hg38.reference.fingerprint.vcf.gz",
+  "WholeGenomeGermlineSingleSample.fingerprint_genotypes_index": "gs://broad-gotc-test-storage/single_sample/plumbing/bams/G96830.NA12878/G96830.NA12878.hg38.reference.fingerprint.vcf.gz.tbi",
+  "WholeGenomeGermlineSingleSample.wgs_coverage_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_coverage_regions.hg38.interval_list",
+
+  "WholeGenomeGermlineSingleSample.papi_settings": {
+    "preemptible_tries": 3,
+    "agg_preemptible_tries": 3
+  }
+}

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -5,6 +5,8 @@
     * The ExomeReprocessing pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"ExomeReprocessing.ExomeGermlineSingleSample.BamToGvcf.skip_reblocking\": true' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 2.6.0
 2021-10-18

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -5,6 +5,8 @@
     * The ExternalExomeReprocessing pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"ExternalExomeReprocessing.ExomeReprocessing.ExomeGermlineSingleSample.BamToGvcf.make_gvcf\": false' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 2.6.0
 2021-10-18

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -5,6 +5,8 @@
     * The ExternalWholeGenomeReprocessing pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"ExternalWholeGenomeReprocessing.WholeGenomeReprocessing.WholeGenomeGermlineSingleSample.BamToGvcf.skip_reblocking\": true' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 1.5.0
 2021-10-18

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -5,6 +5,8 @@
     * The WholeGenomeReprocessing pipeline now outputs reblocked gVCFs by default. To skip reblocking, add '\"WholeGenomeReprocessing.WholeGenomeGermlineSingleSample.BamToGvcf.skip_reblocking\": true' to the inputs
 * Adding WGS plumbing tests for dragen_maximum_quality_mode and dragen_functional_equivalence_mode
 * Moved Dragmap docker to WARP and updated to follow repo's best practices
+* Added option to allow empty ref_alt file for running BWA mem with masked reference
+* Added plumbing input JSON for masked reference
 
 # 2.5.0
 2021-10-18

--- a/tasks/broad/Alignment.wdl
+++ b/tasks/broad/Alignment.wdl
@@ -33,6 +33,7 @@ task SamToFastqAndBwaMemAndMba {
     Int preemptible_tries
     Boolean hard_clip_reads = false
     Boolean unmap_contaminant_reads = true
+    Boolean allow_empty_ref_alt = false
   }
 
   Float unmapped_bam_size = size(input_bam, "GiB")
@@ -61,8 +62,8 @@ task SamToFastqAndBwaMemAndMba {
 
     # set the bash variable needed for the command-line
     bash_ref_fasta=~{reference_fasta.ref_fasta}
-    # if reference_fasta.ref_alt has data in it,
-    if [ -s ~{reference_fasta.ref_alt} ]; then
+    # if reference_fasta.ref_alt has data in it or allow_empty_ref_alt is set
+    if [ -s ~{reference_fasta.ref_alt} ] || ~{allow_empty_ref_alt}; then
       java -Xms1000m -Xmx1000m -jar /usr/gitc/picard.jar \
         SamToFastq \
         INPUT=~{input_bam} \
@@ -100,11 +101,14 @@ task SamToFastqAndBwaMemAndMba {
         UNMAP_CONTAMINANT_READS=~{unmap_contaminant_reads} \
         ADD_PG_TAG_TO_READS=false
 
-      grep -m1 "read .* ALT contigs" ~{output_bam_basename}.bwa.stderr.log | \
-      grep -v "read 0 ALT contigs"
+      if ~{!allow_empty_ref_alt}; then
+        grep -m1 "read .* ALT contigs" ~{output_bam_basename}.bwa.stderr.log | \
+        grep -v "read 0 ALT contigs"
+      fi
 
     # else reference_fasta.ref_alt is empty or could not be found
     else
+      echo ref_alt input is empty or not provided. >&2
       exit 1;
     fi
   >>>

--- a/tasks/broad/SplitLargeReadGroup.wdl
+++ b/tasks/broad/SplitLargeReadGroup.wdl
@@ -41,6 +41,7 @@ workflow SplitLargeReadGroup {
     Boolean hard_clip_reads = false
     Boolean unmap_contaminant_reads = true
     Boolean use_bwa_mem = true
+    Boolean allow_empty_ref_alt = false
   }
 
   call Alignment.SamSplitter as SamSplitter {
@@ -65,7 +66,8 @@ workflow SplitLargeReadGroup {
           compression_level = compression_level,
           preemptible_tries = preemptible_tries,
           hard_clip_reads = hard_clip_reads,
-          unmap_contaminant_reads = unmap_contaminant_reads
+          unmap_contaminant_reads = unmap_contaminant_reads,
+          allow_empty_ref_alt = allow_empty_ref_alt
       }
     }
     if (!use_bwa_mem) {

--- a/tasks/broad/UnmappedBamToAlignedBam.wdl
+++ b/tasks/broad/UnmappedBamToAlignedBam.wdl
@@ -47,6 +47,7 @@ workflow UnmappedBamToAlignedBam {
     Boolean somatic = false
     Boolean perform_bqsr = true
     Boolean use_bwa_mem = true
+    Boolean allow_empty_ref_alt = false
   }
 
   Float cutoff_for_large_rg_in_gb = 20.0
@@ -86,7 +87,8 @@ workflow UnmappedBamToAlignedBam {
           preemptible_tries = papi_settings.preemptible_tries,
           hard_clip_reads = hard_clip_reads,
           unmap_contaminant_reads = unmap_contaminant_reads,
-          use_bwa_mem = use_bwa_mem
+          use_bwa_mem = use_bwa_mem,
+          allow_empty_ref_alt = allow_empty_ref_alt
       }
     }
 
@@ -102,7 +104,8 @@ workflow UnmappedBamToAlignedBam {
             compression_level = compression_level,
             preemptible_tries = papi_settings.preemptible_tries,
             hard_clip_reads = hard_clip_reads,
-            unmap_contaminant_reads = unmap_contaminant_reads
+            unmap_contaminant_reads = unmap_contaminant_reads,
+            allow_empty_ref_alt = allow_empty_ref_alt
         }
       }
       if (!use_bwa_mem) {


### PR DESCRIPTION
- Made ref_alt input optional in ReferenceFasta struct
- Removed check if ref_alt file is present in the reference input
  - Previously, the Alignment task would fail if there was either no reference .alt file present or if BWA did not read any ALT contigs. For using a masked reference, however, no reference .alt file must be present in order to signal BWA not to use the liftover approach. This commit removes the validation that an .alt file has been provided.
- Added plumbing input JSON for masked reference

Goal is to merge by early next week (11/9)