### PR TITLE
Update to bwa-mem2 in atac [dont merge!]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -114,4 +114,8 @@ workflows:
   - name: Multiome
     subclass: WDL
     primaryDescriptorPath: /beta-pipelines/multiome/multiome.wdl
+    
+  - name: scATAC
+    subclass: WDL
+    primaryDescriptorPath: /beta-pipelines/multiome/atac.wdl
 

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -115,7 +115,7 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /beta-pipelines/multiome/multiome.wdl
     
-  - name: scATAC
+  - name: scATAC-Multiome
     subclass: WDL
     primaryDescriptorPath: /beta-pipelines/multiome/atac.wdl
 

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -317,9 +317,6 @@ task BWAPairedEndAlignment {
       tar -xf "~{tar_bwa_reference}" -C $REF_DIR --strip-components 1
       rm "~{tar_bwa_reference}"
       
-      # index reference -- do I need to rebuild reference
-      bwa-mem2 index $REF_DIR/genome.fa
-      
       # align w/ bwa-mem2: -t for number of cores
       bwa-mem2 \
         mem \

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -264,7 +264,7 @@ task TrimAdapters {
     }
   }
 
-# align the two trimmed fastq as paired end data using BWA
+# align the two trimmed fastq as paired end data using bwa-mem2
 task BWAPairedEndAlignment {
     input {
       File read1_fastq
@@ -273,15 +273,17 @@ task BWAPairedEndAlignment {
       String read_group_id = "RG1"
       String read_group_sample_name = "RGSN1"
       String output_base_name
-      String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
+      String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685040811"
+      #"us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
       
       # script for monitoring tasks 
       File monitoring_script
       
       # Runtime attributes
-      Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 200 
+      # bwa-mem2 requires 9 times more memory than bwa and disk space 20 times larger than for bwa. (https://oyat.nl/bwa2/)
+      Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 400 
       Int nthreads = 16
-      Int mem_size = 8
+      Int mem_size = 40
     }
 
     parameter_meta {
@@ -294,7 +296,7 @@ task BWAPairedEndAlignment {
       mem_size: "the size of memory used during alignment"
       disk_size : "disk size used in bwa alignment step"
       output_base_name: "basename to be used for the output of the task"
-      docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091)"
+      docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685040811)"
       monitoring_script : "script to monitor resource comsumption of tasks"
     }
 
@@ -312,13 +314,15 @@ task BWAPairedEndAlignment {
         echo "No monitoring script given as input" > monitoring.log &
       fi
 
-      # prepare reference
       declare -r REF_DIR=$(mktemp -d genome_referenceXXXXXX)
       tar -xf "~{tar_bwa_reference}" -C $REF_DIR --strip-components 1
       rm "~{tar_bwa_reference}"
-
-      # align w/ BWA: -t for number of cores
-      bwa \
+      
+      # index reference -- do I need to rebuild reference
+      # ./bwa-mem2 index $REF_DIR/genome.fa
+      
+      # align w/ bwa-mem2: -t for number of cores
+      ./bwa-mem2 \
         mem \
         -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
         -t ~{nthreads} \

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -321,8 +321,8 @@ task BWAPairedEndAlignment {
       # index reference -- do I need to rebuild reference
       # ./bwa-mem2 index $REF_DIR/genome.fa
       
-      # align w/ bwa-mem2: -t for number of cores
-      ./bwa-mem2 \
+      # align w/ bwa-mem2: -t for number of cores -- need to change name -- not sure why its not changing when creating docker
+      bwa-mem2.sse42 \
         mem \
         -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
         -t ~{nthreads} \

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -273,8 +273,7 @@ task BWAPairedEndAlignment {
       String read_group_id = "RG1"
       String read_group_sample_name = "RGSN1"
       String output_base_name
-      String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685040811"
-      #"us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
+      String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504"
       
       # script for monitoring tasks 
       File monitoring_script
@@ -321,8 +320,8 @@ task BWAPairedEndAlignment {
       # index reference -- do I need to rebuild reference
       # ./bwa-mem2 index $REF_DIR/genome.fa
       
-      # align w/ bwa-mem2: -t for number of cores -- need to change name -- not sure why its not changing when creating docker
-      bwa-mem2.sse42 \
+      # align w/ bwa-mem2: -t for number of cores
+      bwa-mem2 \
         mem \
         -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
         -t ~{nthreads} \

--- a/beta-pipelines/multiome/atac.wdl
+++ b/beta-pipelines/multiome/atac.wdl
@@ -163,7 +163,7 @@ task FastqProcessing {
     # Call fastq process 
     # outputs fastq files where the corrected barcode is in the read name
     fastqprocess \
-        --bam-size 10.0 \
+        --bam-size 30.0 \
         --sample-id "~{output_base_name}" \
         --R1 barcodes.fastq.gz \
         --R2 r1.fastq.gz \
@@ -318,7 +318,7 @@ task BWAPairedEndAlignment {
       rm "~{tar_bwa_reference}"
       
       # index reference -- do I need to rebuild reference
-      # ./bwa-mem2 index $REF_DIR/genome.fa
+      bwa-mem2 index $REF_DIR/genome.fa
       
       # align w/ bwa-mem2: -t for number of cores
       bwa-mem2 \


### PR DESCRIPTION
We are currently using bwa-mem in the ATAC portion of our multiome pipeline, and this task has the highest cost. 

The goal is to use bwa-mem2 instead of bwa-mem for read alignment. 

A docker was created to use bwa-mem2, and the reference sequence was indexed using bwa-mem2. 

Link to this ticket can be found here: https://broadworkbench.atlassian.net/browse/PD-1586

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
