### PR TITLE
Add input_id to cell metrics and gene metrics outputs of Optimus

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.6.2
+2023-02-07 (Date of Last Commit)
+
+* Prepended the input_id to the name of the output file in both the CalculateCellMetrics and CalculateGeneMetrics tasks in the Metrics.wdl.
+
 # 5.6.1
 2023-01-23 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -119,14 +119,16 @@ workflow Optimus {
   call Metrics.CalculateGeneMetrics as GeneMetrics {
     input:
       bam_input = MergeBam.output_bam,
-      mt_genes = mt_genes
+      mt_genes = mt_genes,
+      input_id = input_id
   }
 
   call Metrics.CalculateCellMetrics as CellMetrics {
     input:
       bam_input = MergeBam.output_bam,
       mt_genes = mt_genes,
-      original_gtf = annotations_gtf
+      original_gtf = annotations_gtf,
+      input_id = input_id
   }
 
   call StarAlign.MergeStarOutput as MergeStarOutputs {

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -56,7 +56,7 @@ workflow Optimus {
   }
 
   # version of this pipeline
-  String pipeline_version = "5.6.1"
+  String pipeline_version = "5.6.2"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays

--- a/tasks/skylab/Metrics.wdl
+++ b/tasks/skylab/Metrics.wdl
@@ -5,6 +5,7 @@ task CalculateCellMetrics {
     File bam_input
     File original_gtf
     File? mt_genes
+    String input_id
 
     # runtime values
     String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1670337956"
@@ -68,7 +69,7 @@ task CalculateCellMetrics {
   }
   
   output {
-    File cell_metrics = "cell-metrics.csv.gz"
+    File cell_metrics = "~{input_id}.cell-metrics.csv.gz"
   }
 }
 
@@ -76,6 +77,7 @@ task CalculateGeneMetrics {
   input {
     File bam_input
     File? mt_genes
+    String input_id
     # runtime values
     String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1670337956"
     Int machine_mem_mb = 8000
@@ -128,6 +130,6 @@ task CalculateGeneMetrics {
   }
 
   output {
-    File gene_metrics = "gene-metrics.csv.gz"
+    File gene_metrics = "~{input_id}.gene-metrics.csv.gz"
   }
 }

--- a/tasks/skylab/Metrics.wdl
+++ b/tasks/skylab/Metrics.wdl
@@ -44,7 +44,7 @@ task CalculateCellMetrics {
 
     TagSort --bam-input ~{bam_input} \
     --gtf-file annotation.gtf \
-    --metric-output cell-metrics.csv \
+    --metric-output "~{input_id}.cell-metrics.csv" \
     --compute-metric \
     --metric-type cell \
     --barcode-tag CB \
@@ -55,7 +55,7 @@ task CalculateCellMetrics {
     --nthreads ${cpu} \
     ~{"--mitochondrial-gene-names-filename " + mt_genes}
 
-    gzip cell-metrics.csv
+    gzip ~{input_id}.cell-metrics.csv
   }
 
 
@@ -105,7 +105,7 @@ task CalculateGeneMetrics {
     mkdir temp
 
     TagSort --bam-input ~{bam_input} \
-    --metric-output gene-metrics.csv \
+    --metric-output "~{input_id}.gene-metrics.csv" \
     --compute-metric \
     --metric-type gene \
     --gene-tag GX \
@@ -116,7 +116,7 @@ task CalculateGeneMetrics {
     --nthreads ${cpu} \
     ~{"--mitochondrial-gene-names-filename " + mt_genes}
 
-    gzip gene-metrics.csv
+    gzip ~{input_id}.gene-metrics.csv
 
   }
 


### PR DESCRIPTION
### Description

When NeMO transfers files from Optimus runs, they save all of them in one folder and our metrics outputs are not named by the sample ids which make it overwritten.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [X] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [x] If you made a changelog update, did you update the pipeline version number?
