### PR TITLE
Skylab LoomUtils.wdl task to use the MiB instead of GiB for machine_mem_mb

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.6.2
+2023-01-23 (Date of Last Commit)
+
+* Updated LoomUtils.wdl to use MiB instead of GiB for machine_mem_mb.
+
 # 5.6.1
 2023-01-19 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -56,7 +56,7 @@ workflow Optimus {
   }
 
   # version of this pipeline
-  String pipeline_version = "5.6.1"
+  String pipeline_version = "5.6.2"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.18
+2023-01-23 (Date of Last Commit)
+
+* Updated LoomUtils.wdl to use MiB instead of GiB for machine_mem_mb.
+
 # 2.2.17
 2023-01-19 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2 {
       Boolean paired_end
   }
   # Version of this pipeline
-  String pipeline_version = "2.2.17"
+  String pipeline_version = "2.2.18"
 
   if (false) {
      String? none = "None"

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 1.2.16
+2023-01-23 (Date of Last Commit)
+
+* Updated LoomUtils.wdl to use MiB instead of GiB for machine_mem_mb.
+
 # 1.2.15
 2023-01-19 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.2.15"
+  String pipeline_version = "1.2.16"
 
   if (false) {
      String? none = "None"

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 5.1.17
+2023-01-23 (Date of Last Commit)
+
+* Updated LoomUtils.wdl to use MiB instead of GiB for machine_mem_mb.
+
 # 5.1.16
 2023-01-19 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -36,7 +36,7 @@ workflow SmartSeq2SingleSample {
   }
   
   # version of this pipeline
-  String pipeline_version = "5.1.16"
+  String pipeline_version = "5.1.17"
 
   parameter_meta {
     genome_ref_fasta: "Genome reference in fasta format"

--- a/tasks/skylab/LoomUtils.wdl
+++ b/tasks/skylab/LoomUtils.wdl
@@ -17,7 +17,7 @@ task SmartSeq2LoomOutput {
     String pipeline_version
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18
+    Int machine_mem_mb = 8000
     Int cpu = 4
   }
 
@@ -46,7 +46,7 @@ task SmartSeq2LoomOutput {
   runtime {
     docker: docker
     cpu: cpu  # note that only 1 thread is supported by pseudobam
-    memory: "~{machine_mem_mb} GiB"
+    memory: "~{machine_mem_mb} MiB"
     disks: "local-disk ~{disk} HDD"
     disk: disk + " GB" # TES
     preemptible: preemptible
@@ -89,7 +89,7 @@ task OptimusLoomGeneration {
 
     Int preemptible = 3
     Int disk = 200
-    Int machine_mem_mb = 18
+    Int machine_mem_mb = 8000
     Int cpu = 4
   }
 
@@ -142,7 +142,7 @@ task OptimusLoomGeneration {
   runtime {
     docker: docker
     cpu: cpu  # note that only 1 thread is supported by pseudobam
-    memory: "~{machine_mem_mb} GiB"
+    memory: "~{machine_mem_mb} MiB"
     disks: "local-disk ~{disk} HDD"
     disk: disk + " GB" # TES
     preemptible: preemptible
@@ -167,7 +167,7 @@ task AggregateSmartSeq2Loom {
         String pipeline_version
         String docker = "us.gcr.io/broad-gotc-prod/pytools:1.0.0-1661263730"
         Int disk = 200
-        Int machine_mem_mb = 4
+        Int machine_mem_mb = 4000
         Int cpu = 1
     }
 
@@ -201,7 +201,7 @@ task AggregateSmartSeq2Loom {
     runtime {
       docker: docker
       cpu: cpu
-      memory: "~{machine_mem_mb} GiB"
+      memory: "~{machine_mem_mb} MiB"
       disks: "local-disk ~{disk} HDD"
       disk: disk + " GB" # TES
       preemptible: 3
@@ -244,7 +244,7 @@ task SingleNucleusOptimusLoomOutput {
 
         Int preemptible = 3
         Int disk = 200
-        Int machine_mem_mb = 18
+        Int machine_mem_mb = 8000
         Int cpu = 4
     }
 
@@ -281,7 +281,7 @@ task SingleNucleusOptimusLoomOutput {
     runtime {
         docker: docker
         cpu: cpu  # note that only 1 thread is supported by pseudobam
-        memory: "~{machine_mem_mb} GiB"
+        memory: "~{machine_mem_mb} MiB"
         disks: "local-disk ~{disk} HDD"
         disk: disk + " GB" # TES
         preemptible: preemptible
@@ -317,7 +317,7 @@ task SingleNucleusSmartSeq2LoomOutput {
         String pipeline_version
         Int preemptible = 3
         Int disk = 200
-        Int machine_mem_mb = 8
+        Int machine_mem_mb = 8000
         Int cpu = 4
     }
 
@@ -374,7 +374,7 @@ task SingleNucleusSmartSeq2LoomOutput {
     runtime {
         docker: docker
         cpu: cpu
-        memory: "~{machine_mem_mb} GiB"
+        memory: "~{machine_mem_mb} MiB"
         disks: "local-disk ~{disk} HDD"
         disk: disk + " GB" # TES
         preemptible: preemptible


### PR DESCRIPTION
### Description

_The variable name machine_mem_mb was used as GiB input. It wouldn't make a problem with the default settings but if the user wanted to run the task with larger memory requirements, the resource requests were denied by the cloud.


----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ X ] If you made a changelog update, did you update the pipeline version number?
