### PR TITLE
Force fragment size histogram file to exist in rnaseqc output

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,8 +1,9 @@
 # 1.0.19
-2022-10-05 (Date of Last Commit)
+2022-10-11 (Date of Last Commit)
 
 * Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
 * Fixied whitespace in the BroadInternalRNAWithUMIS.wdl, this has no functional effect on the pipeline
+* Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
 
 # 1.0.18
 2022-09-30 (Date of Last Commit)

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -1,3 +1,8 @@
+#1.0.10
+2022-10-11 (Date of Last Commit)
+
+* Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
+
 # 1.0.9
 2022-09-27 (Date of Last Commit)
 

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -1,12 +1,8 @@
-#1.0.10
+# 1.0.9
 2022-10-11 (Date of Last Commit)
 
-* Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
-
-# 1.0.9
-2022-09-27 (Date of Last Commit)
-
 * Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
+* Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
 
 # 1.0.8
 2022-07-29 (Date of Last Commit)

--- a/tasks/broad/RNAWithUMIsTasks.wdl
+++ b/tasks/broad/RNAWithUMIsTasks.wdl
@@ -316,6 +316,8 @@ task rnaseqc2 {
 
   command <<<
     set -euo pipefail
+    # force fragmentSizes histogram output file to exist (even if empty)
+    touch ~{sample_id}.fragmentSizes.txt
     echo $(date +"[%b %d %H:%M:%S] Running RNA-SeQC 2")
     rnaseqc ~{genes_gtf} ~{bam_file} . -s ~{sample_id} -v --bed ~{exon_bed}
     echo "  * compressing outputs"


### PR DESCRIPTION
If there are no fragments used to generate fragment size histogram, rnaseqc does not generate a fragment size histogram file, which causes the task to fail.  This PR forces an empty file to be produced in this case, so that the task succeeds. 