### PR TITLE
Updating docker in UltimaJointGenotyping pipeline

### DIFF
--- a/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.changelog.md
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.changelog.md
@@ -1,3 +1,9 @@
+# 1.1.2
+2023-03-01 (Date of Last Commit)
+
+* Updated version of Ultima's variant calling package which is used to choose a threshold for filtering by mesauring F1 against a truth set
+* Update includes a bug fix in concordance measurement that incorrectly discounted variants with wrong allele called
+
 # 1.1.1
 2022-11-29 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl
@@ -11,7 +11,7 @@ import "../../../../../../tasks/broad/UltimaGenomicsGermlineFilteringThreshold.w
 # For choosing a filtering threshold (where on the ROC curve to filter) a sample with truth data is required.
 workflow UltimaGenomicsJointGenotyping {
 
-  String pipeline_version = "1.1.1"
+  String pipeline_version = "1.1.2"
 
   input {
     File unpadded_intervals_file

--- a/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl
+++ b/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl
@@ -143,7 +143,7 @@ task ExtractSample {
 task FilterSampleVCF{
     input{
         File input_vcf
-        String docker = "gcr.io/terra-project-249020/jukebox_vc:test_jc_optimize_3d7509"
+        String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:UG_vc_0.8.1_399932"
 
         Int disk_size_gb = ceil((size(input_vcf, "GiB"))) + 30
     }
@@ -179,7 +179,7 @@ task FilterSymbolicAlleles {
         String base_file_name
         File input_vcf
         File input_vcf_index
-        String docker = "gcr.io/terra-project-249020/jukebox_vc:test_jc_optimize_3d7509"
+        String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:UG_vc_0.8.1_399932"
     }
 
     String output_vcf_name = "~{base_file_name}" + ".vcf.gz"
@@ -233,7 +233,7 @@ task CompareToGroundTruth {
     String flow_order
     Array[File] annotation_intervals
     Int disk_size
-    String docker = "gcr.io/terra-project-249020/jukebox_vc:test_jc_optimize_3d7509"
+    String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:UG_vc_0.8.1_399932"
   }
 
   String used_flow_order = (if flow_order=="" then "TACG" else flow_order)
@@ -289,7 +289,7 @@ task EvaluateResults {
     File h5_input
     String base_file_name
     Int disk_size
-    String docker = "gcr.io/terra-project-249020/jukebox_vc:test_jc_optimize_3d7509"
+    String docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:UG_vc_0.8.1_399932"
     String score_key
   }
   command <<<
@@ -314,7 +314,7 @@ task EvaluateResults {
   }
   output {
     File eval_report_h5 = "~{base_file_name}.report.h5"
-    File thresholds_report = "~{base_file_name}.report.thresholds.txt"
+    File thresholds_report = "~{base_file_name}.report.thresholds.csv"
   }
 }
 


### PR DESCRIPTION
This update addresses #922. The update of this docker image changes the subworkflow that finds a filtering threshold by optimizing the F1 score on a single truth sample. The outputs of the pipeline change only in the filtering threshold and we have validated that the results are within an acceptable range of difference on the Scientific test results. Therefore, the truth for both the Plumbing and Scientific tests will need to be updated for tests to pass on this branch.