### PR TITLE
install matplotlib<3.7 to fix scanpy

### DIFF
--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -268,7 +268,7 @@ task CompareLooms {
 
   command <<<
   set -e
-  pip3 install matplotlib<3.7 scanpy loompy numpy pandas
+  pip3 install 'matplotlib<3.7' scanpy loompy numpy pandas
 
   python3 <<CODE
   import sys

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -268,7 +268,7 @@ task CompareLooms {
 
   command <<<
   set -e
-  pip3 install scanpy loompy numpy pandas 
+  pip3 install matplotlib<3.7 scanpy loompy numpy pandas
 
   python3 <<CODE
   import sys


### PR DESCRIPTION
### Description

The latest version of scanpy needs an older version of matplotlib

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
