### PR TITLE
Updated slide-seq fastqprocessing to warp-tools docker

### DIFF
--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.8.2
+2023-05-11 (Date of Last Commit)
+
+* Updated the Docker image for Slideseq FastqProcessing. This update has no impact on the Optimus workflow
+
 # 5.8.1
 2023-05-04 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -64,7 +64,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "5.8.1"
+  String pipeline_version = "5.8.2"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.7
+2023-05-11 (Date of Last Commit)
+
+* Updated Docker image for FastqProcessing task to latest warp-tools.
+
 # 1.0.6
 2023-05-04 (Date of Last Commit)
 

--- a/pipelines/skylab/slideseq/SlideSeq.wdl
+++ b/pipelines/skylab/slideseq/SlideSeq.wdl
@@ -23,7 +23,7 @@ import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow SlideSeq {
 
-    String pipeline_version = "1.0.6"
+    String pipeline_version = "1.0.7"
 
     input {
         Array[File] r1_fastq

--- a/tasks/skylab/FastqProcessing.wdl
+++ b/tasks/skylab/FastqProcessing.wdl
@@ -137,7 +137,7 @@ task FastqProcessingSlidSeq {
 
 
     # Runtime attributes
-    String docker =  "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.14-test2"
+    String docker =  "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1683134506"
     Int cpu = 16
     Int machine_mb = 40000
     Int disk = ceil(size(r1_fastq, "GiB")*3 + size(r2_fastq, "GiB")*3) + 50


### PR DESCRIPTION
### Description

Updating the FastqProcessingSlideseq task to include the warp-tools docker instead of the skylab docker. This is to test if recent changes made to fastqprocessing will work with slideseq workflow. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
