### PR TITLE
fix double quotes in changelogs to match master

### DIFF
--- a/pipelines/skylab/build_indices/BuildIndices.changelog.md
+++ b/pipelines/skylab/build_indices/BuildIndices.changelog.md
@@ -6,7 +6,7 @@
 # 2.0.1
 2023-01-19 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 
 # 2.0.0
 

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -26,7 +26,7 @@
 # 5.6.1
 2023-01-23 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 * Updated the emptyDrops container to address concerns outlined in #772 - avoiding the usage of the root directory inside the container. This also includes some optimizations: moved image to GCR instead of Quay, conformed to (most) of our docker style guideline, build time decreased to 1 hour from 1.5-2 hours, and the image size reduced to 1.5GB from 3GB.
 * EmptyDrops container has been upgraded to use R 4.2.2 and BiocManager 3.16
 * Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput

--- a/pipelines/skylab/scATAC/scATAC.changelog.md
+++ b/pipelines/skylab/scATAC/scATAC.changelog.md
@@ -1,7 +1,7 @@
 # 1.3.1
 2023-01-19 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 
 # 1.3.0
 2022-09-23 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -6,7 +6,7 @@
 # 2.2.17
 2023-01-23 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 * Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 2.2.16

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -17,7 +17,7 @@
 # 1.2.15
 2023-01-23 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 * Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 1.2.14

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -6,7 +6,7 @@
 # 5.1.16
 2023-01-23 (Date of Last Commit)
 
-* Added "Disk" to task runtime sections to support running on Azure
+* Added 'Disk' to task runtime sections to support running on Azure
 * Addressed mb/gb memory specification inconsistencies in LoomUtils and CheckInput
 
 # 5.1.15


### PR DESCRIPTION
### Description

Our jenkins job to release to github fails when there are double quotes in our changelog.md files. This PR changes the double quotes to single quotes. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
