### PR TITLE
Updated a check for an empty file produced in the GetFingerprintingIntervalIndices task in JointGenotypingByChromosomePartOne.wdl.

### DIFF
--- a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.changelog.md
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.changelog.md
@@ -1,3 +1,8 @@
+# 1.4.8
+2023-04-05 (Date of Last Commit)
+
+* Updated a check for an empty file produced in the GetFingerprintingIntervalIndices task
+
 # 1.4.7
 2022-11-04 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl
@@ -5,7 +5,7 @@ import "../../../../../../tasks/broad/JointGenotypingTasks.wdl" as Tasks
 # Joint Genotyping for hg38 Exomes and Whole Genomes (has not been tested on hg19)
 workflow JointGenotypingByChromosomePartOne {
 
-  String pipeline_version = "1.4.7"
+  String pipeline_version = "1.4.8"
 
   input {
     File unpadded_intervals_file
@@ -205,8 +205,8 @@ workflow JointGenotypingByChromosomePartOne {
       haplotype_database = haplotype_database
   }
 
-  # The result of GetFingerprintingIntervalIndices with no indices is [""]
-  if (GetFingerprintingIntervalIndices.indices_to_fingerprint[0] != "") {
+  # The result of GetFingerprintingIntervalIndices with no indices is []
+  if (length(GetFingerprintingIntervalIndices.indices_to_fingerprint) > 0) {
     Array[Int] fingerprinting_indices = GetFingerprintingIntervalIndices.indices_to_fingerprint
 
     scatter (idx in fingerprinting_indices) {


### PR DESCRIPTION
Closes #767.

Note that I also searched for other instances of such a file check in the repo and didn't find any.