### PR TITLE
fix spacing in docktstore yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -103,6 +103,6 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipelines/skylab/build_indices/BuildIndices.wdl
 
-- name: SlideSeq
+  - name: SlideSeq
     subclass: WDL
     primaryDescriptorPath: /pipelines/skylab/slideseq/SlideSeq.wdl


### PR DESCRIPTION
### Description

Dockstore isnt parsing the yml because of spacing issues: 
```User dsde-jenkins: Error handling push event for repository broadinstitute/warp and reference refs/tags/SlideSeq_develop
Error reading .dockstore.yml: while parsing a block mapping
 in 'string', line 1, column 1:
    version: 1.2
    ^
expected <block end>, but found '-'
 in 'string', line 106, column 1:
    - name: SlideSeq
    ^

Terminated processing of .dockstore.yml.
```
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
