### PR TITLE
Escape the double quotes in the RNAWithUMIsPipeline.changelog.md

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -4,9 +4,9 @@
 * Updated to use publicly-accessible reference and annotation files.
 * Updated ribosomal intervals to include unlocalized scaffolds in the UCSC naming convention to match our reference (and renamed the file to reflect the fact that the header is not the standard GRCh38)
 * Updated the STAR command line arguments, as follows:
-    * Add "--alignEndsProtrude 20 ConcordantPair"; to rescue the case where the insert size drops below the read length and the sequencer starts to read into the adapters.
-    * Removed "--limitSjdbInsertNsj 1200000"; the default of 1,000,000 is sufficient.
-    * Removed "--outSAMstrandField intronMotif", defaults to "None"
+    * Add \"--alignEndsProtrude 20 ConcordantPair\"; to rescue the case where the insert size drops below the read length and the sequencer starts to read into the adapters.
+    * Removed \"--limitSjdbInsertNsj 1200000\"; the default of 1,000,000 is sufficient.
+    * Removed \"--outSAMstrandField intronMotif\", defaults to \"None\"
 * Updated the RNASeQC2 insert size bed file from v26 to v34
 * Slightly reduced memory and disk usage on several tasks.
 * Standardized memory sizing.

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -2,9 +2,9 @@
 2022-02-18 (Date of Last Commit)
 
 * Updated the STAR command line arguments, as follows:
-    * Add "--alignEndsProtrude 20 ConcordantPair"; to rescue the case where the insert size drops below the read length and the sequencer starts to read into the adapters.
-    * Removed "--limitSjdbInsertNsj 1200000"; the default of 1,000,000 is sufficient.
-    * Removed "--outSAMstrandField intronMotif", defaults to "None"
+    * Add \"--alignEndsProtrude 20 ConcordantPair\"; to rescue the case where the insert size drops below the read length and the sequencer starts to read into the adapters.
+    * Removed \"--limitSjdbInsertNsj 1200000\"; the default of 1,000,000 is sufficient.
+    * Removed \"--outSAMstrandField intronMotif\", defaults to \"None\"
 * Slightly reduced memory and disk usage on several tasks.
 * Standardized memory sizing.
 


### PR DESCRIPTION
Escape the double quotes in the RNAWithUMIsPipeline.changelog.md that is breaking the release.