### PR TITLE
Updated Snapatac2 docker

### DIFF
--- a/dockers/skylab/snapatac2/Dockerfile
+++ b/dockers/skylab/snapatac2/Dockerfile
@@ -7,7 +7,7 @@ ENV TERM=xterm-256color \
         TINI_VERSION=v0.19.0\
         PATH=$PATH:/usr/gitc
 
-ARG SNAPATAC2_VERSION=2.2.0
+ARG SNAPATAC2_VERSION=2.3.0
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org" \
         SNAPATAC2_VERSION=${SNAPATAC2_VERSION}

--- a/dockers/skylab/snapatac2/docker_build.sh
+++ b/dockers/skylab/snapatac2/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.2
+DOCKER_IMAGE_VERSION=1.0.3
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 
@@ -11,7 +11,7 @@ GCR_URL="us.gcr.io/broad-gotc-prod/"
 QUAY_URL="quay.io/broadinstitute/gotc-prod-snapatac2/"
 
 # SnapATAC2 version
-SNAPATAC2_VERSION="2.2.0"
+SNAPATAC2_VERSION="2.3.0"
 
 # Necessary tools and help text
 TOOLS=(docker gcloud)

--- a/dockers/skylab/snapatac2/docker_versions.tsv
+++ b/dockers/skylab/snapatac2/docker_versions.tsv
@@ -1,1 +1,2 @@
 us.gcr.io/broad-gotc-prod/snapatac2:1.0.2-2.2.0-1679678908
+us.gcr.io/broad-gotc-prod/snapatac2:1.0.3-2.3.0-1682089891


### PR DESCRIPTION
### Description

Updated SnapATAC2 docker to the latest versio of SnapATAC2. This version removes fragments that are less than 9 bp, resulting in fragments where chromosome start is always less than chromosome end.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
