### PR TITLE
Update wreleaser README

### DIFF
--- a/wreleaser/README.md
+++ b/wreleaser/README.md
@@ -26,7 +26,7 @@ To reset your cache you can run `wreleaser reset`.
 Make sure you have Go installed ([download](https://jimkang.medium.com/install-go-on-mac-with-homebrew-5fa421fc55f5)). Then install _wreleaser_ with the `go get` command:
 
 ```bash
-go get -u github.com/broadinstitute/warp/wreleaser
+go install github.com/broadinstitute/warp/wreleaser@latest
 ```
 
 #### Option 2


### PR DESCRIPTION
'go get' command is now deprecated in favor of 'go install' when downloading binaries outside of a module