### PR TITLE
Lk pd 2190 make h5ad

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2023-06-08 (Date of Last Commit)
+
+* Added h5ad as a format option for the cell by gene matrix output
+
 # 1.0.1
 
 2023-05-31 (Date of Last Commit)

--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.2
 2023-06-08 (Date of Last Commit)
 
-* Added h5ad as a format option for the cell by gene matrix output
+* Added h5ad as a format option for the cell-by-gene matrix output
 
 # 1.0.1
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -105,7 +105,6 @@ workflow Multiome {
         File cell_metrics = Optimus.cell_metrics
         File gene_metrics = Optimus.gene_metrics
         File? cell_calls = Optimus.cell_calls
-        File loom_output_file = Optimus.loom_output_file
         File h5ad_output_file = Optimus.h5ad_output_file
     }
 }

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -4,7 +4,7 @@ import "../../../pipelines/skylab/multiome/atac.wdl" as atac
 import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 
 workflow Multiome {
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
         # Optimus Inputs
@@ -106,5 +106,6 @@ workflow Multiome {
         File gene_metrics = Optimus.gene_metrics
         File? cell_calls = Optimus.cell_calls
         File loom_output_file = Optimus.loom_output_file
+        File h5ad_output_file = Optimus.h5ad_output_file
     }
 }

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 5.9.0 
+2023-06-08 (Date of Last commit)
+
+* Added h5ad as a format option for the cell by gene matrix output. The h5ad has the same layers and global attributes (unstructured data in h5ad) as the previous Loom output
+
 # 5.8.3
 2023-05-31 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -248,7 +248,6 @@ workflow Optimus {
         gene_id_exon = MergeStarOutputsExons.col_index,
         pipeline_version = "Optimus_v~{pipeline_version}"
     }
-
   }
 
   File final_loom_output = select_first([OptimusLoomGenerationWithExons.loom_output, OptimusLoomGeneration.loom_output])
