### PR TITLE
Np dynamically size memory compare gvcfs

### DIFF
--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -91,7 +91,7 @@ task CompareGvcfs {
 
   runtime {
     docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
-    disks: "local-disk 300 HDD"
+    disks: "local-disk 100 HDD"
     memory: "${memory_mb} MiB"
     preemptible: 3
   }

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 5000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 10000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,8 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
+    #Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
+    Int memory_mb = 200000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 35000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
     #Int memory_mb = 200000
   }
 

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 40000
     #Int memory_mb = 200000
   }
 

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -91,7 +91,7 @@ task CompareGvcfs {
 
   runtime {
     docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
-    disks: "local-disk 100 HDD"
+    disks: "local-disk 300 HDD"
     memory: "${memory_mb} MiB"
     preemptible: 3
   }

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,8 +71,8 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    #Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
-    Int memory_mb = 200000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 30000
+    #Int memory_mb = 200000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 40000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 45000
     #Int memory_mb = 200000
   }
 

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 3.75)
   }
 
   command {
@@ -92,7 +92,7 @@ task CompareGvcfs {
   runtime {
     docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
     disks: "local-disk 100 HDD"
-    memory: "110 GiB"
+    memory: "${memory_mb} MiB"
     preemptible: 3
   }
   

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5)
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 20
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 20
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 5000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 20000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 25000
   }
 
   command {
@@ -91,7 +91,7 @@ task CompareGvcfs {
 
   runtime {
     docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
-    disks: "local-disk 100 HDD"
+    disks: "local-disk 300 HDD"
     memory: "${memory_mb} MiB"
     preemptible: 3
   }

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 10000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 20000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,8 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 45000
-    #Int memory_mb = 200000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 40000
   }
 
   command {

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 30000
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5) + 35000
     #Int memory_mb = 200000
   }
 

--- a/verification/VerifyGermlineSingleSample.wdl
+++ b/verification/VerifyGermlineSingleSample.wdl
@@ -71,7 +71,7 @@ task CompareGvcfs {
   input {
     File test_gvcf
     File truth_gvcf
-    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 3.75)
+    Int memory_mb = ceil(size(test_gvcf, "MiB") + size(truth_gvcf, "MiB") * 5)
   }
 
   command {


### PR DESCRIPTION
### Description
CompareGVCFs keeps failing with OOM, so we are going to dynamically size the memory 

Here are passing scientific tests for JG and ultimaJG
https://gotc-jenkins.dsp-techops.broadinstitute.org/job/warp-workflow-tests/48195/console
https://gotc-jenkins.dsp-techops.broadinstitute.org/job/warp-workflow-tests/48223/console

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
