### PR TITLE
Change optimus adapter check to verify fastqi exists at specific index

### DIFF
--- a/projects/optimus/CreateOptimusAdapterMetadata.wdl
+++ b/projects/optimus/CreateOptimusAdapterMetadata.wdl
@@ -105,7 +105,7 @@ workflow CreateOptimusAdapterMetadata {
 
   ########################## Get Optimus Metadata Files ##########################
   scatter (idx in range(length(output_looms))) {
-    String? fastq_i1_uuid = if defined(fastq_i1_uuids) then select_first([fastq_i1_uuids])[idx] else none
+    String? fastq_i1_uuid = if defined(fastq_i1_uuids[idx]) then select_first([fastq_i1_uuids])[idx] else none
     call CreateOptimusObjects.CreateOptimusAdapterObjects as CreateIntermediateOptimusAdapters {
       input:
         bam = output_bams[idx],


### PR DESCRIPTION
We need to actually check that the fastqi index exists at the specified location, not just that the array exists. This will handle the case where some shards have the fastqi defined and some do not.