### PR TITLE
address mb vs gb inconsistency

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,7 +1,8 @@
 # 5.6.1
-2023-01-19 (Date of Last Commit)
+2023-01-23 (Date of Last Commit)
 
 * Added "Disk" to task runtime sections to support running on Azure
+* Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 5.6.0
 2022-12-06 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -1,7 +1,8 @@
 # 2.2.17
-2023-01-19 (Date of Last Commit)
+2023-01-23 (Date of Last Commit)
 
 * Added "Disk" to task runtime sections to support running on Azure
+* Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 2.2.16
 2022-09-13 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,7 +1,8 @@
 # 1.2.15
-2023-01-19 (Date of Last Commit)
+2023-01-23 (Date of Last Commit)
 
 * Added "Disk" to task runtime sections to support running on Azure
+* Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 1.2.14
 2022-09-20 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -1,7 +1,8 @@
 # 5.1.16
-2023-01-19 (Date of Last Commit)
+2023-01-23 (Date of Last Commit)
 
 * Added "Disk" to task runtime sections to support running on Azure
+* Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 5.1.15
 2022-09-13 (Date of Last Commit)

--- a/tasks/skylab/CheckInputs.wdl
+++ b/tasks/skylab/CheckInputs.wdl
@@ -59,7 +59,7 @@ task checkOptimusInput {
     Boolean force_no_check
     Boolean count_exons
     Int disk = 1
-    Int machine_mem_mb = 1
+    Int machine_mem_mb = 1000
     Int cpu = 1
   }  
 
@@ -115,7 +115,7 @@ task checkOptimusInput {
   runtime {
     docker: "bashell/alpine-bash:latest"
     cpu: cpu
-    memory: "~{machine_mem_mb} GiB"
+    memory: "~{machine_mem_mb} MiB"
     disks: "local-disk ~{disk} HDD"
     disk: disk + " GB" # TES
   }

--- a/tasks/skylab/LoomUtils.wdl
+++ b/tasks/skylab/LoomUtils.wdl
@@ -17,7 +17,7 @@ task SmartSeq2LoomOutput {
     String pipeline_version
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18000
+    Int machine_mem_mb = 16000
     Int cpu = 4
   }
 
@@ -89,7 +89,7 @@ task OptimusLoomGeneration {
 
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18000
+    Int machine_mem_mb = 16000
     Int cpu = 4
   }
 
@@ -244,7 +244,7 @@ task SingleNucleusOptimusLoomOutput {
 
         Int preemptible = 3
         Int disk = 200
-        Int machine_mem_mb = 18000
+        Int machine_mem_mb = 16000
         Int cpu = 4
     }
 

--- a/tasks/skylab/LoomUtils.wdl
+++ b/tasks/skylab/LoomUtils.wdl
@@ -17,7 +17,7 @@ task SmartSeq2LoomOutput {
     String pipeline_version
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18
+    Int machine_mem_mb = 18000
     Int cpu = 4
   }
 
@@ -46,7 +46,7 @@ task SmartSeq2LoomOutput {
   runtime {
     docker: docker
     cpu: cpu  # note that only 1 thread is supported by pseudobam
-    memory: "~{machine_mem_mb} GiB"
+    memory: "~{machine_mem_mb} MiB"
     disks: "local-disk ~{disk} HDD"
     disk: disk + " GB" # TES
     preemptible: preemptible
@@ -89,7 +89,7 @@ task OptimusLoomGeneration {
 
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18
+    Int machine_mem_mb = 18000
     Int cpu = 4
   }
 
@@ -142,7 +142,7 @@ task OptimusLoomGeneration {
   runtime {
     docker: docker
     cpu: cpu  # note that only 1 thread is supported by pseudobam
-    memory: "~{machine_mem_mb} GiB"
+    memory: "~{machine_mem_mb} MiB"
     disks: "local-disk ~{disk} HDD"
     disk: disk + " GB" # TES
     preemptible: preemptible
@@ -167,7 +167,7 @@ task AggregateSmartSeq2Loom {
         String pipeline_version
         String docker = "us.gcr.io/broad-gotc-prod/pytools:1.0.0-1661263730"
         Int disk = 200
-        Int machine_mem_mb = 4
+        Int machine_mem_mb = 4000
         Int cpu = 1
     }
 
@@ -201,7 +201,7 @@ task AggregateSmartSeq2Loom {
     runtime {
       docker: docker
       cpu: cpu
-      memory: "~{machine_mem_mb} GiB"
+      memory: "~{machine_mem_mb} MiB"
       disks: "local-disk ~{disk} HDD"
       disk: disk + " GB" # TES
       preemptible: 3
@@ -244,7 +244,7 @@ task SingleNucleusOptimusLoomOutput {
 
         Int preemptible = 3
         Int disk = 200
-        Int machine_mem_mb = 18
+        Int machine_mem_mb = 18000
         Int cpu = 4
     }
 
@@ -281,7 +281,7 @@ task SingleNucleusOptimusLoomOutput {
     runtime {
         docker: docker
         cpu: cpu  # note that only 1 thread is supported by pseudobam
-        memory: "~{machine_mem_mb} GiB"
+        memory: "~{machine_mem_mb} MiB"
         disks: "local-disk ~{disk} HDD"
         disk: disk + " GB" # TES
         preemptible: preemptible
@@ -317,7 +317,7 @@ task SingleNucleusSmartSeq2LoomOutput {
         String pipeline_version
         Int preemptible = 3
         Int disk = 200
-        Int machine_mem_mb = 8
+        Int machine_mem_mb = 8000
         Int cpu = 4
     }
 
@@ -374,7 +374,7 @@ task SingleNucleusSmartSeq2LoomOutput {
     runtime {
         docker: docker
         cpu: cpu
-        memory: "~{machine_mem_mb} GiB"
+        memory: "~{machine_mem_mb} MiB"
         disks: "local-disk ~{disk} HDD"
         disk: disk + " GB" # TES
         preemptible: preemptible


### PR DESCRIPTION
### Description

----
The memory values labeled `machine_mem_mb` in LoomUtils.wdl were actually being specified in GiB

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
