### PR TITLE
upping compareBams memory to 20 gb

### DIFF
--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -215,10 +215,10 @@ task CompareBams {
 
     java -Xms~{java_memory_size}m -Xmx~{max_heap}m -jar /usr/picard/picard.jar \
     CompareSAMs \
-    ~{test_bam} \
-    ~{truth_bam} \
-    O=comparison.tsv \
-    LENIENT_HEADER=~{lenient_header}
+          ~{test_bam} \
+          ~{truth_bam} \
+          O=comparison.tsv \
+          LENIENT_HEADER=~{lenient_header}
   }
 
   runtime {

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -205,24 +205,27 @@ task CompareBams {
 
   Float bam_size = size(test_bam, "GiB") + size(truth_bam, "GiB")
   Int disk_size = ceil(bam_size * 4) + 20
+  Int memory_mb = 20000
+  Int java_memory_size = memory_mb - 1000
+  Int max_heap = memory_mb - 500
 
   command {
     set -e
     set -o pipefail
 
-    java -Xms3500m -Xmx7000m -jar /usr/picard/picard.jar \
+    java -Xms~{java_memory_size}m -Xmx~{max_heap}m -jar /usr/picard/picard.jar \
     CompareSAMs \
-          ~{test_bam} \
-          ~{truth_bam} \
-          O=comparison.tsv \
-          LENIENT_HEADER=~{lenient_header}
+    ~{test_bam} \
+    ~{truth_bam} \
+    O=comparison.tsv \
+    LENIENT_HEADER=~{lenient_header}
   }
 
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
     disks: "local-disk " + disk_size + " HDD"
     cpu: 2
-    memory: "7500 MiB"
+    memory: "${memory_mb} MiB"
     preemptible: 3
   }
 }


### PR DESCRIPTION
### Description

CompareBams has been failing with OOM errors in out Optimus scientific test. After some testing, it looks like it needs about 20 gb of memory to succeed.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
