### PR TITLE
GL-1809. Temporarily revert changes to use 'public' metadata

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,6 +1,7 @@
 # 1.0.2
-2022-02-18 (Date of Last Commit)
+2022-02-24 (Date of Last Commit)
 
+* Temporarily updated to use reference and annotation files where Terra can access them.
 * Updated to use publicly-accessible reference and annotation files.
 * Updated ribosomal intervals to include unlocalized scaffolds in the UCSC naming convention to match our reference (and renamed the file to reflect the fact that the header is not the standard GRCh38)
 * Updated the STAR command line arguments, as follows:

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -38,15 +38,15 @@ workflow BroadInternalRNAWithUMIs {
     File vault_token_path
   }
 
-  File ref = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta"
-  File refIndex = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai"
-  File refDict = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict"
-  File haplotype_database_file = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.haplotype_database.txt"
-  File refFlat = if (reference_build == "hg19") then "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt"
-  File starIndex = if (reference_build == "hg19") then "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz"
-  File gtf = if (reference_build == "hg19") then "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf"
-  File ribosomalIntervals = if (reference_build == "hg19") then "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list"
-  File exonBedFile = if (reference_build == "hg19") then "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed" else "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  File ref = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta" else "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta"
+  File refIndex = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai" else "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai"
+  File refDict = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict" else "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict"
+  File haplotype_database_file = if (reference_build == "hg19") then "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt" else "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.haplotype_database.txt"
+  File refFlat = if (reference_build == "hg19") then "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt" else "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt"
+  File starIndex = if (reference_build == "hg19") then "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz" else "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz"
+  File gtf = if (reference_build == "hg19") then "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf" else "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf"
+  File ribosomalIntervals = if (reference_build == "hg19") then "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list" else "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list"
+  File exonBedFile = if (reference_build == "hg19") then "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed" else "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 
   parameter_meta {
     reference_build: "String used to define the reference genome build; should be set to 'hg19' or 'hg38'"

--- a/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg19.fastqs.plumbing.json
+++ b/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg19.fastqs.plumbing.json
@@ -11,12 +11,12 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg19.plumbing.json
+++ b/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg19.plumbing.json
@@ -5,12 +5,12 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-HFCB1_100ng_.65X_A3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg38.fastqs.plumbing.json
+++ b/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg38.fastqs.plumbing.json
@@ -11,12 +11,12 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg38.plumbing.json
+++ b/pipelines/broad/rna_seq/test_inputs/Plumbing/SM-HFCB1_100ng_.65X_A3.hg38.plumbing.json
@@ -5,12 +5,12 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-HFCB1_100ng_.65X_A3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg19.fastqs.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg19.fastqs.json
@@ -11,13 +11,13 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg19.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg19.json
@@ -5,13 +5,13 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-HFCB1_100ng_.65X_A3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg38.fastqs.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg38.fastqs.json
@@ -11,12 +11,12 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg38.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-HFCB1_100ng_.65X_A3.hg38.json
@@ -5,12 +5,12 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-HFCB1_100ng_.65X_A3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg19.fastqs.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg19.fastqs.json
@@ -11,13 +11,13 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg19.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg19.json
@@ -5,13 +5,13 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-K4Y2X_350ng_.65X_D3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/hg19/v0/star/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/hg19/v0/annotation/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg19/STAR2.7.10a_genome_hg19_noALT_noHLA_noDecoy_v19_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.genes.v7.collapsed_only.patched_contigs.gtf",
   "RNAWithUMIsPipeline.ref": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta",
   "RNAWithUMIsPipeline.refIndex": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai",
   "RNAWithUMIsPipeline.refDict": "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/hg19/v0/annotation/Homo_sapiens_assembly19.rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/hg19/v0/annotation/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg19/Homo_sapiens_assembly19.rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg19/gencode.v19.hg19.insert_size_intervals_geq1000bp.bed"
 
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg38.fastqs.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg38.fastqs.json
@@ -11,12 +11,12 @@
   "RNAWithUMIsPipeline.platform_unit": "barcode1",
   "RNAWithUMIsPipeline.read_group_name": "RG1",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }

--- a/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg38.json
+++ b/pipelines/broad/rna_seq/test_inputs/Scientific/SM-K4Y2X_350ng_.65X_D3.hg38.json
@@ -5,12 +5,12 @@
 
   "RNAWithUMIsPipeline.output_basename": "SM-K4Y2X_350ng_.65X_D3",
 
-  "RNAWithUMIsPipeline.starIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/star/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
-  "RNAWithUMIsPipeline.gtf": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.annotation_collapsed_only.gtf",
-  "RNAWithUMIsPipeline.ref": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
-  "RNAWithUMIsPipeline.refIndex": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
-  "RNAWithUMIsPipeline.refDict": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
-  "RNAWithUMIsPipeline.refFlat": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/hg38_GENCODE_v34_refFlat.txt",
-  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode_v34_rRNA.interval_list",
-  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-references/Homo_sapiens_assembly38_noALT_noHLA_noDecoy/v0/annotation/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
+  "RNAWithUMIsPipeline.starIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/STAR2.7.10a_genome_GRCh38_noALT_noHLA_noDecoy_v34_oh145.tar.gz",
+  "RNAWithUMIsPipeline.gtf": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.annotation_collapsed_only.gtf",
+  "RNAWithUMIsPipeline.ref": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta",
+  "RNAWithUMIsPipeline.refIndex": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.fasta.fai",
+  "RNAWithUMIsPipeline.refDict": "gs://broad-gotc-test-storage/rna_seq/hg38/Homo_sapiens_assembly38_noALT_noHLA_noDecoy.dict",
+  "RNAWithUMIsPipeline.refFlat": "gs://broad-gotc-test-storage/rna_seq/hg38/hg38_GENCODE_v34_refFlat.txt",
+  "RNAWithUMIsPipeline.ribosomalIntervals": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode_v34_rRNA.interval_list",
+  "RNAWithUMIsPipeline.exonBedFile": "gs://broad-gotc-test-storage/rna_seq/hg38/gencode.v34.GRCh38.insert_size_intervals_geq1000bp.bed"
 }


### PR DESCRIPTION
Temporarily revert changes to use 'public' metadata
The location was not publicly accessible, so reverting to temporary staging location.