### PR TITLE
Migrate dragmap base image to rockylinux from centos8

### DIFF
--- a/dockers/broad/dragmap/Dockerfile
+++ b/dockers/broad/dragmap/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /usr/gitc
 RUN set -eux; \
     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*; \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*; \ 
-        yum update -y; \
+        yum upgrade -y; \
         yum install -y epel-release; \
         yum install -y boost169-devel \
             bzip2 \

--- a/dockers/broad/dragmap/Dockerfile
+++ b/dockers/broad/dragmap/Dockerfile
@@ -18,7 +18,10 @@ LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>"
 WORKDIR /usr/gitc
 
 # Install dependencies
+# https://stackoverflow.com/questions/70926799/centos-through-vm-no-urls-in-mirrorlist
 RUN set -eux; \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*; \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*; \ 
         yum update -y; \
         yum install -y epel-release; \
         yum install -y boost169-devel \

--- a/dockers/broad/dragmap/Dockerfile
+++ b/dockers/broad/dragmap/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:8
+# Using rocky as temp replacement for CentOS
+FROM rockylinux:8.5 
 
 ARG DRAGMAP_VERSION=1.2.1 \
         PICARD_VERSION=2.26.4 \
@@ -18,10 +19,7 @@ LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>"
 WORKDIR /usr/gitc
 
 # Install dependencies
-# https://stackoverflow.com/questions/70926799/centos-through-vm-no-urls-in-mirrorlist
 RUN set -eux; \
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*; \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*; \ 
         yum upgrade -y; \
         yum install -y epel-release; \
         yum install -y boost169-devel \

--- a/dockers/broad/dragmap/README.md
+++ b/dockers/broad/dragmap/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436`
+#### `docker pull us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061`
 
 - __What is this image:__ This image is a centos-based custom image for running DRAGMAP, Picard and SAMTOOLS, it uses `centos:8` as a base image.
 - __What are Dragmap, Picard and Samtools:__ Dragmap is the Dragen mapper/aligner Open Source Software, [more info](https://github.com/Illumina/DRAGMAP). Picard is a set of command line tools for manipulating high-throughput sequencing (HTS) data and formats, [more info](https://github.com/broadinstitute/picard). Samtools is a suite of programs for interacting with high-throughput sequencing data. See [here](https://github.com/samtools/samtools) more information.
@@ -21,8 +21,8 @@ We keep track of all past versions in [docker_versions](docker_versions.tsv) wit
 You can see more information about the image, including the tool versions, by running the following command:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436
-$ docker inspect us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436
+$ docker pull us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061
+$ docker inspect us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061
 ```
 
 ## Usage
@@ -40,5 +40,5 @@ See Picard GitHub for [more info](https://github.com/broadinstitute/picard)
 ```bash
 $ docker run --rm -it \
     -v /bamfiles:/bamfiles \
-    us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436 samtools view -H /bamfiles/<bam-file>
+    us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061 samtools view -H /bamfiles/<bam-file>
 ```

--- a/dockers/broad/dragmap/README.md
+++ b/dockers/broad/dragmap/README.md
@@ -6,7 +6,7 @@ Copy and paste to pull this image
 
 #### `docker pull us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061`
 
-- __What is this image:__ This image is a centos-based custom image for running DRAGMAP, Picard and SAMTOOLS, it uses `centos:8` as a base image.
+- __What is this image:__ This image is a RHEL-based custom image for running DRAGMAP, Picard and SAMTOOLS, it uses `centos:8` as a base image.
 - __What are Dragmap, Picard and Samtools:__ Dragmap is the Dragen mapper/aligner Open Source Software, [more info](https://github.com/Illumina/DRAGMAP). Picard is a set of command line tools for manipulating high-throughput sequencing (HTS) data and formats, [more info](https://github.com/broadinstitute/picard). Samtools is a suite of programs for interacting with high-throughput sequencing data. See [here](https://github.com/samtools/samtools) more information.
 - __How to see tool version used in image:__ Please see below.
 

--- a/dockers/broad/dragmap/docker_build.sh
+++ b/dockers/broad/dragmap/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.1.0
+DOCKER_IMAGE_VERSION=1.1.1
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/dockers/broad/dragmap/docker_versions.tsv
+++ b/dockers/broad/dragmap/docker_versions.tsv
@@ -2,3 +2,4 @@ DOCKER_VERSION
 
 us.gcr.io/broad-gotc-prod/dragmap:1.0.0-1.2.1-2.26.4-1.11-1636392425
 us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436
+us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 3.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
+
 # 3.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
@@ -39,7 +39,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 # WORKFLOW DEFINITION
 workflow ExomeGermlineSingleSample {
 
-  String pipeline_version = "3.0.3"
+  String pipeline_version = "3.0.4"
 
   input {
     PapiSettings papi_settings

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,3 +1,7 @@
+# 3.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
 # 3.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -39,7 +39,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 # WORKFLOW DEFINITION
 workflow WholeGenomeGermlineSingleSample {
 
-  String pipeline_version = "3.0.3"
+  String pipeline_version = "3.0.4"
 
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -1,3 +1,7 @@
+# 3.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
 # 3.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 workflow ExomeReprocessing {
 
-  String pipeline_version = "3.0.3"
+  String pipeline_version = "3.0.4"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
+
 # 3.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
@@ -5,7 +5,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalExomeReprocessing {
 
-  String pipeline_version = "3.0.3"
+  String pipeline_version = "3.0.4"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 2.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
+
 # 2.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
@@ -5,7 +5,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalWholeGenomeReprocessing {
 
-  String pipeline_version = "2.0.3"
+  String pipeline_version = "2.0.4"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -1,3 +1,9 @@
+# 3.0.4
+2022-02-02 (Date of Last Commit)
+
+* Changed dragmap base image from Centos to RockyLinux to comply with trivy scans
+
+
 # 3.0.3
 2022-02-01 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 workflow WholeGenomeReprocessing {
 
-  String pipeline_version = "3.0.3"
+  String pipeline_version = "3.0.4"
 
   input {
     File? input_cram

--- a/tasks/broad/DragmapAlignment.wdl
+++ b/tasks/broad/DragmapAlignment.wdl
@@ -31,7 +31,7 @@ task SamToFastqAndDragmapAndMba {
     Boolean hard_clip_reads = false
     Boolean unmap_contaminant_reads = true
 
-    String docker = "us.gcr.io/broad-gotc-prod/dragmap:1.1.0-1.2.1-2.26.4-1.11-1638901436"
+    String docker = "us.gcr.io/broad-gotc-prod/dragmap:1.1.1-1.2.1-2.26.4-1.11-1643744061"
     Int cpu = 16
     Float disk_multiplier = 8
     Int memory_mb = 40960


### PR DESCRIPTION
Centos 8 just recently went EOL so this is a temporary solution to use [RockyLinux](https://rockylinux.org/) in its place.

I put a ticket on the backlog to circle back around to this if we want to go with debian or alpine.