### PR TITLE
Updated picard and picard-related tasks to Picard 2.26.10 - this upda…

### DIFF
--- a/dockers/broad/arrays_picard_private/docker_build.sh
+++ b/dockers/broad/arrays_picard_private/docker_build.sh
@@ -11,7 +11,7 @@ GCR_URL="us.gcr.io/broad-arrays-prod/arrays-picard-private"
 IMAGE_TAG="$DOCKER_IMAGE_VERSION-$TIMESTAMP"
 
 # Picard private artifact
-PICARD_PRIVATE_VERSION="257537c72dae29257b09bacf413505eed295ac32"
+PICARD_PRIVATE_VERSION="bcd01bb85df4c0876453a4b6359c19c01bd4caf4"
 
 # Necessary tools and help text
 TOOLS=(docker gcloud vault jq)

--- a/dockers/broad/arrays_picard_private/docker_versions.tsv
+++ b/dockers/broad/arrays_picard_private/docker_versions.tsv
@@ -13,3 +13,4 @@ us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1602016912	61af9bff4587
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1629905256 61af9bff4587783e5981a496f422ea36102482b5
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1629909993 61af9bff4587783e5981a496f422ea36102482b5
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359 257537c72dae29257b09bacf413505eed295ac32
+us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612 bcd01bb85df4c0876453a4b6359c19c01bd4caf4

--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,9 @@
+# 2.6.1
+2022-01-11
+
+* Updated picard and picard-related tasks to Picard 2.26.10
+    * Address log4shell security issue (updated to log4j 2.17.1)
+
 # 2.6.0
 2021-11-17
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -23,7 +23,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Arrays {
 
-  String pipeline_version = "2.6.0"
+  String pipeline_version = "2.6.1"
 
   input {
     String chip_well_barcode

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.changelog.md
@@ -1,3 +1,9 @@
+# 1.15.1
+2022-01-11
+
+* Updated picard and picard-related tasks to Picard 2.26.10
+    * Address log4shell security issue (updated to log4j 2.17.1)
+
 # 1.15.0
 2021-11-17
 

--- a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
+++ b/pipelines/broad/arrays/validate_chip/ValidateChip.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/InternalArraysTasks.wdl" as InternalTasks
 
 workflow ValidateChip {
 
-  String pipeline_version = "1.15.0"
+  String pipeline_version = "1.15.1"
 
   input {
     String sample_alias

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,3 +1,9 @@
+# 1.12.1
+2022-01-11
+
+* Updated picard and picard-related tasks to Picard 2.26.10
+    * Address log4shell security issue (updated to log4j 2.17.1)
+
 # 1.12.0
 2021-11-17
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
@@ -20,7 +20,7 @@ import "../../../../tasks/broad/IlluminaGenotypingArrayTasks.wdl" as GenotypingT
 
 workflow IlluminaGenotypingArray {
 
-  String pipeline_version = "1.12.0"
+  String pipeline_version = "1.12.1"
 
   input {
     String sample_alias

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -71,7 +71,7 @@ task BpmToNormalizationManifestCsv {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk 10 HDD"
     memory: "7500 MiB"
     cpu: 2
@@ -130,7 +130,7 @@ task GtcToVcf {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "~{memory_mb} MiB"
     cpu: 2
@@ -195,7 +195,7 @@ task VcfToAdpc {
              --OUTPUT ~{output_adpc_filename}
   }
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -269,7 +269,7 @@ task CreateVerifyIDIntensityContaminationMetricsFile {
              --OUTPUT ~{output_metrics_basefilename}
   }
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -325,7 +325,7 @@ task CollectArraysVariantCallingMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -356,7 +356,7 @@ task VcfToIntervalList {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -410,7 +410,7 @@ task CheckFingerprint {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -459,7 +459,7 @@ task SelectVariants {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -495,7 +495,7 @@ task SelectIndels {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -589,7 +589,7 @@ task MergePedIntoVcf {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     memory: "3500 MiB"
     cpu: "1"
     disks: "local-disk " + disk_size + " HDD"
@@ -693,7 +693,7 @@ task GenotypeConcordance {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -779,7 +779,7 @@ task CreateExtendedIlluminaManifest {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.4"
+    docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     memory: "14000 MiB"
     preemptible: preemptible_tries

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -459,7 +459,7 @@ task SelectVariants {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -495,7 +495,7 @@ task SelectIndels {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -459,7 +459,7 @@ task SelectVariants {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.1"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -495,7 +495,7 @@ task SelectIndels {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.1"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries

--- a/tasks/broad/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/broad/IlluminaGenotypingArrayTasks.wdl
@@ -459,7 +459,7 @@ task SelectVariants {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -495,7 +495,7 @@ task SelectIndels {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.2.4.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries

--- a/tasks/broad/InternalArraysTasks.wdl
+++ b/tasks/broad/InternalArraysTasks.wdl
@@ -27,7 +27,7 @@ task GenerateEmptyVariantCallingMetricsFile {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }
@@ -73,7 +73,7 @@ task BlacklistBarcode {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }
@@ -124,7 +124,7 @@ task VcfToMercuryFingerprintJson {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -152,7 +152,7 @@ task CreateBafRegressMetricsFile {
       --OUTPUT ~{output_metrics_basefilename}
   }
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -229,7 +229,7 @@ task UploadArraysMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -278,7 +278,7 @@ task UploadEmptyArraysMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1631039849"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -377,7 +377,7 @@ task UpdateChipWellBarcodeIndex {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -413,7 +413,7 @@ task GetNextArraysQcAnalysisVersionNumber {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }

--- a/tasks/broad/InternalTasks.wdl
+++ b/tasks/broad/InternalTasks.wdl
@@ -110,7 +110,7 @@ task DownloadGenotypes {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     memory: "3500 MiB"
     maxRetries: select_first([max_retries, 2])
     preemptible: select_first([preemptible_tries, 3])
@@ -162,7 +162,7 @@ task UploadFingerprintToMercury {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
     memory: "3500 MiB"
     maxRetries: select_first([max_retries, 2])
     preemptible: select_first([preemptible_tries, 3])


### PR DESCRIPTION
Updated picard and picard-related tasks to Picard 2.26.10.
this updates to log4j 2.17.1 which address the security issues with log4j.
And update to gatk 4.2.4.1 (which also addresses the security issues with log4j.

Scientific tests were run [here](https://gotc-jenkins.dsp-techops.broadinstitute.org/job/warp-smart-tests/2931/).
Two of thee failed validation of output fingerprint VCFs - explanation [here](https://docs.google.com/document/d/1qtixtdwmiIqbhJyRmf4aZEig8YE-RffCqgLem1BkDiA/edit#heading=h.ury2r6dsg9na)