@@ -269,5 +268,5 @@ workflow Optimus {
     # loom
     File loom_output_file = final_loom_output
     File h5ad_output_file = final_h5ad_output
-}
+  }
 }

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -174,22 +174,6 @@ workflow Optimus {
   }
 
   if (!count_exons) {
-    call LoomUtils.OptimusLoomGeneration{
-      input:
-        input_id = input_id,
-        input_name = input_name,
-        input_id_metadata_field = input_id_metadata_field,
-        input_name_metadata_field = input_name_metadata_field,
-        annotation_file = annotations_gtf,
-        cell_metrics = CellMetrics.cell_metrics,
-        gene_metrics = GeneMetrics.gene_metrics,
-        sparse_count_matrix = MergeStarOutputs.sparse_counts,
-        cell_id = MergeStarOutputs.row_index,
-        gene_id = MergeStarOutputs.col_index,
-        empty_drops_result = RunEmptyDrops.empty_drops_result,
-        counting_mode = counting_mode,
-        pipeline_version = "Optimus_v~{pipeline_version}"
-    }
     call H5adUtils.OptimusH5adGeneration{
       input:
         input_id = input_id,
@@ -215,23 +199,6 @@ workflow Optimus {
         matrix = STARsoloFastq.matrix_sn_rna,
         input_id = input_id
     }
-    call LoomUtils.SingleNucleusOptimusLoomOutput as OptimusLoomGenerationWithExons{
-      input:
-        input_id = input_id,
-        input_name = input_name,
-        input_id_metadata_field = input_id_metadata_field,
-        input_name_metadata_field = input_name_metadata_field,
-        annotation_file = annotations_gtf,
-        cell_metrics = CellMetrics.cell_metrics,
-        gene_metrics = GeneMetrics.gene_metrics,
-        sparse_count_matrix = MergeStarOutputs.sparse_counts,
-        cell_id = MergeStarOutputs.row_index,
-        gene_id = MergeStarOutputs.col_index,
-        sparse_count_matrix_exon = MergeStarOutputsExons.sparse_counts,
-        cell_id_exon = MergeStarOutputsExons.row_index,
-        gene_id_exon = MergeStarOutputsExons.col_index,
-        pipeline_version = "Optimus_v~{pipeline_version}"
-    }
     call H5adUtils.SingleNucleusOptimusH5adOutput as OptimusH5adGenerationWithExons{
       input:
         input_id = input_id,
@@ -251,7 +218,6 @@ workflow Optimus {
     }
   }
 
-  File final_loom_output = select_first([OptimusLoomGenerationWithExons.loom_output, OptimusLoomGeneration.loom_output])
   File final_h5ad_output = select_first([OptimusH5adGenerationWithExons.h5ad_output, OptimusH5adGeneration.h5ad_output])
 
 
@@ -266,8 +232,7 @@ workflow Optimus {
     File cell_metrics = CellMetrics.cell_metrics
     File gene_metrics = GeneMetrics.gene_metrics
     File? cell_calls = RunEmptyDrops.empty_drops_result
-    # loom
-    File loom_output_file = final_loom_output
+    # h5ad
     File h5ad_output_file = final_h5ad_output
   }
 }

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -4,7 +4,6 @@ import "../../../tasks/skylab/FastqProcessing.wdl" as FastqProcessing
 import "../../../tasks/skylab/StarAlign.wdl" as StarAlign
 import "../../../tasks/skylab/Metrics.wdl" as Metrics
 import "../../../tasks/skylab/RunEmptyDrops.wdl" as RunEmptyDrops
-import "../../../tasks/skylab/LoomUtils.wdl" as LoomUtils
 import "../../../tasks/skylab/CheckInputs.wdl" as OptimusInputChecks
 import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -7,6 +7,7 @@ import "../../../tasks/skylab/RunEmptyDrops.wdl" as RunEmptyDrops
 import "../../../tasks/skylab/LoomUtils.wdl" as LoomUtils
 import "../../../tasks/skylab/CheckInputs.wdl" as OptimusInputChecks
 import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
+import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 
 workflow Optimus {
   meta {

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -189,6 +189,22 @@ workflow Optimus {
         counting_mode = counting_mode,
         pipeline_version = "Optimus_v~{pipeline_version}"
     }
+    call H5adUtils.OptimusH5adGeneration{
+      input:
+        input_id = input_id,
+        input_name = input_name,
+        input_id_metadata_field = input_id_metadata_field,
+        input_name_metadata_field = input_name_metadata_field,
+        annotation_file = annotations_gtf,
+        cell_metrics = CellMetrics.cell_metrics,
+        gene_metrics = GeneMetrics.gene_metrics,
+        sparse_count_matrix = MergeStarOutputs.sparse_counts,
+        cell_id = MergeStarOutputs.row_index,
+        gene_id = MergeStarOutputs.col_index,
+        empty_drops_result = RunEmptyDrops.empty_drops_result,
+        counting_mode = counting_mode,
+        pipeline_version = "Optimus_v~{pipeline_version}"
+    }
   }
   if (count_exons  && counting_mode=="sn_rna") {
     call StarAlign.MergeStarOutput as MergeStarOutputsExons {
@@ -215,10 +231,28 @@ workflow Optimus {
         gene_id_exon = MergeStarOutputsExons.col_index,
         pipeline_version = "Optimus_v~{pipeline_version}"
     }
+    call H5adUtils.SingleNucleusOptimusH5adOutput as OptimusH5adGenerationWithExons{
+      input:
+        input_id = input_id,
+        input_name = input_name,
+        input_id_metadata_field = input_id_metadata_field,
+        input_name_metadata_field = input_name_metadata_field,
+        annotation_file = annotations_gtf,
+        cell_metrics = CellMetrics.cell_metrics,
+        gene_metrics = GeneMetrics.gene_metrics,
+        sparse_count_matrix = MergeStarOutputs.sparse_counts,
+        cell_id = MergeStarOutputs.row_index,
+        gene_id = MergeStarOutputs.col_index,
+        sparse_count_matrix_exon = MergeStarOutputsExons.sparse_counts,
+        cell_id_exon = MergeStarOutputsExons.row_index,
+        gene_id_exon = MergeStarOutputsExons.col_index,
+        pipeline_version = "Optimus_v~{pipeline_version}"
+    }
 
   }
 
   File final_loom_output = select_first([OptimusLoomGenerationWithExons.loom_output, OptimusLoomGeneration.loom_output])
+  File final_h5ad_output = select_first([OptimusH5adGenerationWithExons.h5ad_output, OptimusH5adGeneration.h5ad_output])
 
 
   output {
@@ -234,5 +268,6 @@ workflow Optimus {
     File? cell_calls = RunEmptyDrops.empty_drops_result
     # loom
     File loom_output_file = final_loom_output
+    File h5ad_output_file = final_h5ad_output
 }
 }

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -64,7 +64,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "5.8.3"
+  String pipeline_version = "5.9.0"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -53,7 +53,7 @@ task OptimusH5adGeneration {
     touch empty_drops_result.csv
 
     if [ "~{counting_mode}" == "sc_rna" ]; then
-        python3 /warptools/tools/scripts/create_h5ad_optimus.py \
+        python3 /warptools/scripts/create_h5ad_optimus.py \
           ~{if defined(empty_drops_result) then "--empty_drops_file  " + empty_drops_result  else "--empty_drops_file empty_drops_result.csv "  } \
           --add_emptydrops_data ~{add_emptydrops_data} \
           --annotation_file ~{annotation_file} \
@@ -150,7 +150,7 @@ task SingleNucleusOptimusH5adOutput {
     command {
         set -euo pipefail
 
-        python3 /warptools/tools/scripts/create_snrna_optimus_exon_h5ad.py \
+        python3 warptools/scripts/create_snrna_optimus_exon_h5ad.py \
         --annotation_file ~{annotation_file} \
         --cell_metrics ~{cell_metrics} \
         --gene_metrics ~{gene_metrics} \

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686577614"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2190-make-h5ad"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686577614"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2190-make-h5ad"
         # name of the sample
         String input_id
         # user provided id

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686572906"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686577614"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686572906"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686577614"
         # name of the sample
         String input_id
         # user provided id

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -61,7 +61,7 @@ task OptimusH5adGeneration {
           --gene_metrics ~{gene_metrics} \
           --cell_id ~{cell_id} \
           --gene_id  ~{gene_id} \
-          --output_path_for_h5ad "~{input_id}.h5ad" \
+          --output_path_for_h5ad "~{input_id}" \
           --input_id ~{input_id} \
           ~{"--input_name " + input_name} \
           ~{"--input_id_metadata_field " + input_id_metadata_field} \
@@ -76,7 +76,7 @@ task OptimusH5adGeneration {
           --gene_metrics ~{gene_metrics} \
           --cell_id ~{cell_id} \
           --gene_id  ~{gene_id} \
-          --output_path_for_h5ad "~{input_id}.h5ad" \
+          --output_path_for_h5ad "~{input_id}" \
           --input_id ~{input_id} \
           ~{"--input_name " + input_name} \
           ~{"--input_id_metadata_field " + input_id_metadata_field} \
@@ -160,7 +160,7 @@ task SingleNucleusOptimusH5adOutput {
         --count_matrix_2 ~{sparse_count_matrix_exon} \
         --cell_id_2 ~{cell_id_exon} \
         --gene_id_2  ~{gene_id_exon} \
-        --output_path_for_h5ad "~{input_id}.h5ad" \
+        --output_path_for_h5ad "~{input_id}" \
         --input_id ~{input_id} \
         ~{"--input_name " + input_name} \
         ~{"--input_id_metadata_field " + input_id_metadata_field} \

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686246774"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686253441"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686246774"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686253441"
         # name of the sample
         String input_id
         # user provided id
@@ -150,7 +150,7 @@ task SingleNucleusOptimusH5adOutput {
     command {
         set -euo pipefail
 
-        python3 warptools/scripts/create_snrna_optimus_exon_h5ad.py \
+        python3 /warptools/scripts/create_snrna_optimus_exon_h5ad.py \
         --annotation_file ~{annotation_file} \
         --cell_metrics ~{cell_metrics} \
         --gene_metrics ~{gene_metrics} \

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686253441"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686572906"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686253441"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686572906"
         # name of the sample
         String input_id
         # user provided id

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2190-make-h5ad"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686671920"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2190-make-h5ad"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686671920"
         # name of the sample
         String input_id
         # user provided id

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -150,7 +150,7 @@ task SingleNucleusOptimusH5adOutput {
     command {
         set -euo pipefail
 
-        python3 /warptools/scripts/create_snrna_optimus_exon_h5ad.py \
+        python3 /warptools/scripts/create_snrna_optimus_exons_h5ad.py \
         --annotation_file ~{annotation_file} \
         --cell_metrics ~{cell_metrics} \
         --gene_metrics ~{gene_metrics} \

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -6,7 +6,7 @@ task OptimusH5adGeneration {
 
   input {
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686167237"
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686246774"
     # name of the sample
     String input_id
     # user provided id
@@ -105,7 +105,7 @@ task SingleNucleusOptimusH5adOutput {
 
     input {
         #runtime values
-        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686167237"
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686246774"
         # name of the sample
         String input_id
         # user provided id

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -1,0 +1,184 @@
+version 1.0
+
+
+
+task OptimusH5adGeneration {
+
+  input {
+    #runtime values
+    String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686167237"
+    # name of the sample
+    String input_id
+    # user provided id
+    String? input_name
+    String? input_id_metadata_field
+    String? input_name_metadata_field
+    # gene annotation file in GTF format
+    File annotation_file
+    # the file "merged-cell-metrics.csv.gz" that contains the cellwise metrics
+    File cell_metrics
+    # the file "merged-gene-metrics.csv.gz" that contains the  genwise metrics
+    File gene_metrics
+    # file (.npz)  that contains the count matrix
+    File sparse_count_matrix
+    # file (.npy) that contains the array of cell barcodes
+    File cell_id
+    # file (.npy) that contains the array of gene names
+    File gene_id
+    # emptydrops output metadata
+    File? empty_drops_result
+    String counting_mode = "sc_rna"
+    String add_emptydrops_data = "yes"
+
+
+    String pipeline_version
+
+    Int preemptible = 3
+    Int disk = 200
+    Int machine_mem_mb = 16000
+    Int cpu = 4
+  }
+
+  meta {
+    description: "This task will converts some of the outputs of Optimus pipeline into a h5ad file"
+  }
+
+  parameter_meta {
+    preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
+  }
+
+  command <<<
+    set -euo pipefail
+
+    touch empty_drops_result.csv
+
+    if [ "~{counting_mode}" == "sc_rna" ]; then
+        python3 /warptools/tools/scripts/create_h5ad_optimus.py \
+          ~{if defined(empty_drops_result) then "--empty_drops_file  " + empty_drops_result  else "--empty_drops_file empty_drops_result.csv "  } \
+          --add_emptydrops_data ~{add_emptydrops_data} \
+          --annotation_file ~{annotation_file} \
+          --cell_metrics ~{cell_metrics} \
+          --gene_metrics ~{gene_metrics} \
+          --cell_id ~{cell_id} \
+          --gene_id  ~{gene_id} \
+          --output_path_for_h5ad "~{input_id}.h5ad" \
+          --input_id ~{input_id} \
+          ~{"--input_name " + input_name} \
+          ~{"--input_id_metadata_field " + input_id_metadata_field} \
+          ~{"--input_name_metadata_field " + input_name_metadata_field} \
+          --count_matrix ~{sparse_count_matrix} \
+          --expression_data_type "exonic" \
+          --pipeline_version ~{pipeline_version}
+    else
+        python3 /warptools/scripts/create_snrna_optimus_full_h5ad.py \
+          --annotation_file ~{annotation_file} \
+          --cell_metrics ~{cell_metrics} \
+          --gene_metrics ~{gene_metrics} \
+          --cell_id ~{cell_id} \
+          --gene_id  ~{gene_id} \
+          --output_path_for_h5ad "~{input_id}.h5ad" \
+          --input_id ~{input_id} \
+          ~{"--input_name " + input_name} \
+          ~{"--input_id_metadata_field " + input_id_metadata_field} \
+          ~{"--input_name_metadata_field " + input_name_metadata_field} \
+          --count_matrix ~{sparse_count_matrix} \
+          --expression_data_type "whole_transcript"\
+          --pipeline_version ~{pipeline_version}
+    fi
+  >>>
+
+  runtime {
+    docker: docker
+    cpu: cpu  # note that only 1 thread is supported by pseudobam
+    memory: "~{machine_mem_mb} MiB"
+    disks: "local-disk ~{disk} HDD"
+    disk: disk + " GB" # TES
+    preemptible: preemptible
+  }
+
+  output {
+    File h5ad_output = "~{input_id}.h5ad"
+  }
+}
+
+task SingleNucleusOptimusH5adOutput {
+
+    input {
+        #runtime values
+        String docker = "us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686167237"
+        # name of the sample
+        String input_id
+        # user provided id
+        String? input_name
+        String? input_id_metadata_field
+        String? input_name_metadata_field
+        # gene annotation file in GTF format
+        File annotation_file
+        # the file "merged-cell-metrics.csv.gz" that contains the cellwise metrics
+        File cell_metrics
+        # the file "merged-gene-metrics.csv.gz" that contains the  genwise metrics
+        File gene_metrics
+        # file (.npz)  that contains the count matrix
+        File sparse_count_matrix
+        # file (.npy) that contains the array of cell barcodes
+        File cell_id
+        # file (.npy) that contains the array of gene names
+        File gene_id
+        # the file "merged-gene-metrics.csv.gz" that contains the  genwise metrics
+        File sparse_count_matrix_exon
+        # file (.npy) that contains the array of cell barcodes
+        File cell_id_exon
+        # file (.npy) that contains the array of gene names
+        File gene_id_exon
+
+        String pipeline_version
+
+        Int preemptible = 3
+        Int disk = 200
+        Int machine_mem_mb = 16000
+        Int cpu = 4
+    }
+
+    meta {
+        description: "This task will converts some of the outputs of Optimus pipeline into a h5ad file"
+    }
+
+    parameter_meta {
+        preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
+    }
+
+    command {
+        set -euo pipefail
+
+        python3 /warptools/tools/scripts/create_snrna_optimus_exon_h5ad.py \
+        --annotation_file ~{annotation_file} \
+        --cell_metrics ~{cell_metrics} \
+        --gene_metrics ~{gene_metrics} \
+        --count_matrix_1 ~{sparse_count_matrix} \
+        --cell_id_1 ~{cell_id} \
+        --gene_id_1  ~{gene_id} \
+        --count_matrix_2 ~{sparse_count_matrix_exon} \
+        --cell_id_2 ~{cell_id_exon} \
+        --gene_id_2  ~{gene_id_exon} \
+        --output_path_for_h5ad "~{input_id}.h5ad" \
+        --input_id ~{input_id} \
+        ~{"--input_name " + input_name} \
+        ~{"--input_id_metadata_field " + input_id_metadata_field} \
+        ~{"--input_name_metadata_field " + input_name_metadata_field} \
+        --expression_data_type "whole_transcript" \
+        --pipeline_version ~{pipeline_version}
+    }
+
+    runtime {
+        docker: docker
+        cpu: cpu  # note that only 1 thread is supported by pseudobam
+        memory: "~{machine_mem_mb} MiB"
+        disks: "local-disk ~{disk} HDD"
+        disk: disk + " GB" # TES
+        preemptible: preemptible
+    }
+
+    output {
+        File h5ad_output = "~{input_id}.h5ad"
+    }
+}

--- a/verification/VerifyMultiome.wdl
+++ b/verification/VerifyMultiome.wdl
@@ -5,9 +5,6 @@ import "../verification/VerifyTasks.wdl" as VerifyTasks
 workflow VerifyMultiome {
 
     input {
-        File test_loom
-        File truth_loom
-
         File test_optimus_h5ad
         File truth_optimus_h5ad
 

--- a/verification/VerifyMultiome.wdl
+++ b/verification/VerifyMultiome.wdl
@@ -8,6 +8,9 @@ workflow VerifyMultiome {
         File test_loom
         File truth_loom
 
+        File test_optimus_h5ad
+        File truth_optimus_h5ad
+
         File test_optimus_bam
         File truth_optimus_bam
 
@@ -23,8 +26,8 @@ workflow VerifyMultiome {
         File test_fragment_file
         File truth_fragment_file
 
-        File test_h5ad
-        File truth_h5ad
+        File test_atac_h5ad
+        File truth_atac_h5ad
 
         Boolean? done
     }
@@ -67,9 +70,14 @@ workflow VerifyMultiome {
             truth_text_files = [truth_fragment_file]
     }
 
-    call VerifyTasks.CompareH5adFiles as CompareH5adFiles {
+    call VerifyTasks.CompareH5adFiles as CompareH5adFilesATAC {
         input:
-            test_h5ad  = test_h5ad,
-            truth_h5ad = truth_h5ad
+            test_atac_h5ad  = test_atac_h5ad,
+            truth_atac_h5ad = truth_atac_h5ad
+    }
+    call VerifyTasks.CompareH5adFiles as CompareH5adFilesOptimus {
+        input:
+            test_optimus_h5ad  = test_optimus_h5ad,
+            truth_optimus_h5ad = truth_optimus_h5ad
     }
 }

--- a/verification/VerifyMultiome.wdl
+++ b/verification/VerifyMultiome.wdl
@@ -66,12 +66,12 @@ workflow VerifyMultiome {
 
     call VerifyTasks.CompareH5adFiles as CompareH5adFilesATAC {
         input:
-            test_atac_h5ad  = test_atac_h5ad,
-            truth_atac_h5ad = truth_atac_h5ad
+            test_h5ad  = test_atac_h5ad,
+            truth_h5ad = truth_atac_h5ad
     }
     call VerifyTasks.CompareH5adFiles as CompareH5adFilesOptimus {
         input:
-            test_optimus_h5ad  = test_optimus_h5ad,
-            truth_optimus_h5ad = truth_optimus_h5ad
+            test_h5ad  = test_optimus_h5ad,
+            truth_h5ad = truth_optimus_h5ad
     }
 }

--- a/verification/VerifyMultiome.wdl
+++ b/verification/VerifyMultiome.wdl
@@ -51,12 +51,6 @@ workflow VerifyMultiome {
             truth_zip = truth_cell_metrics
     }
 
-    call VerifyTasks.CompareLooms as CompareLooms {
-        input:
-            test_loom  = test_loom,
-            truth_loom = truth_loom
-    }
-
     call VerifyTasks.CompareBams as CompareAtacBams {
         input:
             test_bam       = test_atac_bam,

--- a/verification/VerifyOptimus.wdl
+++ b/verification/VerifyOptimus.wdl
@@ -8,6 +8,9 @@ workflow VerifyOptimus {
     File test_loom
     File truth_loom
 
+    File test_h5ad
+    File truth_h5ad
+
     File test_bam
     File truth_bam
 
@@ -44,5 +47,11 @@ workflow VerifyOptimus {
       test_loom  = test_loom,
       truth_loom = truth_loom
   }
+  
+  call VerifyTasks.CompareH5adFiles as CompareH5adFilesOptimus {
+        input:
+            test_h5ad  = test_h5ad,
+            truth_h5ad = truth_h5ad
+    }
 
 }

--- a/verification/VerifyOptimus.wdl
+++ b/verification/VerifyOptimus.wdl
@@ -41,12 +41,6 @@ workflow VerifyOptimus {
       test_zip  = test_cell_metrics,
       truth_zip = truth_cell_metrics
   }
-
-  call VerifyTasks.CompareLooms as CompareLooms{
-    input:
-      test_loom  = test_loom,
-      truth_loom = truth_loom
-  }
   
   call VerifyTasks.CompareH5adFiles as CompareH5adFilesOptimus {
         input:

--- a/verification/VerifyOptimus.wdl
+++ b/verification/VerifyOptimus.wdl
@@ -5,9 +5,6 @@ import "../verification/VerifyTasks.wdl" as VerifyTasks
 workflow VerifyOptimus {
   
   input {
-    File test_loom
-    File truth_loom
-
     File test_h5ad
     File truth_h5ad
 

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -151,6 +151,12 @@ workflow TestMultiome {
             results_path = results_path,
             truth_path = truth_path
         }
+        call Utilities.GetValidationInputs as GetOptimusH5ad {
+          input:
+            input_file = Multiome.h5ad_output_file,
+            results_path = results_path,
+            truth_path = truth_path
+        }
         call Utilities.GetValidationInputs as GetOptimusBam {
           input:
             input_file = Multiome.bam,
@@ -192,6 +198,8 @@ workflow TestMultiome {
         input:
           truth_loom = GetLoom.truth_file, 
           test_loom = GetLoom.results_file,
+          truth_optimus_h5ad = GetOptimusH5ad.truth_file,
+          test_optimus_h5ad =GetOptimusH5ad.results_file
           truth_optimus_bam = GetOptimusBam.truth_file, 
           test_optimus_bam = GetOptimusBam.results_file,
           truth_gene_metrics = GetGeneMetrics.truth_file, 
@@ -202,8 +210,8 @@ workflow TestMultiome {
           test_atac_bam = GetAtacBam.results_file,
           truth_fragment_file = GetFragmentFile.truth_file,
           test_fragment_file = GetFragmentFile.results_file,
-          truth_h5ad = GetSnapMetrics.truth_file,
-          test_h5ad = GetSnapMetrics.results_file,
+          truth_atac_h5ad = GetSnapMetrics.truth_file,
+          test_atac_h5ad = GetSnapMetrics.results_file,
           done = CopyToTestResults.done
       }
     }

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -98,7 +98,7 @@ workflow TestMultiome {
     # Collect all of the pipeline outputs into single Array[String]
     Array[String] pipeline_outputs = flatten([
                                     [ # File outputs
-                                    Multiome.loom_output_file,
+                                    Multiome.h5ad_output_file,
                                     Multiome.matrix_col_index,
                                     Multiome.matrix_row_index,
                                     Multiome.matrix,

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -145,12 +145,6 @@ workflow TestMultiome {
 
     # This is achieved by passing each desired file/array[files] to GetValidationInputs
     if (!update_truth){
-        call Utilities.GetValidationInputs as GetLoom {
-          input:
-            input_file = Multiome.loom_output_file,
-            results_path = results_path,
-            truth_path = truth_path
-        }
         call Utilities.GetValidationInputs as GetOptimusH5ad {
           input:
             input_file = Multiome.h5ad_output_file,
@@ -196,8 +190,6 @@ workflow TestMultiome {
 
       call VerifyMultiome.VerifyMultiome as Verify {
         input:
-          truth_loom = GetLoom.truth_file, 
-          test_loom = GetLoom.results_file,
           truth_optimus_h5ad = GetOptimusH5ad.truth_file,
           test_optimus_h5ad =GetOptimusH5ad.results_file
           truth_optimus_bam = GetOptimusBam.truth_file, 

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -191,7 +191,7 @@ workflow TestMultiome {
       call VerifyMultiome.VerifyMultiome as Verify {
         input:
           truth_optimus_h5ad = GetOptimusH5ad.truth_file,
-          test_optimus_h5ad =GetOptimusH5ad.results_file
+          test_optimus_h5ad = GetOptimusH5ad.results_file,
           truth_optimus_bam = GetOptimusBam.truth_file, 
           test_optimus_bam = GetOptimusBam.results_file,
           truth_gene_metrics = GetGeneMetrics.truth_file, 

--- a/verification/test-wdls/TestOptimus.wdl
+++ b/verification/test-wdls/TestOptimus.wdl
@@ -95,6 +95,7 @@ workflow TestOptimus {
                                       Optimus.matrix_col_index,
                                       Optimus.cell_calls,
                                       Optimus.loom_output_file,
+                                      Optimus.h5ad_output_file,
   ])
 
   # Collect all of the pipeline metrics into a single Array
@@ -131,6 +132,13 @@ workflow TestOptimus {
         truth_path   = truth_path
     }
 
+    call Utilities.GetValidationInputs as GetH5adInputs {
+      input:
+        input_file   = Optimus.h5ad_output_file,
+        results_path = results_path,
+        truth_path   = truth_path
+    }
+
     call Utilities.GetValidationInputs as GetBamInputs {
       input:
         input_file   = Optimus.bam,
@@ -155,10 +163,12 @@ workflow TestOptimus {
     call VerifyOptimus.VerifyOptimus as Verify {
       input:
         test_loom          = GetLoomInputs.results_file,
+        test_h5ad          = GetH5adInputs.results_file,
         test_bam           = GetBamInputs.results_file,
         test_gene_metrics  = GetGeneMetrics.results_file,
         test_cell_metrics  = GetCellMetrics.results_file,
         truth_loom         = GetLoomInputs.truth_file,
+        truth_h5ad         = GetH5adInputs.truth_file,
         truth_bam          = GetBamInputs.truth_file,
         truth_gene_metrics = GetGeneMetrics.truth_file,
         truth_cell_metrics = GetCellMetrics.truth_file,

--- a/verification/test-wdls/TestOptimus.wdl
+++ b/verification/test-wdls/TestOptimus.wdl
@@ -162,12 +162,10 @@ workflow TestOptimus {
 
     call VerifyOptimus.VerifyOptimus as Verify {
       input:
-        test_loom          = GetLoomInputs.results_file,
         test_h5ad          = GetH5adInputs.results_file,
         test_bam           = GetBamInputs.results_file,
         test_gene_metrics  = GetGeneMetrics.results_file,
         test_cell_metrics  = GetCellMetrics.results_file,
-        truth_loom         = GetLoomInputs.truth_file,
         truth_h5ad         = GetH5adInputs.truth_file,
         truth_bam          = GetBamInputs.truth_file,
         truth_gene_metrics = GetGeneMetrics.truth_file,

--- a/verification/test-wdls/TestOptimus.wdl
+++ b/verification/test-wdls/TestOptimus.wdl
@@ -94,7 +94,6 @@ workflow TestOptimus {
                                       Optimus.matrix_row_index,
                                       Optimus.matrix_col_index,
                                       Optimus.cell_calls,
-                                      Optimus.loom_output_file,
                                       Optimus.h5ad_output_file,
   ])
 
@@ -125,13 +124,6 @@ workflow TestOptimus {
 
   # If not updating truth then gather the inputs and call verification wdl
   if (!update_truth) {
-    call Utilities.GetValidationInputs as GetLoomInputs {
-      input:
-        input_file   = Optimus.loom_output_file,
-        results_path = results_path,
-        truth_path   = truth_path
-    }
-
     call Utilities.GetValidationInputs as GetH5adInputs {
       input:
         input_file   = Optimus.h5ad_output_file,


### PR DESCRIPTION
### Description
We're removing the Loom output because Loom is no longer supported and replacing it with h5ad. As a first pass, this PR adds the h5ad file as an additional input. We'll compare the two outputs after tests run. Once comparison is complete, we'll remove the Loom task and outputs. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [x ] Did you add inputs, outputs, or tasks to a workflow?
- [x ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
