### PR TITLE
update warp-tools docker

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -2,6 +2,7 @@
 2023-03-15 (Date of Last Commit)
 
 * Removed the following columns from the cell metrics csv and the Loom as the counts were empty/incorrect: reads_unmapped, reads_mapped_exonic, reads_mapped_intronic, reads_mapped_utr, reads_mapped_intergenic
+* Updated warp-tools docker. The latest loom building script updates the optimus_output_schema_version from 1.0.0 to 1.0.1 to capture the metrics changes listed above 
 
 # 5.7.2
 2023-02-28 (Date of Last Commit)

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -2,6 +2,8 @@
 2023-03-15 (Date of Last Commit)
 
 * Removed the following columns from the cell metrics csv and the Loom as the counts were empty/incorrect: reads_unmapped, reads_mapped_exonic, reads_mapped_intronic, reads_mapped_utr, reads_mapped_intergenic
+* Updated warp-tools docker. The latest loom building script updates the optimus_output_schema_version from 1.0.0 to 1.0.1 to capture the metrics changes listed above 
+
 
 # 1.0.1
 2023-02-28 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
+++ b/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.changelog.md
@@ -2,6 +2,7 @@
 2023-03-15 (Date of Last Commit)
 
 * SlideSeq-specific and Optimus-specific changes to Metrics.wdl. This change does not affect the MultiSmartSeq2 pipeline.
+* Updated warp-tools docker to support the Optimus and SlideSeq changes 
 
 # 2.2.18
 2022-11-18 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -2,6 +2,7 @@
 2023-03-15 (Date of Last Commit)
 
 * SlideSeq-specific and Optimus-specific changes to Metrics.wdl. This change does not affect the MultiSampleSmartSeq2SingleNucleus pipeline.
+* Updated warp-tools docker to support the Optimus and SlideSeq changes 
 
 # 1.2.18
 2023-02-28 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
+++ b/pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.changelog.md
@@ -2,6 +2,7 @@
 2023-03-15 (Date of Last Commit)
 
 * SlideSeq-specific and Optimus-specific changes to Metrics.wdl. This change does not affect the SmartSeq2SingleSample pipeline.
+* Updated warp-tools docker to support the Optimus and SlideSeq changes 
 
 # 5.1.17
 2022-11-18 (Date of Last Commit)

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -10,7 +10,7 @@ task FastqProcessing {
     String sample_id
 
     #using the latest build of warp-tools in GCR
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     #runtime values
     Int machine_mem_mb = 40000
     Int cpu = 16   

--- a/tasks/skylab/LoomUtils.wdl
+++ b/tasks/skylab/LoomUtils.wdl
@@ -62,7 +62,7 @@ task OptimusLoomGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1678990890"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     # name of the sample
     String input_id
     # user provided id
@@ -218,7 +218,7 @@ task SingleNucleusOptimusLoomOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1678990890"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
         # name of the sample
         String input_id
         # user provided id
@@ -401,7 +401,7 @@ task SlideSeqLoomOutput {
     String input_id
     String pipeline_version
 
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1678990890"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     Int disk_size_gb = 200
     Int memory_mb = 18000
     Int cpu = 4

--- a/tasks/skylab/Metrics.wdl
+++ b/tasks/skylab/Metrics.wdl
@@ -9,7 +9,7 @@ task CalculateCellMetrics {
 
     # runtime values
 
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     Int machine_mem_mb = 8000
     Int cpu = 4
     Int disk = ceil(size(bam_input, "Gi") * 4) + ceil((size(original_gtf, "Gi") * 3)) 
@@ -86,7 +86,7 @@ task CalculateGeneMetrics {
     String input_id
     # runtime values
 
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1676307243"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     Int machine_mem_mb = 8000
     Int cpu = 4
     Int disk = ceil(size(bam_input, "Gi") * 4) 
@@ -147,7 +147,7 @@ task CalculateUMIsMetrics {
     File? mt_genes
     String input_id
     # runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1674487316"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     Int machine_mem_mb = 16000
     Int cpu = 8
     Int disk = ceil(size(bam_input, "Gi") * 4)
@@ -213,7 +213,7 @@ task FastqMetricsSlideSeq {
 
 
     # Runtime attributes
-    String docker =  "us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1674487316"
+    String docker =  "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
     Int cpu = 16
     Int machine_mb = 40000
     Int disk = ceil(size(r1_fastq, "GiB")*3)  + 50


### PR DESCRIPTION
### Description
Updated the warp-tools docker to include the version increase for the optimus_output_schema_version (https://github.com/broadinstitute/warp-tools/pull/29)

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
