### PR TITLE
Make Cross Check Fingerprints Optional in Joint Genotyping Workflow

### DIFF
--- a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
@@ -415,19 +415,21 @@ workflow JointGenotyping {
     }
   }
 
-  if (!scatter_cross_check_fingerprints) {
+  if (cross_check_fingerprints) {
+    if (!scatter_cross_check_fingerprints) {
 
-    scatter (line in sample_name_map_lines) {
-      File gvcf_paths = line[1]
-    }
+      scatter (line in sample_name_map_lines) {
+        File gvcf_paths = line[1]
+      }
 
-    call Tasks.CrossCheckFingerprint as CrossCheckFingerprintSolo {
-      input:
-        gvcf_paths = gvcf_paths,
-        vcf_paths = ApplyRecalibration.recalibrated_vcf,
-        sample_name_map = sample_name_map,
-        haplotype_database = haplotype_database,
-        output_base_name = callset_name
+      call Tasks.CrossCheckFingerprint as CrossCheckFingerprintSolo {
+        input:
+          gvcf_paths = gvcf_paths,
+          vcf_paths = ApplyRecalibration.recalibrated_vcf,
+          sample_name_map = sample_name_map,
+          haplotype_database = haplotype_database,
+          output_base_name = callset_name
+      }
     }
   }
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
@@ -453,8 +453,8 @@ workflow JointGenotyping {
     # Output the interval list generated/used by this run workflow.
     Array[File] output_intervals = SplitIntervalList.output_intervals
 
-    # Output the metrics from crosschecking fingerprints.
-    File? crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics], default = null)
+    # Output the metrics from crosschecking fingerprints. If cross_check_fingerprints=false, then this will be null.
+    File? crosscheck_fingerprint_check = if (defined(CrossCheckFingerprintSolo.crosscheck_metrics)) then CrossCheckFingerprintSolo.crosscheck_metrics else if (defined(GatherFingerprintingMetrics.gathered_metrics)) then GatherFingerprintingMetrics.gathered_metrics else "null"
   }
   meta {
     allowNestedInputs: true

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
@@ -454,7 +454,7 @@ workflow JointGenotyping {
     Array[File] output_intervals = SplitIntervalList.output_intervals
 
     # Output the metrics from crosschecking fingerprints.
-    File? crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics])
+    File? crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics], default = null)
   }
   meta {
     allowNestedInputs: true

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl
@@ -454,7 +454,7 @@ workflow JointGenotyping {
     Array[File] output_intervals = SplitIntervalList.output_intervals
 
     # Output the metrics from crosschecking fingerprints.
-    File crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics])
+    File? crosscheck_fingerprint_check = select_first([CrossCheckFingerprintSolo.crosscheck_metrics, GatherFingerprintingMetrics.gathered_metrics])
   }
   meta {
     allowNestedInputs: true


### PR DESCRIPTION
### Description
This PR aims to make the cross check fingerprint task optional in the joint genotyping workflow. During my analysis, I came across a target panel that didn't have sufficient coverage for the sites used for cross check fingerprints. To prevent the entire joint-genotyping workflow from failing, I have made cross check fingerprints an optional task that can be turned off by setting the input "cross_check_fingerprints=false".

To implement this change, I made modifications to line 418 and line 457 in the `pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl`. This change also makes the output crosscheck_fingerprint_check become optional @kayleemathews @ekiernan. I have also thoroughly tested these changes in my own analysis. 

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
