### PR TITLE
Update custom GATK image to GATk 4.2.4.0 

### DIFF
--- a/dockers/broad/gatk/Dockerfile
+++ b/dockers/broad/gatk/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk/openjdk8:alpine-slim
 
-ARG GATK4_VERSION=4.1.8.0 \
+ARG GATK4_VERSION=4.2.4.0 \
         GATK3_VERSION=3.5
 
 ENV TERM=xterm-256color \

--- a/dockers/broad/gatk/README.md
+++ b/dockers/broad/gatk/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571`
+#### `docker pull us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271`
 `
 
 - __What is this image:__ This image is a lightweight alpine-based image for running GATK (it includes both GATK4 & GATK3 -- 3.5 is included for backwards compatibility with HaplotypeCalling).
@@ -23,8 +23,8 @@ We keep track of all past versions in [docker_versions](docker_versions.tsv) wit
 You can see more information about the image, including the tool versions, by running the following command:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571
-$ docker inspect us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571
+$ docker pull us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271
+$ docker inspect us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ $ docker inspect us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571
 ```bash
 $ docker run --rm -it \
     -v /gatk-files:/gatk-files \
-    us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571  /usr/gitc/gatk4/gatk --java-options "-Xms2000m -Xmx2500m" \
+    us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271  /usr/gitc/gatk4/gatk --java-options "-Xms2000m -Xmx2500m" \
     PrintReads \
     -I /gatk-files/input_bam\
     --interval-padding 500 \
@@ -47,7 +47,7 @@ $ docker run --rm -it \
 ```bash
 $ docker run --rm -it \
     -v /gatk-files:/gatk-files \
-    us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571  java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xms8000m -Xmx9000m \
+    us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271  java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xms8000m -Xmx9000m \
     -jar /usr/gitc/GATK35.jar \
     -T HaplotypeCaller \
     -R /gatk-files/ref_fasta \

--- a/dockers/broad/gatk/docker_build.sh
+++ b/dockers/broad/gatk/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.0
+DOCKER_IMAGE_VERSION=1.1.0
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 
@@ -11,7 +11,7 @@ GCR_URL="us.gcr.io/broad-gotc-prod/gatk"
 QUAY_URL="quay.io/broadinstitute/gotc-prod-gatk"
 
 # GATK4 version
-GATK4_VERSION="4.1.8.0"
+GATK4_VERSION="4.2.4.0"
 
 # GATK3 version
 GATK3_VERSION="3.5"

--- a/dockers/broad/gatk/docker_versions.tsv
+++ b/dockers/broad/gatk/docker_versions.tsv
@@ -2,3 +2,4 @@ DOCKER_VERSION
 
 us.gcr.io/broad-gotc-prod/gatk:1.0.0-1625076597
 us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571
+us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271

--- a/tasks/broad/GermlineVariantDiscovery.wdl
+++ b/tasks/broad/GermlineVariantDiscovery.wdl
@@ -66,7 +66,7 @@ task HaplotypeCaller_GATK35_GVCF {
       --read_filter OverclippedRead
   }
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/gatk:1.0.0-4.1.8.0-1626439571"
+    docker: "us.gcr.io/broad-gotc-prod/gatk:1.1.0-4.2.4.0-1639667271"
     preemptible: preemptible_tries
     memory: "10000 MiB"
     cpu: "1"


### PR DESCRIPTION
Addressing the log4shell vulnerability 