### PR TITLE
ATAC pipeline optimization for fastqprocess

### DIFF
--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -193,15 +193,15 @@ task BWAPairedEndAlignment {
     String read_group_id = "RG1"
     String read_group_sample_name = "RGSN1"
     String output_base_name
-    String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091"
+    String docker_image = "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504"
 
     # script for monitoring tasks
     File monitoring_script
 
     # Runtime attributes
-    Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 200
+    Int disk_size = ceil(3.25 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(tar_bwa_reference, "GiB"))) + 400
     Int nthreads = 16
-    Int mem_size = 8
+    Int mem_size = 40
   }
 
   parameter_meta {
@@ -214,7 +214,7 @@ task BWAPairedEndAlignment {
     mem_size: "the size of memory used during alignment"
     disk_size : "disk size used in bwa alignment step"
     output_base_name: "basename to be used for the output of the task"
-    docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa:1.0.0-0.7.17-1678998091)"
+    docker_image: "the docker image using BWA to be used (default: us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504)"
     monitoring_script : "script to monitor resource comsumption of tasks"
   }
 
@@ -238,7 +238,7 @@ task BWAPairedEndAlignment {
     rm "~{tar_bwa_reference}"
 
     # align w/ BWA: -t for number of cores
-    bwa \
+    bwa-mem2 \
     mem \
     -R "@RG\tID:~{read_group_id}\tSM:~{read_group_sample_name}" \
     -t ~{nthreads} \


### PR DESCRIPTION
We recently ran the full sized PBMC 10k dataset through our multiome pipeline. The goal here is to decrease the cost of the fastqprocessing task. 

We did the following:

- Swap files to decrease localization time. Change file specifications to string in WDL. At the beginning of the task, copy the file with another utility which is supposed to be faster. Use`gcloud storage cp`
- Don’t concatenate files – keep as array and give that as input to fastqprocess. 
- Increase bam_size to 30 (from 10) in fastqprocess (similar to Optimus). 

This corresponds to ticket: https://broadworkbench.atlassian.net/browse/PD-2250 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
