### PR TITLE
Split FastQ for slide seq

### DIFF
--- a/dockers/skylab/create-npz-output/Dockerfile
+++ b/dockers/skylab/create-npz-output/Dockerfile
@@ -13,3 +13,4 @@ RUN mkdir /tools
 WORKDIR /tools
 
 COPY create-npz-output.py .
+COPY create-merged-npz-output.py .

--- a/dockers/skylab/create-npz-output/create-merged-npz-output.py
+++ b/dockers/skylab/create-npz-output/create-merged-npz-output.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import argparse
+import gzip
+import numpy as np
+import sys
+
+import scipy.io
+import scipy.sparse
+
+
+def read_barcodes_list(barcodes_file):
+    # read the barcodes file and create the barcode to index
+    barcodes = []
+    with gzip.open(barcodes_file, 'rt') if barcodes_file.endswith('.gz') else  \
+        open(barcodes_file, 'r') as fin:
+        for line in fin:
+           if line.startswith(r'^#'): # skip comments
+              continue
+           fields = line.strip().split('\t')
+           barcodes.append(fields[0])
+    barcode_list = np.asarray(barcodes)
+    return barcode_list
+
+def read_features_list(features_file):
+    # read the features file and create the feature to index map
+    features = []
+    with gzip.open(features_file, 'rt') if features_file.endswith('.gz') else  \
+        open(features_file, 'r') as fin:
+        for line in fin:
+           if line.startswith(r'^#'): # skip comments
+              continue
+           fields = line.strip().split('\t')
+           features.append(fields[0])
+    features_list = np.asarray(features)
+    return features_list
+
+def main():
+    description = """Create npz, npy file from the mtx files produced by STARsolo"""
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--barcodes',
+                        dest='barcodes',
+                        nargs = '+',
+                        required=True,
+                        help="The barcodes file")
+
+    parser.add_argument('--features',
+                        dest='features',
+                        nargs = '+',
+                        required=True,
+                        help="The features file")
+
+    parser.add_argument('--matrix',
+                        dest='matrix',
+                        nargs = '+',
+                        required=True,
+                        help="The matrix file")
+
+    args = parser.parse_args()
+
+    # features list file 
+    features_list = read_features_list(args.features[0])
+    np.save("sparse_counts_col_index.npy", features_list)
+
+    # read the barcodes file and create the barcode to index
+    barcode_list = read_barcodes_list(args.barcodes[0])
+
+    #TODO make sure the args.matrix, args.barcodes args features are of equal length
+    data_dict = {}
+    for i in range(len(args.matrix)):
+        # convert the mtx file to the matrix
+        matrix = scipy.io.mmread(args.matrix[i]).transpose().tocoo()
+
+        for col, row, count in zip(matrix.col, matrix.row, matrix.data):
+             if (row, col) not in data_dict:
+                 data_dict[(row,col)] = 0
+             data_dict[(row,col)] += count
+        
+    shape = matrix.shape
+    data = []
+    rows = []
+    cols = []
+    for (row, col), count in data_dict.items():
+        rows.append(row)
+        cols.append(col)
+        data.append(count)
+         
+    coo_matrix = scipy.sparse.coo_matrix((data, (rows, cols)), shape=shape)
+
+    # we need to keep only those rows that have non-zero reads/counts
+    matrix = coo_matrix.tocsr()
+    nonzero_row_indices, _ = matrix.nonzero()
+    unique_nonzero_row_indices = np.sort(np.unique(nonzero_row_indices))
+    scipy.sparse.save_npz("sparse_counts.npz", matrix[unique_nonzero_row_indices, :], compressed=True)
+
+    # we need to keep only those barcodes that have non-zero reads/counts
+    np.save("sparse_counts_row_index.npy", barcode_list[unique_nonzero_row_indices])
+      
+if __name__ == '__main__':
+    main()

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -82,7 +82,7 @@ workflow Optimus {
       counting_mode = counting_mode
   }
 
