### PR TITLE
Update ATAC wdl to include all tasks

### DIFF
--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,7 +1,6 @@
 version 1.0
 
 import "../../tasks/skylab/MergeSortBam.wdl" as Merge
-#import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
 workflow ATAC {
   meta {

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -87,7 +87,7 @@ workflow ATAC {
   
   } 
 
-    call MergeSortBamFiles {
+    call Merge.MergeSortBamFiles as MergeBam {
     input:
       bam_inputs = AddCBtags.output_cb_bam,
       output_bam_filename = output_base_name + ".bam",
@@ -97,7 +97,7 @@ workflow ATAC {
 
   call CreateFragmentFile {
     input:
-      bam = MergeSortBamFiles.output_bam,
+      bam = MergeBam.output_bam,
       chrom_sizes = chrom_sizes,
       barcodes_in_read_name = barcodes_in_read_name,
       atac_gtf = atac_gtf

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -104,7 +104,7 @@ workflow ATAC {
    }
 
   output {
-    File bam_aligned_output = MergeSortBamFiles.output_bam
+    File bam_aligned_output = MergeBam.output_bam
     File fragment_file = CreateFragmentFile.fragment_file
     File snap_metrics = CreateFragmentFile.Snap_metrics
   }

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -352,8 +352,8 @@ task AddCBtags {
   
   command <<<
     # We reused tags from Broad's Share-seq pipeline; XC tag is not currently needed by pipeline 
-    samtools view -h ~{bam} 
-    | awk '{if ($0 ~ /^@/) {print $0} else {cr=substr($1, index($1, "CR:")+3); n=split($1, a,":CB:"); if (n == 2) {cb="CB:Z:"a[1]"\t";} else {cb="";} print($0 "\tCR:Z:" cr "\t" cb "XC:Z:" substr($1, index($1, "CB:")+3));}}' 
+    samtools view -h ~{bam} \
+    | awk '{if ($0 ~ /^@/) {print $0} else {cr=substr($1, index($1, "CR:")+3); n=split($1, a,":CB:"); if (n == 2) {cb="CB:Z:"a[1]"\t";} else {cb="";} print($0 "\tCR:Z:" cr "\t" cb "XC:Z:" substr($1, index($1, "CB:")+3));}}' \
     | samtools view -b -o ~{bam_cb_output_name}
     
     # samtools view -h ~{bam} \

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,5 +1,8 @@
 version 1.0
 
+import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
+#import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
+
 workflow ATAC {
   meta {
     description: "Processing for single-cell ATAC-seq data from the level of raw fastq reads. This is the first step of the multiome pipeline. ATAC-seq (Assay for Transposase-Accessible Chromatin using sequencing) is a technique used in molecular biology to assess genome-wide chromatin accessibility. This pipeline processes 10x Genomics Multiome ATAC FASTQ files."
@@ -18,11 +21,20 @@ workflow ATAC {
     # BWA ref 
     File tar_bwa_reference
     
+    # CreateFragmentFile input variables 
+    Boolean barcodes_in_read_name
+    # GTF for SnapATAC2 to calculate TSS sites of fragment file
+    File atac_gtf
+    # Text file containing chrom_sizes for genome build (i.e. hg38)
+    File chrom_sizes
+
     # script for monitoring tasks 
     File monitoring_script
 
-    Boolean barcodes_in_read_name
+    # Whitelist
+    File whitelist
 
+    # TrimAdapters input 
     String adapter_seq_read1 = "GTCTCGTGGGCTCGGAGATGTGTATAAGAGACAG"
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
@@ -37,122 +49,168 @@ workflow ATAC {
 
   }
 
-  call AddBarcodes {
+  call FastqProcessing as SplitFastq {
     input:
       read1_fastq = read1_fastq_gzipped,
       read3_fastq = read3_fastq_gzipped,
       barcodes_fastq = read2_fastq_gzipped,
-      output_base_name = output_base_name
-  }
-  call TrimAdapters {
-    input:
-      fastq_input_read1 = AddBarcodes.fastq_barcodes_output_read1,
-      fastq_input_read3 = AddBarcodes.fastq_barcodes_output_read3,
       output_base_name = output_base_name,
-      monitoring_script = monitoring_script,
-      adapter_seq_read1 = adapter_seq_read1,
-      adapter_seq_read3 = adapter_seq_read3
+      whitelist = whitelist
    }
-  call BWAPairedEndAlignment {
-    input:
-      fastq_input_read1 = TrimAdapters.fastq_trimmed_adapter_output_read1,
-      fastq_input_read3 = TrimAdapters.fastq_trimmed_adapter_output_read3,
-      tar_bwa_reference = tar_bwa_reference,
-      output_base_name = output_base_name,
-      monitoring_script = monitoring_script
+
+  scatter(idx in range(length(SplitFastq.fastq_R1_output_array))) {
+
+    call TrimAdapters {
+      input:
+        read1_fastq = SplitFastq.fastq_R1_output_array[idx], 
+        read3_fastq = SplitFastq.fastq_R3_output_array[idx],
+        output_base_name = output_base_name + "_" + idx,
+        monitoring_script = monitoring_script,
+        adapter_seq_read1 = adapter_seq_read1,
+        adapter_seq_read3 = adapter_seq_read3
     }
+
+    call BWAPairedEndAlignment {
+      input:
+        read1_fastq = TrimAdapters.fastq_trimmed_adapter_output_read1,
+        read3_fastq = TrimAdapters.fastq_trimmed_adapter_output_read3,
+        tar_bwa_reference = tar_bwa_reference,
+        output_base_name = output_base_name + "_" + idx,
+        monitoring_script = monitoring_script
+      }
+  } 
+
+  call Merge.MergeSortBamFiles as MergeBam {
+    input:
+      bam_inputs = BWAPairedEndAlignment.bam_aligned_output,
+      output_bam_filename = output_base_name + ".bam",
+      sort_order = "coordinate"
+  }
+  
   call AddCBtags {
     input:
-      bam = BWAPairedEndAlignment.bam_aligned_output,
+      bam = MergeBam.output_bam,
       output_base_name = output_base_name
-  }
+   }
+
   call CreateFragmentFile {
     input:
-      bam = AddCBtags.sorted_cb_bam,
+      bam = AddCBtags.output_cb_bam,
+      chrom_sizes = chrom_sizes,
       barcodes_in_read_name = barcodes_in_read_name,
-  }
+      atac_gtf = atac_gtf
+   }
+
   output {
-    File bam_aligned_output = BWAPairedEndAlignment.bam_aligned_output
+    File bam_aligned_output = AddCBtags.output_cb_bam
     File fragment_file = CreateFragmentFile.fragment_file
+    File snap_metrics = CreateFragmentFile.Snap_metrics
   }
 }
 
-  task AddBarcodes {
+task FastqProcessing {
+
+  input {
+    Array[File] read1_fastq
+    Array[File] read3_fastq
+    Array[File] barcodes_fastq
+    String read_structure = "16C"
+    String barcode_orientation = "FIRST_BP_RC"
+    String output_base_name
+    File whitelist
+
+    # [?] copied from corresponding optimus wdl for fastqprocessing 
+    # using the latest build of warp-tools in GCR
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1682971351"
+    # Runtime attributes [?]
+    Int mem_size = 5
+    Int cpu = 16   
+    # TODO decided cpu
+    # estimate that bam is approximately equal in size to fastq, add 20% buffer
+    Int disk_size = ceil(2 * ( size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(barcodes_fastq, "GiB") )) + 400
+    Int preemptible = 3
+   }
+
+  meta {
+    description: "Converts a set of fastq files to unaligned bam file/fastq file, also corrects barcodes and partitions the alignments by barcodes. Allows for variable barcode and umi lengths as input, if applicable."
+   }
+
+  parameter_meta {
+        read1_fastq: "Array of read 1 FASTQ files of paired reads -- forward reads"
+        read3_fastq: "Array of read 3 FASTQ files of paired reads -- reverse reads"
+        barcodes_fastq: "Array of read 2 FASTQ files which contains the cellular barcodes"
+        output_base_name: "Name of sample matching this file, inserted into read group header"
+        read_structure: "A string that specifies the barcode (C) positions in the Read 2 fastq"
+        barcode_orientation: "A string that specifies the orientation of barcode needed for scATAC data. The default is FIRST_BP. Other options include LAST_BP, FIRST_BP_RC or LAST_BP_RC."
+        whitelist: "10x genomics cell barcode whitelist for scATAC"
+        docker: "(optional) the docker image containing the runtime environment for this task"
+        mem_size: "(optional) the amount of memory (MiB) to provision for this task"
+        cpu: "(optional) the number of cpus to provision for this task"
+        disk_size: "(optional) the amount of disk space (GiB) to provision for this task"
+        preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
+   }
+
+  command <<<
+  
+    set -euo pipefail
+    
+    # Cat files for each r1, r3 and barcodes together [? is this a good idea or should we just do what optimus does]
+    cat ~{sep=' ' read1_fastq} > r1.fastq.gz
+    cat ~{sep=' ' read3_fastq} > r3.fastq.gz
+    cat ~{sep=' ' barcodes_fastq} > barcodes.fastq.gz
+    
+    # Call fastq process 
+    # outputs fastq files where the corrected barcode is in the read name
+    fastqprocess \
+        --bam-size 30.0 \
+        --sample-id "~{output_base_name}" \
+        --R1 barcodes.fastq.gz \
+        --R2 r1.fastq.gz \
+        --R3 r3.fastq.gz \
+        --white-list "~{whitelist}" \
+        --output-format "FASTQ" \
+        --barcode-orientation "~{barcode_orientation}" \
+        --read-structure "~{read_structure}"
+        
+    >>>
+
+  runtime {
+    docker: docker
+    cpu: cpu
+    memory: "${mem_size} MiB"
+    disks: "local-disk ${disk_size} HDD"
+    preemptible: preemptible
+   }
+  
+  output {
+    Array[File] fastq_R1_output_array = glob("fastq_R1_*")
+    Array[File] fastq_R3_output_array = glob("fastq_R3_*")
+   }
+ }
+
+# trim read 1 and read 2 adapter sequeunce with cutadapt
+task TrimAdapters {
     input {
-      Array[File] read1_fastq
-      Array[File] read3_fastq
-      Array[File] barcodes_fastq
+      File read1_fastq
+      File read3_fastq
       String output_base_name
-      Int mem_size = 5
-      String docker_image = "us.gcr.io/broad-gotc-prod/atac_barcodes:1.0.3-1679503564"
-      Int disk_size = ceil(2 * ( size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(barcodes_fastq, "GiB") )) + 400
-  }
 
-   parameter_meta {
-      read1_fastq: "Read 1 FASTQ with read 1 of paired reads"
-      read3_fastq: "Read 3 FASTQ with read 2 of paired reads"
-      barcodes_fastq: "Read 2 FASTQ with cellular barcodes"
-      mem_size: "Size of memory in GB"
-      output_base_name: "base name to be used for the output of the task"
-      docker_image: "the docker image using cutadapt to be used (default: )"
-      disk_size : "disk size used in trimming adapters step"
-  }
-      
-    # output names for trimmed reads
-    String fastq_barcodes_read1 = output_base_name + ".R1.barcodes.fastq"
-    String fastq_barcodes_read3 = output_base_name + ".R3.barcodes.fastq"
-   
-    # Adding barcodes to read 1 and read 3 fastq
-    command <<<
-      set -euo pipefail
-      
-      # Cat files for each r1, r3 and barcodes together
-      cat ~{sep=' ' read1_fastq} > r1.fastq.gz
-      cat ~{sep=' ' read3_fastq} > r3.fastq.gz
-      cat ~{sep=' ' barcodes_fastq} > barcodes.fastq.gz
-      
-      gunzip r1.fastq.gz r3.fastq.gz barcodes.fastq.gz
-      
-      # Add barcodes to the concatenated fastq files using python script
-      echo "Append barcodes to R1 and R3 fastq files." 
-      python3 /usr/gitc/atac_barcodes.py -r1 r1.fastq -r3 r3.fastq -cb barcodes.fastq -out_r1 ~{fastq_barcodes_read1} -out_r3 ~{fastq_barcodes_read3}
-      
-      gzip ~{fastq_barcodes_read1} ~{fastq_barcodes_read3}
-      echo "These are the zipped files and sizes."
-      ls -l
-     >>>
-
-    # use docker image for given tool cutadapat
-    runtime {
-      docker: docker_image
-      disks: "local-disk ${disk_size} HDD"
-      memory: "${mem_size} GiB"
-    }
-
-    output {
-      File fastq_barcodes_output_read1 = "~{fastq_barcodes_read1}.gz"
-      File fastq_barcodes_output_read3 = "~{fastq_barcodes_read3}.gz"
-    }
-  }
-  # trim read 1 and read 2 adapter sequeunce with cutadapt
-  task TrimAdapters {
-    input {
-      File fastq_input_read1
-      File fastq_input_read3
-      String output_base_name
-      String docker_image = "quay.io/broadinstitute/cutadapt:1.18"
-      File monitoring_script
-      Int disk_size = ceil(2 * ( size(fastq_input_read1, "GiB") + size(fastq_input_read3, "GiB") )) + 200
-      Int mem_size = 4
-      Int min_length = 10
+	Int min_length = 10
       Int quality_cutoff = 0
-      String adapter_seq_read1
+      
+	String adapter_seq_read1
       String adapter_seq_read3
-  }
+
+	# Runtime attributes/docker
+      Int disk_size = ceil(2 * ( size(read1_fastq, "GiB") + size(read3_fastq, "GiB") )) + 200
+      Int mem_size = 4
+	String docker_image = "quay.io/broadinstitute/cutadapt:1.18"
+      File monitoring_script
+   }
 
    parameter_meta {
-      fastq_input_read1: "read 1 fastq file containing sequencing reads as input for the pipeline"
-      fastq_input_read3: "read 3 fastq file containing sequencing reads as input for the pipeline"
+      read1_fastq: "read 1 fastq file containing sequencing reads as input for the pipeline"
+      read3_fastq: "read 3 fastq file containing sequencing reads as input for the pipeline"
       min_length: "the minimum length for trimming. Reads that are too short even before adapter removal are also discarded"
       quality_cutoff: "cutadapt option to trim low-quality ends from reads before adapter removal"
       adapter_seq_read1: "cutadapt option for the sequence adapter for read 1 fastq"
@@ -162,7 +220,7 @@ workflow ATAC {
       monitoring_script : "script to monitor resource consumption of tasks"
       mem_size: "the size of memory used during trimming adapters"
       disk_size : "disk size used in trimming adapters step"
-  }
+   }
       
     # output names for trimmed reads
     String fastq_trimmed_adapter_output_name_read1 = output_base_name + ".R1.trimmed_adapters.fastq.gz"
@@ -188,15 +246,15 @@ workflow ATAC {
         -A ~{adapter_seq_read3} \
         --output ~{fastq_trimmed_adapter_output_name_read1} \
         --paired-output ~{fastq_trimmed_adapter_output_name_read3} \
-        ~{fastq_input_read1} ~{fastq_input_read3}
-  >>>
+        ~{read1_fastq} ~{read3_fastq}
+    >>>
 
     # use docker image for given tool cutadapat
     runtime {
       docker: docker_image
       disks: "local-disk ${disk_size} HDD"
       memory: "${mem_size} GiB" 
-  }
+    }
 
     output {
       File fastq_trimmed_adapter_output_read1 = fastq_trimmed_adapter_output_name_read1
@@ -205,25 +263,29 @@ workflow ATAC {
     }
   }
 
-  # align the two trimmed fastq as piared end data using BWA
-  task BWAPairedEndAlignment {
+# align the two trimmed fastq as paired end data using BWA
+task BWAPairedEndAlignment {
     input {
-      File fastq_input_read1
-      File fastq_input_read3
+      File read1_fastq
+      File read3_fastq
       File tar_bwa_reference
       String read_group_id = "RG1"
       String read_group_sample_name = "RGSN1"
       String output_base_name
       String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
-      File monitoring_script
-      Int disk_size = ceil(3.25 * (size(fastq_input_read1, "GiB") + size(fastq_input_read3, "GiB") + size(tar_bwa_reference, "GiB"))) + 200 
+      
+	# script for monitoring tasks 
+	File monitoring_script
+      
+	# Runtime attributes
+	Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 200 
       Int nthreads = 16
       Int mem_size = 8
-   }
+    }
 
     parameter_meta {
-      fastq_input_read1: "the trimmed read 1 fastq file containing sequencing reads as input for the aligner"
-      fastq_input_read3: "the trimmed read 1 fastq file containing sequencing reads as input for the aligner"
+      read1_fastq: "the trimmed read 1 fastq file containing sequencing reads as input for the aligner"
+      read3_fastq: "the trimmed read 1 fastq file containing sequencing reads as input for the aligner"
       tar_bwa_reference: "the pre built tar file containing the reference fasta and cooresponding reference files for the BWA aligner"
       read_group_id: "the read group id to be added upon alignment"
       read_group_sample_name: "the read group sample to be added upon alignment"
@@ -260,7 +322,7 @@ workflow ATAC {
         -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
         -t ~{nthreads} \
         $REF_DIR/genome.fa \
-        ~{fastq_input_read1} ~{fastq_input_read3} \
+        ~{read1_fastq} ~{read3_fastq} \
         | samtools view -bS - > ~{bam_aligned_output_name}    
      >>>
 
@@ -271,62 +333,13 @@ workflow ATAC {
       memory: "${mem_size} GiB"
     }
 
-
     output {
       File bam_aligned_output = bam_aligned_output_name
       File monitoring_log = "monitoring.log"
     }
   }
 
-# make fragment file
-task CreateFragmentFile {
-  input {
-    File bam
-    Boolean barcodes_in_read_name
-    Int disk_size = ceil(size(bam, "GiB") + 200)
-    Int mem_size = 100
-  }
-
-  String bam_base_name = basename(bam, ".bam")
-
-  parameter_meta {
-    bam: "the aligned bam with CB in CB tag; output of the AddCBtags task"
-  }
-
-  command <<<
-    set -e pipefail
-
-    python3 <<CODE
-
-
-    barcodes_in_read_name = "~{barcodes_in_read_name}"
-    bam = "~{bam}"
-    bam_base_name = "~{bam_base_name}"
-
-    # if barcodes are in the read name, then use barcode_regex to extract them. otherwise, use barcode_tag
-
-    if barcodes_in_read_name=="true":
-      import snapatac2.preprocessing as pp
-      pp.make_fragment_file("~{bam}", "~{bam_base_name}.fragments.tsv", is_paired=True, barcode_regex="([^:]*)")
-    elif barcodes_in_read_name=="false":
-      import snapatac2.preprocessing as pp
-      pp.make_fragment_file("~{bam}", "~{bam_base_name}.fragments.tsv", is_paired=True, barcode_tag="CB")
-
-    CODE
-  >>>
-
-  runtime {
-    docker: "us.gcr.io/broad-gotc-prod/snapatac2:1.0.3-2.3.0-1682089891"
-    disks: "local-disk ${disk_size} HDD"
-    cpu: 1
-    memory: "${mem_size} GiB"
-  }
-
-  output {
-    File fragment_file = "~{bam_base_name}.fragments.tsv"
-  }
-}
-
+#add CB and CR tags to BAM file
 task AddCBtags {
   input {
     File bam
@@ -339,13 +352,21 @@ task AddCBtags {
   
   command <<<
     # We reused tags from Broad's Share-seq pipeline; XC tag is not currently needed by pipeline 
-    samtools view -h ~{bam} | awk '{if ($0 ~ /^@/) {print $0} else {cb = substr($1, 1, index($1, ":")-1); print($0 "\tCB:Z:" cb "\tXC:Z:" cb "_" substr($1, index($1, ":")+1));}}' | samtools view -b -o ~{bam_cb_output_name}
+    samtools view -h ~{bam} 
+    | awk '{if ($0 ~ /^@/) {print $0} else {cr=substr($1, index($1, "CR:")+3); n=split($1, a,":CB:"); if (n == 2) {cb="CB:Z:"a[1]"\t";} else {cb="";} print($0 "\tCR:Z:" cr "\t" cb "XC:Z:" substr($1, index($1, "CB:")+3));}}' 
+    | samtools view -b -o ~{bam_cb_output_name}
+    
+    # samtools view -h ~{bam} \
+    # | awk '{if ($1 ~ /CB/) {cb = substr($1, 1, index($1, ":")-1); print($0 "\tCB:Z:" cb);} else {print $0}}' \
+    # | awk '{if ($0 ~ /^@/) {print $0} else {cr=substr($1, index($1, "CR:")+3); print($0 "\tCR:Z:" cr "\tXC:Z:" substr($1, index($1, "CB:")+3));}}' \
+    # | samtools view -b -o ~{bam_cb_output_name}
+  
     # Piping to samtools sort works, but isn't necessary for SnapATAC2
     #| \ samtools sort -o ~{bam_cb_output_name}
   >>>
 
   output {
-    File sorted_cb_bam = "~{bam_cb_output_name}"
+    File output_cb_bam = "~{bam_cb_output_name}"
   }
 
   runtime {
@@ -354,3 +375,74 @@ task AddCBtags {
     memory: "${mem_size} GiB"
   }
 }
+# make fragment file
+task CreateFragmentFile {
+  input {
+    File bam
+    File atac_gtf
+    File chrom_sizes
+    Boolean barcodes_in_read_name
+    Int disk_size = ceil(size(bam, "GiB") + 200)
+    Int mem_size = 50
+  }
+
+  String bam_base_name = basename(bam, ".bam")
+
+  parameter_meta {
+    bam: "Aligned bam with CB in CB tag. This is the output of the AddCBtags task."
+    atac_gtf: "GTF for SnapATAC2 to calculate TSS sites of fragment file."
+    chrom_sizes: "Text file containing chrom_sizes for genome build (i.e. hg38)."
+    barcodes_in_read_name: "Set to True if barcodes are in the read names, and False otherwise. "
+    disk_size: "Disk size used in create fragment file step."
+    mem_size: "The size of memory used in create fragment file."
+  }
+
+  command <<<
+    set -e pipefail
+
+    python3 <<CODE
+
+    # set parameters
+    atac_gtf = "~{atac_gtf}"
+    barcodes_in_read_name = "~{barcodes_in_read_name}"
+    bam = "~{bam}"
+    bam_base_name = "~{bam_base_name}"
+    chrom_sizes = "~{chrom_sizes}"
+    
+    # calculate chrom size dictionary based on text file
+    chrom_size_dict={}
+    with open('~{chrom_sizes}', 'r') as f:
+        for line in f:
+            key, value = line.strip().split()
+            chrom_size_dict[str(key)] = int(value)
+
+    # use snap atac2
+    import snapatac2.preprocessing as pp
+    import snapatac2 as snap
+
+    # if barcodes are in the read name, then use barcode_regex to extract them. otherwise, use barcode_tag
+    if barcodes_in_read_name=="true":
+      pp.make_fragment_file("~{bam}", "~{bam_base_name}.fragments.tsv", is_paired=True, barcode_regex="([^:]*)")
+    elif barcodes_in_read_name=="false":
+      pp.make_fragment_file("~{bam}", "~{bam_base_name}.fragments.tsv", is_paired=True, barcode_tag="CB")
+    
+    # calculate quality metrics
+    pp.import_data("~{bam_base_name}.fragments.tsv", file="~{bam_base_name}.metrics.h5ad", chrom_size=chrom_size_dict, gene_anno="~{atac_gtf}")
+
+    CODE
+  >>>
+
+  runtime {
+    docker: "us.gcr.io/broad-gotc-prod/snapatac2:1.0.3-2.3.0-1682089891"
+    disks: "local-disk ${disk_size} HDD"
+    memory: "${mem_size} GiB"
+  }
+
+  output {
+    File fragment_file = "~{bam_base_name}.fragments.tsv"
+    File Snap_metrics = "~{bam_base_name}.metrics.h5ad"
+  }
+}
+
+
+

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/broadinstitute/warp/develop/tasks/skylab/MergeSortBam.wdl" as Merge
+"../../../tasks/skylab/MergeSortBam.wdl" as Merge
 #import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
 workflow ATAC {

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -339,7 +339,7 @@ task BWAPairedEndAlignment {
     }
   }
 
-#add CB and CR tags to BAM file
+#add CB, CR and XC tags to BAM file
 task AddCBtags {
   input {
     File bam

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
+import "../../tasks/skylab/MergeSortBam.wdl" as Merge
 #import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
 workflow ATAC {

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../../tasks/skylab/MergeSortBam.wdl" as Merge
+import "https://raw.githubusercontent.com/broadinstitute/warp/develop/tasks/skylab/MergeSortBam.wdl" as Merge
 #import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
 workflow ATAC {

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -156,7 +156,7 @@ task FastqProcessing {
   
     set -euo pipefail
     
-    # Cat files for each r1, r3 and barcodes together [? is this a good idea or should we just do what optimus does]
+    # Cat files for each r1, r3 and barcodes together 
     cat ~{sep=' ' read1_fastq} > r1.fastq.gz
     cat ~{sep=' ' read3_fastq} > r3.fastq.gz
     cat ~{sep=' ' barcodes_fastq} > barcodes.fastq.gz

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-"../../../tasks/skylab/MergeSortBam.wdl" as Merge
+import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 #import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 
 workflow ATAC {


### PR DESCRIPTION
Updated ATAC WDL to include barcode correction and splitting the fastq steps. 

SplitFastq splits the fastq files into small fastq files. The scatter step in the WDL (similar to Optimus) is added to run the TrimAdapters/BWA tasks simultaneously on the multiple smaller fastq files.  

Update the AddCBtags task to add both the CR and CB tags to the output BAM file. In the BAM file, so far, all reads with valid and invalid barcodes are included. Reads with valid barcodes have both the CB and CR tags, while reads with invalid barcodes only have the CR tags. Updated bash command to reflect that. (This may need to be updated again if only reads with valid barcodes are required.)

We ran this WDL in Terra. The job run can be found here: https://app.terra.bio/#workspaces/warp-pipelines/atac-multiome-bwa/job_history/2b487c5a-6acb-44a7-b391-9c47df8fbe73 
### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [x] Did you add inputs, outputs, or tasks to a workflow?
- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
