### PR TITLE
Update TDR ingest to v1.4

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.17
-2022-07-21 (Date of Last Commit)
+2022-07-28 (Date of Last Commit)
 
-* Update TDR ingest script task and docker to remove staging bucket and specify timestamp fields
+* Update TDR ingest script task and docker to remove staging bucket, specify timestamp fields, and use merge ingest strategy
 * Specify the RSEM post-processed transcriptome bam as output
 * Dynamically allocate memory in fastp task, increase fixed memory to 8gb in RNASeQC2, and increased fixed memory to 64gb in GroupByUMI
 * Remove transcriptome bam index from output

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -64,7 +64,7 @@ workflow BroadInternalRNAWithUMIs {
     environment: "The environment (dev or prod) used for determining which service to use to retrieve Mercury fingerprints"
     vault_token_path: "The path to the vault token used for accessing the Mercury Fingerprint Store"
     tdr_dataset_uuid: "Optional string used to define the Terra Data Repo (TDR) dataset to which outputs will be ingested"
-    tdr_sample_id: "Optional string used to identify the sample being processed; this is the primary key in the TDR dataset"
+    tdr_sample_id: "Optional string used to identify the sample being processed; this must be the primary key in the TDR dataset"
   }
 
   # make sure either hg19 or hg38 is supplied as reference_build input
@@ -162,8 +162,7 @@ workflow BroadInternalRNAWithUMIs {
     call tasks.updateOutputsInTDR {
       input:
         tdr_dataset_uuid = select_first([tdr_dataset_uuid, ""]),
-        outputs_json = formatPipelineOutputs.pipeline_outputs_json,
-        sample_id = select_first([tdr_sample_id, ""])
+        outputs_json = formatPipelineOutputs.pipeline_outputs_json
     }
   }
 

--- a/tasks/broad/RNAWithUMIsTasks.wdl
+++ b/tasks/broad/RNAWithUMIsTasks.wdl
@@ -761,7 +761,7 @@ task formatPipelineOutputs {
   >>>
 
   runtime {
-    docker: "broadinstitute/horsefish:tdr_import_v1.2"
+    docker: "broadinstitute/horsefish:tdr_import_v1.4"
     cpu: cpu
     memory: "~{memory_mb} MiB"
     disks: "local-disk ~{disk_size_gb} HDD"
@@ -776,7 +776,6 @@ task updateOutputsInTDR {
   input {
     String tdr_dataset_uuid
     File outputs_json
-    String sample_id
 
     Int cpu = 1
     Int memory_mb = 2000
@@ -788,21 +787,17 @@ task updateOutputsInTDR {
     # -d dataset uuid
     # -t target table in dataset
     # -o json of data to ingest
-    # -k primary key field name
-    # -v primary key value
     # -f field to populate with timestamp at ingest (can have multiple)
     python -u /scripts/export_pipeline_outputs_to_tdr.py \
       -d "~{tdr_dataset_uuid}" \
       -t "sample" \
       -o "~{outputs_json}" \
-      -k "sample_id" \
-      -v "~{sample_id}" \
       -f "version_timestamp" \
       -f "analysis_end_time"
   >>>
 
   runtime {
-    docker: "broadinstitute/horsefish:tdr_import_v1.2"
+    docker: "broadinstitute/horsefish:tdr_import_v1.4"
     cpu: cpu
     memory: "~{memory_mb} MiB"
     disks: "local-disk ~{disk_size_gb} HDD"


### PR DESCRIPTION
using the new ingest strategy ("merge") that doesn't require us to specify the primary key value in the task