### PR TITLE
Update warp-tools docker version

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,10 +1,11 @@
 # 5.7.0
-2023-02-07 (Date of Last Commit)
+2023-02-16 (Date of Last Commit)
 
 * Changed the chemistry input to an int tenx_chemistry_version that accepts either 2 or 3.
 * Added new whitelist_v2 and whitelist_v3 inputs that are set to a public references and selected based on chemistry.
 * Added new checks to the checkOptimusInput task to verify that the chemistry is either v2 or v3.
 * Added new checks to the checkOptimusInput that verify the read1 FASTQ is the correct chemistry based on read length; these checks can be ignored with new boolean input ignore_r1_read_length. 
+* Updated warp-tools docker version in FastqProcessing.wdl and Metrics.wdl due to previous bug fix (broadinstitute/warp-tools#18). The issue was integer division that caused the percent of mitochondrial molecules to always be calculated as zero.
 
 # 5.6.2
 2023-02-07 (Date of Last Commit)

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -10,7 +10,7 @@ task FastqProcessing {
     String sample_id
 
     #using the latest build of warp-tools in GCR
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1670337956"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
     #runtime values
     Int machine_mem_mb = 40000
     Int cpu = 16   

--- a/tasks/skylab/Metrics.wdl
+++ b/tasks/skylab/Metrics.wdl
@@ -8,7 +8,7 @@ task CalculateCellMetrics {
     String input_id
 
     # runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1670337956"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
     Int machine_mem_mb = 8000
     Int cpu = 4
     Int disk = ceil(size(bam_input, "Gi") * 4) + ceil((size(original_gtf, "Gi") * 3)) 
@@ -79,7 +79,7 @@ task CalculateGeneMetrics {
     File? mt_genes
     String input_id
     # runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1670337956"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
     Int machine_mem_mb = 8000
     Int cpu = 4
     Int disk = ceil(size(bam_input, "Gi") * 4) 


### PR DESCRIPTION
Updated the warp-tools docker version in FastqProcessing.wdl and Metrics.wdl. 

This update was required due to bug fix in a recent pull request in warp-tools (https://github.com/broadinstitute/warp-tools/pull/18). The issue was integer division that caused the percent of mitochondrial molecules to always be calculated as zero.

As a result, a new version of the warp-tools docker was built and pushed into gcr. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
