### PR TITLE
Allow nested inputs in the imputation pipeline

### DIFF
--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -376,4 +376,9 @@ workflow Imputation {
     File failed_chunks = StoreChunksInfo.failed_chunks
     File n_failed_chunks = StoreChunksInfo.n_failed_chunks
   }
+
+  meta {
+    allowNestedInputs: true
+  }
+
 }


### PR DESCRIPTION
This will allow users to configure the inputs to tasks from the inputs json