### PR TITLE
Update to bwa-mem2 in atac wdl

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2023-06-02 (Date of Last Commit)
+
+* Replaced bwa-mem with bwa-mem2 in BWAPairedEndAlignment task. 
+
 # 1.0.1
 
 2023-05-31 (Date of Last Commit)

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -4,7 +4,7 @@ import "../../../pipelines/skylab/multiome/atac.wdl" as atac
 import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 
 workflow Multiome {
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
         # Optimus Inputs

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2023-06-02 (Date of Last Commit)
+
+* Replaced bwa-mem with bwa-mem2 in BWAPairedEndAlignment task. 
+
 # 1.0.1
 
 2023-05-31 (Date of Last Commit)

--- a/pipelines/skylab/multiome/atac.json
+++ b/pipelines/skylab/multiome/atac.json
@@ -5,5 +5,5 @@
   "ATAC.TrimAdapters.adapter_seq_read2": "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG",
   "ATAC.output_base_name": "scATAC",
   "ATAC.monitoring_script": "gs://fc-51792410-8543-49ba-ad3f-9e274900879f/cromwell_monitoring_script2.sh",
-  "ATAC.tar_bwa_reference": "gs://broad-gotc-test-storage/scATAC/input/plumbing/reference/mm10/mm10.tar"
+  "ATAC.tar_bwa_reference": "gs://fc-dd55e131-ef49-4d02-aa2a-20640daaae1e/submissions/8f0dd71a-b42f-4503-b839-3f146941758a/IndexRef/53a91851-1f6c-4ab9-af66-b338ffb28b5a/call-BwaMem2Index/GRCh38.primary_assembly.genome.bwamem2.fa.tar"
 }

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -193,15 +193,15 @@ task BWAPairedEndAlignment {
     String read_group_id = "RG1"
     String read_group_sample_name = "RGSN1"
     String output_base_name
-    String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
+    String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504"
 
     # script for monitoring tasks
     File monitoring_script
 
     # Runtime attributes
-    Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 200
+    Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 400
     Int nthreads = 16
-    Int mem_size = 8
+    Int mem_size = 40
   }
 
   parameter_meta {
@@ -214,7 +214,7 @@ task BWAPairedEndAlignment {
     mem_size: "the size of memory used during alignment"
     disk_size : "disk size used in bwa alignment step"
     output_base_name: "basename to be used for the output of the task"
-    docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091)"
+    docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504)"
     monitoring_script : "script to monitor resource comsumption of tasks"
   }
 
@@ -238,7 +238,7 @@ task BWAPairedEndAlignment {
     rm "~{tar_bwa_reference}"
 
     # align w/ BWA: -t for number of cores
-    bwa \
+    bwa-mem2 \
     mem \
     -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
     -t ~{nthreads} \

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -37,7 +37,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "1.0.1"
+  String pipeline_version = "1.0.2"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
+++ b/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
@@ -18,7 +18,7 @@
     "gs://broad-gotc-test-storage/Multiome/input/plumbing/fastq_R3_atac.fastq.gz"
   ],
   "Multiome.ref_genome_fasta":"gs://gcp-public-data--broad-references/hg38/v0/GRCh38.primary_assembly.genome.fa",
-  "Multiome.tar_bwa_reference":"gs://broad-gotc-test-storage/Multiome/input/plumbing/bwa0.7.17-Human-GENCODE-build-GRCh38.tar",
+  "Multiome.tar_bwa_reference":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/GRCh38.primary_assembly.genome.bwamem2.fa.tar",
   "Multiome.tar_star_reference":"gs://broad-gotc-test-storage/Multiome/input/plumbing/modified_star2.7.10a-Human-GENCODE-build-GRCh38-43.tar",
   "Multiome.chrom_sizes":"gs://broad-gotc-test-storage/Multiome/input/hg38.chrom.sizes",
   "Multiome.monitoring_script":"gs://broad-gotc-test-storage/Multiome/input/cromwell_monitoring_script2.sh"

--- a/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
@@ -27,7 +27,7 @@
     "gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R3_001.fastq.gz"
   ],
   "Multiome.ref_genome_fasta":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/GRCh38.primary_assembly.genome.fa",
-  "Multiome.tar_bwa_reference":"gs://fc-dd55e131-ef49-4d02-aa2a-20640daaae1e/submissions/8f0dd71a-b42f-4503-b839-3f146941758a/IndexRef/53a91851-1f6c-4ab9-af66-b338ffb28b5a/call-BwaMem2Index/GRCh38.primary_assembly.genome.bwamem2.fa.tar",
+  "Multiome.tar_bwa_reference":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/GRCh38.primary_assembly.genome.bwamem2.fa.tar",
   "Multiome.tar_star_reference":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/modified_star_primary_gencode_Human_vGencode_V43.tar",
   "Multiome.chrom_sizes":"gs://broad-gotc-test-storage/Multiome/input/hg38.chrom.sizes",
   "Multiome.monitoring_script":"gs://broad-gotc-test-storage/Multiome/input/cromwell_monitoring_script2.sh"

--- a/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
@@ -27,7 +27,7 @@
     "gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R3_001.fastq.gz"
   ],
   "Multiome.ref_genome_fasta":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/GRCh38.primary_assembly.genome.fa",
-  "Multiome.tar_bwa_reference":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/bwa0.7.17-Human-GENCODE-build-GRCh38.tar",
+  "Multiome.tar_bwa_reference":"gs://fc-dd55e131-ef49-4d02-aa2a-20640daaae1e/submissions/8f0dd71a-b42f-4503-b839-3f146941758a/IndexRef/53a91851-1f6c-4ab9-af66-b338ffb28b5a/call-BwaMem2Index/GRCh38.primary_assembly.genome.bwamem2.fa.tar",
   "Multiome.tar_star_reference":"gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/modified_star_primary_gencode_Human_vGencode_V43.tar",
   "Multiome.chrom_sizes":"gs://broad-gotc-test-storage/Multiome/input/hg38.chrom.sizes",
   "Multiome.monitoring_script":"gs://broad-gotc-test-storage/Multiome/input/cromwell_monitoring_script2.sh"


### PR DESCRIPTION
We are currently using bwa-mem in the ATAC portion of our multiome pipeline, and this task has the highest cost.

The goal is to use bwa-mem2 instead of bwa-mem for read alignment.

A docker was created to use bwa-mem2, and the reference sequence was indexed using bwa-mem2.

Link to this ticket can be found here: https://broadworkbench.atlassian.net/browse/PD-1586

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [] Did you add inputs, outputs, or tasks to a workflow?
- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