-  call FastqProcessing.FastqProcessing as SplitFastq {
+  call FastqProcessing.FastqProcessingOptimus as SplitFastq {
     input:
       i1_fastq = i1_fastq,
       r1_fastq = r1_fastq,

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -1,10 +1,12 @@
 version 1.0
 
+import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 import "../../../tasks/skylab/StarAlign.wdl" as StarAlign
 import "../../../tasks/skylab/Metrics.wdl" as Metrics
 import "../../../tasks/skylab/RunEmptyDrops.wdl" as RunEmptyDrops
 import "../../../tasks/skylab/LoomUtils.wdl" as LoomUtils
 import "../../../tasks/skylab/OptimusInputChecks.wdl" as OptimusInputChecks
+import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow Optimus {
   meta {
@@ -80,40 +82,58 @@ workflow Optimus {
       counting_mode = counting_mode
   }
 
-  call StarAlign.STARsoloFastq as STARsoloFastq {
+  call FastqProcessing.FastqProcessing as SplitFastq {
     input:
+      i1_fastq = i1_fastq,
       r1_fastq = r1_fastq,
       r2_fastq = r2_fastq,
-      white_list = whitelist,
-      tar_star_reference = tar_star_reference,
+      whitelist = whitelist,
       chemistry = chemistry,
-      counting_mode = counting_mode,
-      output_bam_basename = output_bam_basename
+      sample_id = input_id
   }
 
+  scatter(idx in range(length(SplitFastq.fastq_R1_output_array))) {
+    call StarAlign.STARsoloFastq as STARsoloFastq {
+      input:
+        r1_fastq = [SplitFastq.fastq_R1_output_array[idx]],
+        r2_fastq = [SplitFastq.fastq_R2_output_array[idx]],
+        white_list = whitelist,
+        tar_star_reference = tar_star_reference,
+        chemistry = chemistry,
+        counting_mode = counting_mode,
+        output_bam_basename = output_bam_basename + "_" + idx
+    }
+  }
+
+  call Merge.MergeSortBamFiles as MergeBam {
+    input:
+      bam_inputs = STARsoloFastq.bam_output,
+      output_bam_filename = output_bam_basename + ".bam",
+      sort_order = "unsorted"
+  }
   call Metrics.CalculateGeneMetrics as GeneMetrics {
     input:
-      bam_input = STARsoloFastq.bam_output
+      bam_input = MergeBam.output_bam
   }
 
   call Metrics.CalculateCellMetrics as CellMetrics {
     input:
-      bam_input = STARsoloFastq.bam_output,
+      bam_input = MergeBam.output_bam,
       original_gtf = annotations_gtf
   }
 
-  call StarAlign.ConvertStarOutput as ConvertOutputs {
+  call StarAlign.MergeStarOutput as MergeStarOutputs {
     input:
       barcodes = STARsoloFastq.barcodes,
       features = STARsoloFastq.features,
       matrix = STARsoloFastq.matrix
   }
-
+ 
   call RunEmptyDrops.RunEmptyDrops {
     input:
-      sparse_count_matrix = ConvertOutputs.sparse_counts,
-      row_index = ConvertOutputs.row_index,
-      col_index = ConvertOutputs.col_index,
+      sparse_count_matrix = MergeStarOutputs.sparse_counts,
+      row_index = MergeStarOutputs.row_index,
+      col_index = MergeStarOutputs.col_index,
       emptydrops_lower = emptydrops_lower
   }
 
@@ -126,9 +146,9 @@ workflow Optimus {
       annotation_file = annotations_gtf,
       cell_metrics = CellMetrics.cell_metrics,
       gene_metrics = GeneMetrics.gene_metrics,
-      sparse_count_matrix = ConvertOutputs.sparse_counts,
-      cell_id = ConvertOutputs.row_index,
-      gene_id = ConvertOutputs.col_index,
+      sparse_count_matrix = MergeStarOutputs.sparse_counts,
+      cell_id = MergeStarOutputs.row_index,
+      gene_id = MergeStarOutputs.col_index,
       empty_drops_result = RunEmptyDrops.empty_drops_result,
       counting_mode = counting_mode,
       pipeline_version = "Optimus_v~{pipeline_version}"
@@ -138,10 +158,10 @@ workflow Optimus {
     # version of this pipeline
     String pipeline_version_out = pipeline_version
 
-    File bam = STARsoloFastq.bam_output
-    File matrix = ConvertOutputs.sparse_counts
-    File matrix_row_index = ConvertOutputs.row_index
-    File matrix_col_index = ConvertOutputs.col_index
+    File bam = MergeBam.output_bam
+    File matrix = MergeStarOutputs.sparse_counts
+    File matrix_row_index = MergeStarOutputs.row_index
+    File matrix_col_index = MergeStarOutputs.col_index
     File cell_metrics = CellMetrics.cell_metrics
     File gene_metrics = GeneMetrics.gene_metrics
     File cell_calls = RunEmptyDrops.empty_drops_result

--- a/pipelines/skylab/optimus/example_inputs/test_optimus_full_datasets/inputs_L8TX_pbmc.json
+++ b/pipelines/skylab/optimus/example_inputs/test_optimus_full_datasets/inputs_L8TX_pbmc.json
@@ -1,0 +1,42 @@
+{
+  "Optimus.r1_fastq": [
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_A04_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_B04_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_F03_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_G03_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_H03_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_E12_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_F12_R1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_G12_R1.fastq.gz"
+  ],
+  "Optimus.r2_fastq": [
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_A04_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_B04_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_F03_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_G03_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_H03_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_E12_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_F12_R2.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_G12_R2.fastq.gz"
+  ],
+  "Optimus.i1_fastq": [
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_A04_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_B04_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_F03_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_G03_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_171026_01_H03_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_E12_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_F12_I1.fastq.gz",
+"gs://hca-dcp-sc-pipelines-test-data/referenceData/fastq/chemistry_X10_V2/L8TX/L8TX_180221_01_G12_I1.fastq.gz"
+  ],
+  "Optimus.whitelist": "gs://hca-dcp-sc-pipelines-test-data/whitelists/737K-august-2016.txt",
+  "Optimus.tar_star_reference": "gs://gcp-public-data--broad-references/hg38/v0/star/star_2.7.9a_primary_gencode_human_v27.tar", 
+  "Optimus.input_id": "8k_pbmc",
+  "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/gencode.v27.primary_assembly.annotation.gtf", 
+  "Optimus.ref_genome_fasta": "gs://gcp-public-data--broad-references/hg38/v0/GRCh38.primary_assembly.genome.fa"
+}
+
+
+
+
+

--- a/pipelines/skylab/slide_seq/SlideSeq.wdl
+++ b/pipelines/skylab/slide_seq/SlideSeq.wdl
@@ -1,0 +1,42 @@
+version 1.0
+
+import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
+
+## Copyright Broad Institute, 2021
+##
+## This WDL pipeline implements data processing for RNA with UMIs
+##
+## Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
+## For program versions, see docker containers.
+##
+## LICENSING :
+## This script is released under the WDL source code license (BSD-3) (see LICENSE in
+## https://github.com/broadinstitute/wdl). Note however that the programs it calls may
+## be subject to different licenses. Users are responsible for checking that they are
+## authorized to run all programs before running this script. Please see the docker
+## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
+## licensing information pertaining to the included programs.
+
+
+workflow SlideSeq{
+
+    String pipeline_version = "0.0.1"
+
+    input {
+        Array[File] r1_fastq
+        Array[File] r2_fastq
+        String sample_id
+
+        Int? cell_barcode_length
+        Int? umi_length
+    }
+
+    parameter_meta {
+        r1_fastq: "Array of Read 1 FASTQ files"
+        r2_fastq: "Array of Read 2 FASTQ files"
+        sample_id: "Id for the sample being processed"
+        cell_barcode_length: "Number of cell barcode base pairs in the Read 1 FASTQ"
+        umi_length: "Number of UMI base pairs in the Read 1 FASTQ"
+    }
+
+}

--- a/pipelines/skylab/slide_seq/SlideSeq.wdl
+++ b/pipelines/skylab/slide_seq/SlideSeq.wdl
@@ -25,18 +25,34 @@ workflow SlideSeq{
     input {
         Array[File] r1_fastq
         Array[File] r2_fastq
+        Array[File]? i1_fastq
         String sample_id
 
-        Int? cell_barcode_length
-        Int? umi_length
+        Int cell_barcode_length
+        Int umi_length
     }
 
     parameter_meta {
-        r1_fastq: "Array of Read 1 FASTQ files"
-        r2_fastq: "Array of Read 2 FASTQ files"
-        sample_id: "Id for the sample being processed"
+        r1_fastq: "Array of Read 1 FASTQ files - forward read, contains cell barcodes and molecule barcodes"
+        r2_fastq: "Array of Read 2 FASTQ files - reverse read, contains cDNA fragment generated from captured mRNA"
+        i1_fastq: "(optional) Array of i1 FASTQ files - index read, for demultiplexing of multiple samples on one flow cell."
+        sample_id: "Name of sample matching this file, inserted into read group header"
         cell_barcode_length: "Number of cell barcode base pairs in the Read 1 FASTQ"
         umi_length: "Number of UMI base pairs in the Read 1 FASTQ"
+    }
+
+    call FastqProcessing.FastqProcessingSlidSeq as SplitFastq {
+        input:
+            r1_fastq = r1_fastq,
+            r2_fastq = r2_fastq,
+            i1_fastq = i1_fastq,
+            umi_length = umi_length,
+            cell_barcode_length = cell_barcode_length,
+            sample_id = sample_id
+    }
+
+    output {
+
     }
 
 }

--- a/pipelines/skylab/slide_seq/SlideSeq.wdl
+++ b/pipelines/skylab/slide_seq/SlideSeq.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
-## Copyright Broad Institute, 2021
+## Copyright Broad Institute, 2022
 ##
 ## This WDL pipeline implements data processing for RNA with UMIs
 ##

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task FastqProcessing {
+task FastqProcessingOptimus {
   input {
     Array[File] r1_fastq
     Array[File] r2_fastq
@@ -9,15 +9,12 @@ task FastqProcessing {
     String chemistry
     String sample_id
 
-    # runtime values
+
+    # Runtime attributes
     String docker = "quay.io/kishorikonwar0/fastqprocess:1.0.0"
-
-    Int machine_mem_mb = 40000
     Int cpu = 16   
-    #TODO decided cpu
-    # estimate that bam is approximately equal in size to fastq, add 20% buffer
+    Int machine_mb = 40000
     Int disk = ceil(size(r1_fastq, "GiB")*3 + size(r2_fastq, "GiB")*3) + 500
-
     Int preemptible = 3
   }
 
@@ -32,11 +29,6 @@ task FastqProcessing {
     whitelist: "10x genomics cell barcode whitelist"
     chemistry: "chemistry employed, currently can be tenX_v2 or tenX_v3, the latter implies NO feature barcodes"
     sample_id: "name of sample matching this file, inserted into read group header"
-    docker: "(optional) the docker image containing the runtime environment for this task"
-    machine_mem_mb: "(optional) the amount of memory (MiB) to provision for this task"
-    cpu: "(optional) the number of cpus to provision for this task"
-    disk: "(optional) the amount of disk space (GiB) to provision for this task"
-    preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
   }
 
   command {
@@ -47,17 +39,17 @@ task FastqProcessing {
         import shutil
         import gzip
         import re
-         
+        
         iscompressed = True
         with gzip.open(filename, 'rt') as fin:
-           try:
-               _ = fin.readline()
-           except:
-               iscompressed = False
+          try:
+              _ = fin.readline()
+          except:
+              iscompressed = False
 
         basename = re.sub(r'.gz$', '', filename)
         basename = re.sub(r'.fastq$', '', basename)
- 
+
         if iscompressed:
             # if it is already compressed then add an extension .fastq.gz
             newname = basename + ".fastq.gz" 
@@ -71,7 +63,7 @@ task FastqProcessing {
 
         return newname
     optstring = ""
-     
+
     r1_fastqs = [ "${sep='", "' r1_fastq}" ]
     r2_fastqs = [ "${sep='", "' r2_fastq}" ]
     i1_fastqs = [ "${sep='", "' i1_fastq}" ]
@@ -111,9 +103,116 @@ task FastqProcessing {
   
   runtime {
     docker: docker
-    memory: "${machine_mem_mb} MiB"
-    disks: "local-disk ${disk} HDD"
     cpu: cpu
+    memory: "${machine_mb} MiB"
+    disks: "local-disk ${disk} HDD"
+    preemptible: preemptible
+  }
+  
+  output {
+    Array[File] fastq_R1_output_array = glob("fastq_R1_*")
+    Array[File] fastq_R2_output_array = glob("fastq_R2_*")
+  }
+}
+
+task FastqProcessingSlidSeq {
+
+  input {
+    Array[File] r1_fastq
+    Array[File] r2_fastq
+    Array[File]? i1_fastq
+    Int umi_length
+    Int cell_barcode_length
+    String sample_id
+
+
+    # Runtime attributes
+    String docker =  "quay.io/kishorikonwar0/fastqprocess:1.0.0"
+    Int cpu = 16   
+    Int machine_mb = 40000
+    Int disk = ceil(size(r1_fastq, "GiB")*3 + size(r2_fastq, "GiB")*3) + 500
+    Int preemptible = 3
+  }
+
+  meta {
+    description: "Converts a set of fastq files to unaligned bam file, also corrects barcodes and partitions the alignments by barcodes. Allows for variable barcode and umi lengths as input"
+  }
+
+  parameter_meta {
+        r1_fastq: "Array of Read 1 FASTQ files - forward read, contains cell barcodes and molecule barcodes"
+        r2_fastq: "Array of Read 2 FASTQ files - reverse read, contains cDNA fragment generated from captured mRNA"
+        i1_fastq: "(optional) Array of i1 FASTQ files - index read, for demultiplexing of multiple samples on one flow cell."
+        sample_id: "Name of sample matching this file, inserted into read group header"
+        cell_barcode_length: "Number of cell barcode base pairs in the Read 1 FASTQ"
+        umi_length: "Number of UMI base pairs in the Read 1 FASTQ"
+    
+  }
+
+  command {
+
+    command {
+    set -e
+
+    FASTQS=$(python3 <<CODE
+    def rename_file(filename):
+        import shutil
+        import gzip
+        import re
+        
+        iscompressed = True
+        with gzip.open(filename, 'rt') as fin:
+          try:
+              _ = fin.readline()
+          except:
+              iscompressed = False
+
+        basename = re.sub(r'.gz$', '', filename)
+        basename = re.sub(r'.fastq$', '', basename)
+
+        if iscompressed:
+            # if it is already compressed then add an extension .fastq.gz
+            newname = basename + ".fastq.gz" 
+        else: 
+            # otherwis, add just the .fastq extension
+            newname = basename + ".fastq"
+
+        if filename != newname:
+            # safe to rename since the old and the new names are different
+            shutil.move(filename, newname)
+
+        return newname
+    optstring = ""
+
+    r1_fastqs = [ "${sep='", "' r1_fastq}" ]
+    r2_fastqs = [ "${sep='", "' r2_fastq}" ]
+    i1_fastqs = [ "${sep='", "' i1_fastq}" ]
+    for fastq in r1_fastqs:
+        if fastq.strip(): 
+            optstring += " --R1 " + rename_file(fastq)
+    for fastq in r2_fastqs:
+        if fastq.strip(): 
+            optstring += " --R2 " + rename_file(fastq)
+    for fastq in i1_fastqs:
+        if fastq.strip(): 
+            optstring += " --I1 " + rename_file(fastq)
+    print(optstring)
+    CODE)
+
+
+    fastqprocess \
+        --bam-size 30.0 \
+        --barcode-length "~{cell_barcode_length}" \
+        --umi-length "~{umi_length}" \
+        --sample-id "~{sample_id}" \
+        --output-format FASTQ \
+        $FASTQS
+  }
+
+  runtime {
+    docker: docker
+    cpu: cpu
+    memory: "${machine_mb} MiB"
+    disks: "local-disk ${disk} HDD"
     preemptible: preemptible
   }
   

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -39,7 +39,7 @@ task FastqProcessingOptimus {
         import shutil
         import gzip
         import re
-        
+
         iscompressed = True
         with gzip.open(filename, 'rt') as fin:
           try:
@@ -158,7 +158,7 @@ task FastqProcessingSlidSeq {
         import shutil
         import gzip
         import re
-        
+
         iscompressed = True
         with gzip.open(filename, 'rt') as fin:
           try:

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -10,7 +10,7 @@ task FastqProcessing {
     String sample_id
 
     # runtime values
-    String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.12"
+    String docker = "quay.io/kishorikonwar0/fastqprocess:1.0.0"
 
     Int machine_mem_mb = 40000
     Int cpu = 16   
@@ -100,12 +100,13 @@ task FastqProcessing {
     fi
 
     fastqprocess \
-        --bam-size 1.0 \
+        --bam-size 30.0 \
         --barcode-length 16 \
         --umi-length $UMILENGTH \
         --sample-id "~{sample_id}" \
         $FASTQS \
-        --white-list "~{whitelist}" 
+        --white-list "~{whitelist}" \
+        --output-format FASTQ
   }
   
   runtime {
@@ -117,6 +118,7 @@ task FastqProcessing {
   }
   
   output {
-    Array[File] bam_output_array = glob("subfile_*")
+    Array[File] fastq_R1_output_array = glob("fastq_R1_*")
+    Array[File] fastq_R2_output_array = glob("fastq_R2_*")
   }
 }

--- a/tasks/skylab/MergeSortBam.wdl
+++ b/tasks/skylab/MergeSortBam.wdl
@@ -57,3 +57,6 @@ task MergeSortBamFiles {
     File output_bam = output_bam_filename
   }
 }
+
+
+

--- a/tasks/skylab/MergeSortBam.wdl
+++ b/tasks/skylab/MergeSortBam.wdl
@@ -57,6 +57,3 @@ task MergeSortBamFiles {
     File output_bam = output_bam_filename
   }
 }
-
-
-

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -420,7 +420,7 @@ task MergeStarOutput {
     declare -a features_files=(~{sep=' ' features})
     declare -a matrix_files=(~{sep=' ' matrix})
 
-   # create the  compresed raw count matrix with the counts, gene names and the barcodes
+   # create the  compressed raw count matrix with the counts, gene names and the barcodes
     python3 /tools/create-merged-npz-output.py \
         --barcodes $barcodes_files \
         --features $features_files \

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -384,3 +384,61 @@ task ConvertStarOutput {
     File sparse_counts = "sparse_counts.npz"
   }
 }
+
+
+task MergeStarOutput {
+
+  input {
+    Array[File] barcodes
+    Array[File] features
+    Array[File] matrix
+
+    #runtime values
+    #String docker = "quay.io/kishorikonwar/secondary-analysis-python3-scientific:utils2"
+    String docker = "quay.io/kishorikonwar0/mergestaroutput:1.0.0"
+    Int machine_mem_mb = 8250
+    Int cpu = 1
+    Int disk = ceil(size(matrix, "Gi") * 2) + 10
+    Int preemptible = 3
+  }
+
+  meta {
+    description: "Create three files as .npy,  .npy and .npz for numpy array and scipy csr matrix for the barcodes, gene names and the count matrix by merging multiple  STARSolo count matrices (mtx format)."
+  }
+
+  parameter_meta {
+    docker: "(optional) the docker image containing the runtime environment for this task"
+    machine_mem_mb: "(optional) the amount of memory (MiB) to provision for this task"
+    cpu: "(optional) the number of cpus to provision for this task"
+    disk: "(optional) the amount of disk space (GiB) to provision for this task"
+    preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
+  }
+
+  command {
+    set -e
+    declare -a barcodes_files=(~{sep=' ' barcodes})
+    declare -a features_files=(~{sep=' ' features})
+    declare -a matrix_files=(~{sep=' ' matrix})
+
+   # create the  compresed raw count matrix with the counts, gene names and the barcodes
+    python3 /tools/create-merged-npz-output.py \
+        --barcodes $barcodes_files \
+        --features $features_files \
+        --matrix $matrix_files
+
+  }
+
+  runtime {
+    docker: docker
+    memory: "${machine_mem_mb} MiB"
+    disks: "local-disk ${disk} HDD"
+    cpu: cpu
+    preemptible: preemptible
+  }
+
+  output {
+    File row_index = "sparse_counts_row_index.npy"
+    File col_index = "sparse_counts_col_index.npy"
+    File sparse_counts = "sparse_counts.npz"
+  }
+}


### PR DESCRIPTION
First commit into the Slide seq feature branch.

This incorporates the scalable Optimus changes from [GL-1879](https://github.com/broadinstitute/warp/tree/gl-1789-scalable-optimus) and applies them to Fastq processing for SlideSeq.

Its pretty much the same except it allows for variable cell-barcode and umi-lengths as input rather than determined by the 10x chemistry. 