### PR TITLE
Update rnaseqc to address edge case in bias metric calculations

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.19
-2022-10-12 (Date of Last Commit)
+2022-10-27 (Date of Last Commit)
 
 * Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
 * Fixied whitespace in the BroadInternalRNAWithUMIS.wdl, this has no functional effect on the pipeline
@@ -7,6 +7,7 @@
 * Updated task IngestOutputsToTDR in InternalTasks.wdl with new optional input variable. This update has no effect on this pipeline.
 * Updated task FormatArraysOutputs in InternalArrraysTasks.wdl with new docker tag to accommodate changes for BroadInternalArrays pipeline. Change has no effect on this pipeline.
 * Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
+* Update rnaseqc2 version to address bias metric edge cases
 
 # 1.0.18
 2022-09-30 (Date of Last Commit)

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -1,8 +1,9 @@
 # 1.0.9
-2022-10-11 (Date of Last Commit)
+2022-10-27 (Date of Last Commit)
 
 * Removed task MakeOptionalOutputBam in Utilities.wdl, this update has no effect on this pipeline
 * Force task rnaseqc2 to produce an empty fragment size file when rnaseqc2 does not produce this file due to insufficient data.
+* Update rnaseqc2 version to address bias metric edge cases
 
 # 1.0.8
 2022-07-29 (Date of Last Commit)

--- a/tasks/broad/RNAWithUMIsTasks.wdl
+++ b/tasks/broad/RNAWithUMIsTasks.wdl
@@ -308,7 +308,7 @@ task rnaseqc2 {
     String sample_id
     File exon_bed
 
-    String docker =  "us.gcr.io/broad-dsde-methods/ckachulis/rnaseqc:2.4.2"
+    String docker =  "gcr.io/broad-cga-aarong-gtex/rnaseqc@sha256:627feb33609357a81b5d8aadfed562d60d1292fe364aaec8c86f4d39e1e11417"
     Int cpu = 1
     Int memory_mb = 8000
     Int disk_size_gb = ceil(size(bam_file, 'GiB') + size(genes_gtf, 'GiB') + size(exon_bed, 'GiB')) + 50

--- a/verification/VerifyRNAWithUMIs.wdl
+++ b/verification/VerifyRNAWithUMIs.wdl
@@ -46,7 +46,8 @@ workflow VerifyRNAWithUMIs {
     input:
       test_bam = test_transcriptome_bam,
       truth_bam = truth_transcriptome_bam,
-      lenient_header = true
+      lenient_header = true,
+      lenient_low_mq = true
   }
 
   call VerifyTasks.CompareCompressedTextFiles as CompareGeneTpms {

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -199,6 +199,7 @@ task CompareBams {
     File test_bam
     File truth_bam
     Boolean lenient_header = false
+    Boolean lenient_low_mq = false
   }
 
   Float bam_size = size(test_bam, "GiB") + size(truth_bam, "GiB")
@@ -213,7 +214,8 @@ task CompareBams {
           ~{test_bam} \
           ~{truth_bam} \
           O=comparison.tsv \
-          LENIENT_HEADER=~{lenient_header}
+          LENIENT_HEADER=~{lenient_header} \
+          LENIENT_LOW_MQ_ALIGNMENT=~{lenient_low_mq}
   }
 
   runtime {


### PR DESCRIPTION
Addresses #842.  Issue was fixed in getzlab/rnaseqc@c426536132b7f90e108707c5e4da206097e31ad7 