### PR TITLE
Lk pd 2229 update optimus fastqprocessing

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.8.1
+2023-05-04 (Date of Last Commit)
+
+* Defeated the rebel scum
+* Updated inputs for the FastqProcessing task, which now requires read structure. This is dynamically calculated from the CheckInputs task
 # 5.8.0
 2023-04-24 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,8 +1,8 @@
 # 5.8.1
 2023-05-04 (Date of Last Commit)
 
-* Defeated the rebel scum
 * Updated inputs for the FastqProcessing task, which now requires read structure. This is dynamically calculated from the CheckInputs task
+
 # 5.8.0
 2023-04-24 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -64,7 +64,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "5.9.0"
+  String pipeline_version = "5.8.1"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -37,6 +37,9 @@ workflow Optimus {
     # Whitelist is selected based on the input tenx_chemistry_version
     File whitelist = checkOptimusInput.whitelist_out
 
+    # read_structure is based on v2 or v3 chemistry
+    String read_struct = checkOptimusInput.read_struct_out
+
     # Emptydrops lower cutoff
     Int emptydrops_lower = 100
 
@@ -61,7 +64,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "5.8.0"
+  String pipeline_version = "5.9.0"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))
@@ -113,7 +116,8 @@ workflow Optimus {
       r2_fastq = r2_fastq,
       whitelist = whitelist,
       chemistry = tenx_chemistry_version,
-      sample_id = input_id
+      sample_id = input_id,
+      read_struct = read_struct
   }
 
   scatter(idx in range(length(SplitFastq.fastq_R1_output_array))) {

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -2,6 +2,7 @@
 2023-05-04 (Date of Last Commit)
 
 * Updated the warp-tools docker for Optimus fastqprocess; change does not impact this workflow
+
 # 1.0.5
 2023-04-23 (Date of Last Commit)
 

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,7 @@
+# 1.0.6
+2023-05-04 (Date of Last Commit)
+
+* Updated the warp-tools docker for Optimus fastqprocess; change does not impact this workflow
 # 1.0.5
 2023-04-23 (Date of Last Commit)
 

--- a/pipelines/skylab/slideseq/SlideSeq.wdl
+++ b/pipelines/skylab/slideseq/SlideSeq.wdl
@@ -23,7 +23,7 @@ import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow SlideSeq {
 
-    String pipeline_version = "1.0.5"
+    String pipeline_version = "1.0.6"
 
     input {
         Array[File] r1_fastq

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,4 +1,5 @@
-# 1.2.23 (Date of Last Commit)
+# 1.2.23 
+2023-05-04 (Date of Last Commit)
 
 * Updated the CheckInputs WDL for the Optimus workflow. This changes does impact snSS2
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,7 @@
+# 1.2.23 (Date of Last Commit)
+
+* Updated the CheckInputs WDL for the Optimus workflow. This changes does impact snSS2
+
 # 1.2.22
 
 2023-04-23 (Date of Last Commit)

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.2.22"
+  String pipeline_version = "1.2.23"
 
   if (false) {
      String? none = "None"

--- a/tasks/skylab/CheckInputs.wdl
+++ b/tasks/skylab/CheckInputs.wdl
@@ -108,15 +108,17 @@ task checkOptimusInput {
         echo "ERROR: Invalid value count_exons should not be used with \"${counting_mode}\" input."
       fi
     fi
-    
+    # Check for chemistry version to produce read structure and whitelist
     if [[ ~{tenx_chemistry_version} == 2 ]]
       then
       WHITELIST=~{whitelist_v2}
       echo $WHITELIST > whitelist.txt
+      echo 16C10M > read_struct.txt
     elif [[ ~{tenx_chemistry_version} == 3 ]]
       then
       WHITELIST=~{whitelist_v3}
       echo $WHITELIST > whitelist.txt
+      echo 16C12M > read_struct.txt
     else
       pass="false"
       echo "ERROR: Chemistry version must be either 2 or 3"
@@ -148,6 +150,7 @@ task checkOptimusInput {
 
   output {
     String whitelist_out = read_string("whitelist.txt")
+    String read_struct_out = read_string("read_struct.txt")
   }
   runtime {
     docker: "bashell/alpine-bash:latest"

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -8,9 +8,10 @@ task FastqProcessing {
     File whitelist
     Int chemistry
     String sample_id
+    String read_struct
 
     #using the latest build of warp-tools in GCR
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679490798"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1683134506"
     #runtime values
     Int machine_mem_mb = 40000
     Int cpu = 16   
@@ -29,6 +30,7 @@ task FastqProcessing {
     r1_fastq: "input fastq file"
     r2_fastq: "input fastq file"
     i1_fastq: "(optional) input fastq file"
+    read_struct: "read structure for the 10x chemistry. This automatically selected in the checkInputs task"
     whitelist: "10x genomics cell barcode whitelist"
     chemistry: "chemistry employed, currently can be tenX_v2 or tenX_v3, the latter implies NO feature barcodes"
     sample_id: "name of sample matching this file, inserted into read group header"
@@ -101,11 +103,10 @@ task FastqProcessing {
 
     fastqprocess \
         --bam-size 30.0 \
-        --barcode-length 16 \
-        --umi-length $UMILENGTH \
         --sample-id "~{sample_id}" \
         $FASTQS \
         --white-list "~{whitelist}" \
+        --read-structure "~{read_struct}" \
         --output-format FASTQ
   }
   


### PR DESCRIPTION
### Description
Updated the Optimus pipeline to include modified inputs for the Fastqprocessing task. Fastq processing now takes in read structure instead of barcode and UMI lengths. 

We added a check to the CheckInputs task so that Optimus will choose the correct read structure based on the 10x chemistry selected as input. 

This work relates to the ticket https://broadworkbench.atlassian.net/jira/software/projects/PD/boards/167?selectedIssue=PD-2229


----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
