### PR TITLE
Fix picard-private by migrating to debian base

### DIFF
--- a/dockers/broad/arrays_picard_private/Dockerfile
+++ b/dockers/broad/arrays_picard_private/Dockerfile
@@ -1,10 +1,11 @@
-FROM frolvlad/alpine-glibc:glibc-2.33
+FROM adoptopenjdk/openjdk8:debian-slim
 
 ARG PICARD_PRIVATE_VERSION=257537c72dae29257b09bacf413505eed295ac32
 
 ENV TERM=xterm-256color \
     NO_VAULT=true \
-    ARTIFACTORY_URL=https://broadinstitute.jfrog.io/artifactory/libs-snapshot-local/org/broadinstitute/picard-private
+    ARTIFACTORY_URL=https://broadinstitute.jfrog.io/artifactory/libs-snapshot-local/org/broadinstitute/picard-private \
+    TINI_VERSION=v0.19.0
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
         PICARD_PRIVATE_VERSION=${PICARD_PRIVATE_VERSION}
@@ -13,29 +14,34 @@ WORKDIR /usr/gitc
 
 # Install dependencies
 RUN set -eux; \
-        apk --no-cache upgrade; \
-        apk add --no-cache \    
+        apt-get update; \
+        apt-get install -y \    
             bash \
             curl \ 
             findutils \
             jq \ 
-            openjdk8-jre \
             python3 \
-            tini \
             unzip \
             wget \
     ; \
-# Download picard private jar
+# Install Picard private
     curl -L ${ARTIFACTORY_URL}/${PICARD_PRIVATE_VERSION}/jars/picard-private-all-${PICARD_PRIVATE_VERSION}.jar > picard-private.jar \
     ; \
 # Download the gsutil install script
-    wget https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash -O - | bash \
-    ; \ 
+    curl -sSL https://sdk.cloud.google.com | bash \
+    ; \
 # Set up Vault
     curl -L https://releases.hashicorp.com/vault/1.0.2/vault_1.0.2_linux_amd64.zip > temp.zip; \
     unzip temp.zip; \
     rm temp.zip; \ 
-    mv vault /usr/local/bin/
+    mv vault /usr/local/bin/ \
+    ; \
+# Install tini
+    wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini; \
+    chmod +x /sbin/tini \
+    ; \
+# Clean up cached files
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set tini as default entry point
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/dockers/broad/arrays_picard_private/docker_build.sh
+++ b/dockers/broad/arrays_picard_private/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=4.1.0
+DOCKER_IMAGE_VERSION=4.1.1
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/dockers/broad/arrays_picard_private/docker_versions.tsv
+++ b/dockers/broad/arrays_picard_private/docker_versions.tsv
@@ -14,3 +14,4 @@ us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1629905256 61af9bff4587
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.0.10-1629909993 61af9bff4587783e5981a496f422ea36102482b5
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1631191359 257537c72dae29257b09bacf413505eed295ac32
 us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612 bcd01bb85df4c0876453a4b6359c19c01bd4caf4
+us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677 bcd01bb85df4c0876453a4b6359c19c01bd4caf4

--- a/tasks/broad/InternalArraysTasks.wdl
+++ b/tasks/broad/InternalArraysTasks.wdl
@@ -27,7 +27,7 @@ task GenerateEmptyVariantCallingMetricsFile {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }
@@ -73,7 +73,7 @@ task BlacklistBarcode {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }
@@ -124,7 +124,7 @@ task VcfToMercuryFingerprintJson {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -152,7 +152,7 @@ task CreateBafRegressMetricsFile {
       --OUTPUT ~{output_metrics_basefilename}
   }
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -229,7 +229,7 @@ task UploadArraysMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -278,7 +278,7 @@ task UploadEmptyArraysMetrics {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -377,7 +377,7 @@ task UpdateChipWellBarcodeIndex {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     disks: "local-disk " + disk_size + " HDD"
     memory: "3500 MiB"
     preemptible: preemptible_tries
@@ -413,7 +413,7 @@ task GetNextArraysQcAnalysisVersionNumber {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     memory: "3500 MiB"
     preemptible: preemptible_tries
   }

--- a/tasks/broad/InternalTasks.wdl
+++ b/tasks/broad/InternalTasks.wdl
@@ -117,7 +117,7 @@ task DownloadGenotypes {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     memory: "3500 MiB"
     maxRetries: select_first([max_retries, 2])
     preemptible: select_first([preemptible_tries, 3])
@@ -168,7 +168,7 @@ task UploadFingerprintToMercury {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.0-1641925612"
+    docker: "us.gcr.io/broad-arrays-prod/arrays-picard-private:4.1.1-1647006677"
     memory: "3500 MiB"
     maxRetries: select_first([max_retries, 2])
     preemptible: select_first([preemptible_tries, 3])


### PR DESCRIPTION
Had to migrate to a debian base. There was some weird stuff going on in gsutil install where it couldn't find a dynamically linked binary because it was non-musl (alpine).

Switch to debian will just be easier to maintain going forward without having to deal with annoying library linking issues.