### PR TITLE
changed atac min_num_fragments and min_tsse to 0

### DIFF
--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -422,8 +422,9 @@ task CreateFragmentFile {
     elif barcodes_in_read_name=="false":
       pp.make_fragment_file("~{bam}", "~{bam_base_name}.fragments.tsv", is_paired=True, barcode_tag="CB")
     
-    # calculate quality metrics
-    pp.import_data("~{bam_base_name}.fragments.tsv", file="~{bam_base_name}.metrics.h5ad", chrom_size=chrom_size_dict, gene_anno="~{atac_gtf}")
+    # calculate quality metrics; note min_num_fragments and min_tsse are set to 0 instead of default
+    # those settings allow us to retain all barcodes
+    pp.import_data("~{bam_base_name}.fragments.tsv", file="~{bam_base_name}.metrics.h5ad", chrom_size=chrom_size_dict, gene_anno="~{atac_gtf}", min_num_fragments=0, min_tsse=0)
 
     CODE
   >>>


### PR DESCRIPTION
### Description
We want to the ATAC portion of multiome to retain all barcodes in the output metrics, allowing users to filter as they want. 

We updated the import_data function so that min_number_fragments and min_tsse are set to 0. This avoids filtering of barcodes.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
