### PR TITLE
Work around for long file paths in featureCounts

### DIFF
--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 1.2.24
+2023-05-24 (Date of Last Commit)
+
+* Added a move command to work around a maximum file path length in featureCounts
+
 # 1.2.23 
 2023-05-04 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.2.23"
+  String pipeline_version = "1.2.24"
 
   if (false) {
      String? none = "None"

--- a/tasks/skylab/FeatureCounts.wdl
+++ b/tasks/skylab/FeatureCounts.wdl
@@ -29,8 +29,20 @@ task CountAlignments {
 
   command <<<
     set -e
-    declare -a bam_files=(~{sep=' ' aligned_bam_inputs})
+    # move the input files to
+
+    declare -a bam_file_paths=(~{sep=' ' aligned_bam_inputs})
     declare -a output_prefix=(~{sep=' ' input_ids})
+
+    # move the bam files to get around the issue of long file paths causing a segfault in featureCounts
+    declare -a bam_files
+    for filepath in ${bam_file_paths[@]};
+      do
+        filename="$(basename $filepath)"
+        mv $filepath $filename
+        bam_files+=("$filename")
+      done;
+
     for (( i=0; i<${#bam_files[@]}; ++i));
       do
         # counting the introns

--- a/tasks/skylab/FeatureCounts.wdl
+++ b/tasks/skylab/FeatureCounts.wdl
@@ -29,7 +29,6 @@ task CountAlignments {
 
   command <<<
     set -e
-    # move the input files to
 
     declare -a bam_file_paths=(~{sep=' ' aligned_bam_inputs})
     declare -a output_prefix=(~{sep=' ' input_ids})


### PR DESCRIPTION
Add a move command to work around a maximum file path length in featureCounts

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
