### PR TITLE
Fix for large Ultima samples in Single Sample pipeline

### DIFF
--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.6
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.1.5
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Imputation {
 
-  String pipeline_version = "1.1.5"
+  String pipeline_version = "1.1.6"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,8 @@
+# 2.6.16
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 2.6.15
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -23,7 +23,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Arrays {
 
-  String pipeline_version = "2.6.15"
+  String pipeline_version = "2.6.16"
 
   input {
     String chip_well_barcode

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.8
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 3.1.7
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
@@ -39,7 +39,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 # WORKFLOW DEFINITION
 workflow ExomeGermlineSingleSample {
 
-  String pipeline_version = "3.1.7"
+  String pipeline_version = "3.1.8"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.5
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update makes this pipeline more robust for large samples
+
 # 1.0.4
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl
@@ -50,7 +50,7 @@ workflow UltimaGenomicsWholeGenomeGermline {
     filtering_model_no_gt_name: "String describing the optional filtering model; default set to rf_model_ignore_gt_incl_hpol_runs"
   }
 
-  String pipeline_version = "1.0.4"
+  String pipeline_version = "1.0.5"
 
 
   References references = alignment_references.references

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.9
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 3.1.8
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -40,7 +40,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 workflow WholeGenomeGermlineSingleSample {
 
 
-  String pipeline_version = "3.1.8"
+  String pipeline_version = "3.1.9"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
@@ -1,3 +1,8 @@
+# 2.1.8
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 2.1.7
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
@@ -9,7 +9,7 @@ import "../../../../../tasks/broad/DragenTasks.wdl" as DragenTasks
 workflow VariantCalling {
 
 
-  String pipeline_version = "2.1.7"
+  String pipeline_version = "2.1.8"
 
 
   input {

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.changelog.md
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.5
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update makes this pipeline more robust to large samples
+
 # 1.0.4
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
@@ -67,7 +67,8 @@ workflow UltimaGenomicsWholeGenomeCramOnly {
       reads_per_split               = reads_per_split,
       rsq_threshold                 = rsq_threshold,
       alignment_references          = alignment_references,
-      references                    = references
+      references                    = references,
+      save_bam_file                 = save_bam_file
   }
 
   # Convert the final merged recalibrated BAM file to CRAM format
@@ -117,13 +118,6 @@ workflow UltimaGenomicsWholeGenomeCramOnly {
       flow_order                            = ExtractSampleNameFlowOrder.flow_order
   }
 
-  call Utilities.MakeOptionalOutputBam {
-    input:
-      bam_input = AlignmentAndMarkDuplicates.output_bam,
-      bai_input = AlignmentAndMarkDuplicates.output_bam_index,
-      keep_inputs = save_bam_file
-  }
-
   # Outputs that will be retained when execution is complete
   output {
     File output_cram = ConvertToCram.output_cram
@@ -155,8 +149,8 @@ workflow UltimaGenomicsWholeGenomeCramOnly {
     String id = ExtractSampleNameFlowOrder.readgroup_id
 
     #Intermediate outputs required for germline pipeline
-    File? output_bam = MakeOptionalOutputBam.optional_output_bam
-    File? output_bam_index = MakeOptionalOutputBam.optional_output_bai
+    File? output_bam = AlignmentAndMarkDuplicates.optional_output_bam
+    File? output_bam_index = AlignmentAndMarkDuplicates.optional_output_bam_index
 
     String output_safe_name = MakeSafeFilename.output_safe_name
   }

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
@@ -43,7 +43,7 @@ workflow UltimaGenomicsWholeGenomeCramOnly {
     save_bam_file: "If true, then save intermeidate ouputs used by germline pipeline (such as the output BAM) otherwise they won't be kept as outputs."
   }
 
-  String pipeline_version = "1.0.4"
+  String pipeline_version = "1.0.5"
 
   References references = alignment_references.references
 

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/test_inputs/Plumbing/NA12878.downsampled.json
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/test_inputs/Plumbing/NA12878.downsampled.json
@@ -2,9 +2,9 @@
     "UltimaGenomicsWholeGenomeCramOnly.input_cram_list": ["gs://broad-gotc-test-storage/somatic_single_sample/ugwgs/plumbing/crams/downsampled_NA12878.cram"],
     "UltimaGenomicsWholeGenomeCramOnly.base_file_name": "downsampled_NA12878",
     "UltimaGenomicsWholeGenomeCramOnly.contamination_sites": {
-        "contamination_sites_vcf": "gs://concordance/hg38/Homo_sapiens_assembly38.contam_fixed.vcf",
-        "contamination_sites_vcf_index":"gs://concordance/hg38/Homo_sapiens_assembly38.contam_fixed.vcf.idx",
-        "contamination_sites_path": "gs://concordance/hg38/verifyBamID_inputs/Homo_sapiens_assembly38.contam.cskp."
+        "contamination_sites_vcf": "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/verify_bam_id/Homo_sapiens_assembly38.contam_fixed.vcf",
+        "contamination_sites_vcf_index":"gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/verify_bam_id/Homo_sapiens_assembly38.contam_fixed.vcf.idx",
+        "contamination_sites_path": "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/verify_bam_id/Homo_sapiens_assembly38.contam.cskp."
     },
     "UltimaGenomicsWholeGenomeCramOnly.alignment_references": {
         "references": {
@@ -21,17 +21,17 @@
     },
     "UltimaGenomicsWholeGenomeCramOnly.vcf_post_processing": {
         "annotation_intervals": [
-            "gs://concordance/hg38/annotation_intervals/LCR-hs38.bed",
-            "gs://concordance/hg38/annotation_intervals/exome.twist.bed",
-            "gs://concordance/hg38/annotation_intervals/mappability.0.bed",
-            "gs://concordance/hg38/annotation_intervals/hmers_7_and_higher.bed"
+            "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/LCR-hs38.bed",
+            "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/exome.twist.bed",
+            "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/mappability.0.bed",
+            "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/hmers_7_and_higher.bed"
         ],
-        "runs_file":"gs://concordance/hg38/runs.conservative.bed",
+        "runs_file":"gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/runs.conservative.bed",
         "af_only_gnomad": "gs://gatk-best-practices/somatic-hg38/af-only-gnomad.hg38.vcf.gz",
         "af_only_gnomad_index": "gs://gatk-best-practices/somatic-hg38/af-only-gnomad.hg38.vcf.gz.tbi",
         "filter_cg_insertions": "true",
-        "filtering_blocklist_file": "gs://concordance/filtering_models/blacklist_0.5.1.pkl",
-        "training_blocklist_file": "gs://concordance/filtering_models/blacklist_ua_good_old_blacklist.h5",
+        "filtering_blocklist_file": "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/filtering_models/blacklist_0.5.1.pkl",
+        "training_blocklist_file": "gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/filtering_models/blacklist_ua_good_old_blacklist.h5",
         "exome_weight": 100,
         "exome_weight_annotation": "exome.twist",
         "max_duplication_in_reasonable_sample": "0.3",

--- a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
+++ b/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.2
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.1.1
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl
+++ b/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl
@@ -8,7 +8,7 @@ workflow BroadInternalImputation {
     meta {
         description: "Push outputs of Imputation.wdl to TDR dataset table ImputationOutputsTable and split out Imputation arrays into ImputationWideOutputsTable."
     }
-    String pipeline_version = "1.1.1"
+    String pipeline_version = "1.1.2"
     
     input {
         # inputs to wrapper task 

--- a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.changelog.md
+++ b/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.8
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.0.7
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl
+++ b/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl
@@ -9,7 +9,7 @@ workflow BroadInternalArrays {
         description: "Push outputs of Arrays.wdl to TDR dataset table ArraysOutputsTable."
     }
 
-    String pipeline_version = "1.0.7"
+    String pipeline_version = "1.0.8"
 
     input {
         # inputs to wrapper task

--- a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.changelog.md
+++ b/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.6
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update makes this pipeline more robust to large samples
+
 # 1.0.5
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
+++ b/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
@@ -6,7 +6,7 @@ import "../../../../../../../pipelines/broad/qc/CheckFingerprint.wdl" as FP
 
 workflow BroadInternalUltimaGenomics {
 
-  String pipeline_version = "1.0.5"
+  String pipeline_version = "1.0.6"
 
   input {
   

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.19
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.0.18
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -7,7 +7,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow BroadInternalRNAWithUMIs {
 
-  String pipeline_version = "1.0.18"
+  String pipeline_version = "1.0.19"
 
   input {
     # input needs to be either "hg19" or "hg38"

--- a/pipelines/broad/qc/CheckFingerprint.changelog.md
+++ b/pipelines/broad/qc/CheckFingerprint.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.10
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.0.9
 2022-09-30 (Date of Last Commit)
 

--- a/pipelines/broad/qc/CheckFingerprint.wdl
+++ b/pipelines/broad/qc/CheckFingerprint.wdl
@@ -24,7 +24,7 @@ import "../../../tasks/broad/Qc.wdl" as Qc
 
 workflow CheckFingerprint {
 
-  String pipeline_version = "1.0.9"
+  String pipeline_version = "1.0.10"
 
   input {
     File? input_vcf

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.8
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 3.1.7
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
@@ -7,7 +7,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 workflow ExomeReprocessing {
 
 
-  String pipeline_version = "3.1.7"
+  String pipeline_version = "3.1.8"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.10
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 3.1.9
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
@@ -5,7 +5,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalExomeReprocessing {
 
-  String pipeline_version = "3.1.9"
+  String pipeline_version = "3.1.10"
 
 
   input {

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,4 +1,4 @@
-# 2.1.9
+# 2.1.10
 2022-09-27 (Date of Last Commit)
 
 * Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,4 +1,9 @@
 # 2.1.9
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
+# 2.1.9
 2022-09-23 (Date of Last Commit)
 
 * Updated Picard-Python Docker image in Utilities.wdl to fix vulnerabilities.

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 workflow ExternalWholeGenomeReprocessing {
 
 
-  String pipeline_version = "2.1.9"
+  String pipeline_version = "2.1.10"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.9
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 3.1.8
 2022-09-23 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 workflow WholeGenomeReprocessing {
 
-  String pipeline_version = "3.1.8"
+  String pipeline_version = "3.1.9"
 
   input {
     File? input_cram

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.9
+2022-09-27 (Date of Last Commit)
+
+* Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+
 # 1.0.8
 2022-07-29 (Date of Last Commit)
 

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl
@@ -20,7 +20,7 @@ import "../../../tasks/broad/RNAWithUMIsTasks.wdl" as tasks
 
 workflow RNAWithUMIsPipeline {
 
-  String pipeline_version = "1.0.8"
+  String pipeline_version = "1.0.9"
 
   input {
     File? bam

--- a/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl
+++ b/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl
@@ -14,6 +14,7 @@ workflow AlignmentAndMarkDuplicates {
     Float rsq_threshold
     Int reads_per_split
     String base_file_name_sub
+    Boolean save_bam_file
   }
 
   Int compression_level = 2
@@ -69,11 +70,14 @@ workflow AlignmentAndMarkDuplicates {
     input:
       input_bams          = SamToFastqAndBwaMemAndMba.output_bam,
       output_bam_basename = base_file_name_sub + ".aligned.sorted.duplicates_marked",
+      save_bam_file       = save_bam_file,
       disk_size_gb        = mapped_bam_size_local_ssd
   }
 
   output {
     File output_bam = MarkDuplicatesSpark.output_bam
     File output_bam_index = MarkDuplicatesSpark.output_bam_index
+    File? optional_output_bam = MarkDuplicatesSpark.optional_output_bam
+    File? optional_output_bam_index = MarkDuplicatesSpark.optional_output_bam_index
   }
 }

--- a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl
+++ b/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl
@@ -268,12 +268,16 @@ task MarkDuplicatesSpark {
   input {
     Array[File] input_bams
     String output_bam_basename
+    Boolean save_bam_file
     String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:UG_feature_branch_v4"
     Int disk_size_gb
     Int cpu = 32
     Int memory_mb = if 4 * ceil(size(input_bams, "MB")) / 4000 > 600000 then 300000 else 208000
     Int preemptible = 0
   }
+
+  String dummy_file_name_for_optional_output_bam = if save_bam_file then output_bam_basename + ".bam" else "path_that_does_not_exist"
+  String dummy_file_name_for_optional_output_bai = if save_bam_file then output_bam_basename + ".bam.bai" else "path_that_does_not_exist"
 
   parameter_meta {
     input_bams: {
@@ -305,6 +309,8 @@ task MarkDuplicatesSpark {
   output {
     File output_bam = "~{output_bam_basename}.bam"
     File output_bam_index = "~{output_bam_basename}.bam.bai"
+    File? optional_output_bam = "~{dummy_file_name_for_optional_output_bam}"
+    File? optional_output_bam_index = "~{dummy_file_name_for_optional_output_bai}"
   }
 }
 

--- a/tasks/broad/Utilities.wdl
+++ b/tasks/broad/Utilities.wdl
@@ -299,31 +299,3 @@ task GetValidationInputs {
   }
 
 }
-
-# If keep_inputs is true then this outputs the same file that was input, otherwise it outputs null.
-task MakeOptionalOutputBam {
-  input {
-    File bam_input
-    File bai_input
-    Boolean keep_inputs
-    Int preemptible_tries = 3
-  }
-    Int disk_size = ceil(size(bam_input, "GiB")) + 15
-    String basename = basename(bam_input, ".bam")
-  command<<<
-    if [ ~{keep_inputs} = "true" ]
-    then
-      ln -s ~{bam_input} ~{basename}.bam
-      ln -s ~{bai_input} ~{basename}.bai
-    fi
-  >>>
-  runtime {
-    docker: "ubuntu:20.04"
-    disks: "local-disk " + disk_size + " HDD"
-    preemptible: preemptible_tries
-  }
-  output {
-    File? optional_output_bam = "~{basename}.bam"
-    File? optional_output_bai = "~{basename}.bai"
-  }
-}


### PR DESCRIPTION
We've seen that large samples (80X coverage for example) run out of disk on the `MakeOptionalOutputBam` step. All that that task is doing is creating an optional File type for downstream use. It's expensive to run (it localizes the bam only to return the optional file type) so this PR folds that functionality into the previous task (MarkDuplicatesSpark). Now MarkDuplicatesSpark generates an optional output bam.

This should not change any outputs, in other words both the Germline and Somatic Ultima pipeline tests should pass without updating the truth.