### PR TITLE
[FE-16] Update BroadInternalRNAWithUMIs output metrics fields to round to integers

### DIFF
--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.23
+2023-05-02 (Date of Last Commit)
+
+* In MergeMetrics task, update list of metrics to round to integers.
+
 # 1.0.22
 2023-03-20 (Date of Last Commit)
 

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -7,7 +7,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow BroadInternalRNAWithUMIs {
 
-  String pipeline_version = "1.0.22"
+  String pipeline_version = "1.0.23"
 
   input {
     # input needs to be either "hg19" or "hg38"

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.changelog.md
@@ -1,3 +1,9 @@
+# 1.0.13
+2022-05-02 (Date of Last Commit)
+
+* (Imported but not called by this pipeline) In MergeMetrics task, update list of metrics to round to integers.
+
+
 # 1.0.12
 2023-03-20 (Date of Last Commit)
 

--- a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl
+++ b/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl
@@ -20,7 +20,7 @@ import "../../../tasks/broad/RNAWithUMIsTasks.wdl" as tasks
 
 workflow RNAWithUMIsPipeline {
 
-  String pipeline_version = "1.0.12"
+  String pipeline_version = "1.0.13"
 
   input {
     File? bam

--- a/tasks/broad/RNAWithUMIsTasks.wdl
+++ b/tasks/broad/RNAWithUMIsTasks.wdl
@@ -475,7 +475,7 @@ task MergeMetrics {
       value = rows[1][col]
       if value == "?":
         value = "NaN"
-      if key in ["median_insert_size", "median_absolute_deviation", "median_read_length", "hq_median_mismatches"]:
+      if key in ["median_insert_size", "median_absolute_deviation", "median_read_length", "mad_read_length", "pf_hq_median_mismatches"]:
         value = str(int(float(value)))
       print(f"{key}\t{value}")
     EOF


### PR DESCRIPTION
### Description

This PR updates the list of metrics to round to integers (to support TDR integrations with GP - see [FE-16](https://broadworkbench.atlassian.net/browse/FE-16) for context)
- Note that `pf_hq_median_mismatches` was previously mistakenly in the list as `hq_median_mismatches`, but this metric should have the `pf_` prefix.

Functional testing in Terra: TO BE ADDED

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow? NO
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names? NO
- [x] If you made a changelog update, did you update the pipeline version number? YES
