### PR TITLE
Make ATAC and Optimus output variables and output file names unique

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,19 +1,5 @@
-# 1.0.2
-2023-06-12 (Date of Last Commit)
-
-* Updated cutadapt v1.8 to cutadapt v4.4 in the TrimAdapters task to speed up the task and reduce cost
-* Added Dropseq cell metrics to Multiome and Optimus workflows 
-* Added h5ad as a format option for the cell-by-gene matrix output
-* Replaced bwa-mem with bwa-mem2 in BWAPairedEndAlignment task. 
-
-
-# 1.0.1
-2023-05-31 (Date of Last Commit)
-
-* Removed the barcodes_in_read_name boolean from the inputs
-
 # 1.0.0
-2023-05-22 (Date of Last Commit)
+2023-06-16 (Date of Last Commit)
 
-* Initial release of the multiome pipeline. 
+* Initial release of the multiome pipeline
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -4,7 +4,7 @@ import "../../../pipelines/skylab/multiome/atac.wdl" as atac
 import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 
 workflow Multiome {
-    String pipeline_version = "1.0.2"
+    String pipeline_version = "1.0.0"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,13 +7,13 @@ workflow Multiome {
     String pipeline_version = "1.0.2"
 
     input {
+        String input_id
+
         # Optimus Inputs
         String counting_mode = "sn_rna"
         Array[File] gex_r1_fastq
         Array[File] gex_r2_fastq
-        Array[File]? gex_i1_fastq
-        String input_id
-        String output_bam_basename = input_id
+        Array[File]? gex_i1_fastq        
         File tar_star_reference
         File annotations_gtf
         File ref_genome_fasta
@@ -32,11 +32,8 @@ workflow Multiome {
         Array[File] atac_r1_fastq
         Array[File] atac_r2_fastq
         Array[File] atac_r3_fastq
-        # Output name
-        String output_base_name
         # BWA input
         File tar_bwa_reference
-
         File chrom_sizes
         # Trimadapters input
         String adapter_seq_read1 = "GTCTCGTGGGCTCGGAGATGTGTATAAGAGACAG"
@@ -56,8 +53,8 @@ workflow Multiome {
             r1_fastq = gex_r1_fastq,
             r2_fastq = gex_r2_fastq,
             i1_fastq = gex_i1_fastq,
-            input_id = input_id,
-            output_bam_basename = output_bam_basename,
+            input_id = input_id + "_gex",
+            output_bam_basename = input_id + "_gex",
             tar_star_reference = tar_star_reference,
             annotations_gtf = annotations_gtf,
             ref_genome_fasta = ref_genome_fasta,
@@ -78,7 +75,7 @@ workflow Multiome {
             read1_fastq_gzipped = atac_r1_fastq,
             read2_fastq_gzipped = atac_r2_fastq,
             read3_fastq_gzipped = atac_r3_fastq,
-            output_base_name = output_base_name,
+            input_id = input_id + "_atac",
             tar_bwa_reference = tar_bwa_reference,
             monitoring_script = monitoring_script,
             annotations_gtf = annotations_gtf,
@@ -92,22 +89,24 @@ workflow Multiome {
     }
 
     output {
+        
+        String multiome_pipeline_version_out = pipeline_version
+
         # atac outputs
-        File bam_aligned_output = Atac.bam_aligned_output
-        File fragment_file = Atac.fragment_file
-        File snap_metrics = Atac.snap_metrics
+        File bam_aligned_output_atac = Atac.bam_aligned_output
+        File fragment_file_atac = Atac.fragment_file
+        File snap_metrics_atac = Atac.snap_metrics
 
         # optimus outputs
-        String pipeline_version_out = Optimus.pipeline_version_out
-        File genomic_reference_version = Optimus.genomic_reference_version
-        File bam = Optimus.bam
-        File matrix = Optimus.matrix
-        File matrix_row_index = Optimus.matrix_row_index
-        File matrix_col_index = Optimus.matrix_col_index
-        File cell_metrics = Optimus.cell_metrics
-        File gene_metrics = Optimus.gene_metrics
-        File? cell_calls = Optimus.cell_calls
-        File? picard_metrics = Optimus.picard_metrics
-        File h5ad_output_file = Optimus.h5ad_output_file
+        File genomic_reference_version_gex = Optimus.genomic_reference_version
+        File bam_gex = Optimus.bam
+        File matrix_gex = Optimus.matrix
+        File matrix_row_index_gex = Optimus.matrix_row_index
+        File matrix_col_index_gex = Optimus.matrix_col_index
+        File cell_metrics_gex = Optimus.cell_metrics
+        File gene_metrics_gex = Optimus.gene_metrics
+        File? cell_calls_gex = Optimus.cell_calls
+        File? picard_metrics_gex = Optimus.picard_metrics
+        File h5ad_output_file_gex = Optimus.h5ad_output_file
     }
 }

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,18 +1,4 @@
-# 1.0.2
-
-2023-06-12 (Date of Last Commit)
-
-* Updated cutadapt v1.8 to cutadapt v4.4 in the TrimAdapters task to speed up the task and reduce cost. 
-* Replaced bwa-mem with bwa-mem2 in BWAPairedEndAlignment task. 
-
-# 1.0.1
-
-2023-05-31 (Date of Last Commit)
-
-* Moved the FastqProcessing task to the FastqProcessing WDL and renamed it FastqProcessATAC.
-
 # 1.0.0
+2023-06-16 (Date of Last Commit)
 
-2023-05-22 (Date of Last Commit)
-
-* Initial release of the atac pipeline 
+* Initial release of the ATAC pipeline

--- a/pipelines/skylab/multiome/atac.json
+++ b/pipelines/skylab/multiome/atac.json
@@ -3,7 +3,7 @@
   "ATAC.fastq_gzipped_input_read2": "gs://fc-df397f36-b664-4312-a2cb-73647851e484/10k_PBMC_Multiome_nextgem_Chromium_Controller_atac/10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L004_R3_001.fastq.gz",
   "ATAC.TrimAdapters.adapter_seq_read1": "GTCTCGTGGGCTCGGAGATGTGTATAAGAGACAG",
   "ATAC.TrimAdapters.adapter_seq_read2": "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG",
-  "ATAC.output_base_name": "scATAC",
+  "ATAC.input_id": "scATAC",
   "ATAC.monitoring_script": "gs://fc-51792410-8543-49ba-ad3f-9e274900879f/cromwell_monitoring_script2.sh",
   "ATAC.tar_bwa_reference": "gs://fc-dd55e131-ef49-4d02-aa2a-20640daaae1e/submissions/8f0dd71a-b42f-4503-b839-3f146941758a/IndexRef/53a91851-1f6c-4ab9-af66-b338ffb28b5a/call-BwaMem2Index/GRCh38.primary_assembly.genome.bwamem2.fa.tar"
 }

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -37,7 +37,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "1.0.2"
+  String pipeline_version = "1.0.0"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -16,7 +16,7 @@ workflow ATAC {
     Array[File] read3_fastq_gzipped
 
     # Output prefix/base name for all intermediate files and pipeline outputs
-    String output_base_name
+    String input_id
 
     # BWA ref
     File tar_bwa_reference
@@ -54,7 +54,7 @@ workflow ATAC {
       read1_fastq = read1_fastq_gzipped,
       read3_fastq = read3_fastq_gzipped,
       barcodes_fastq = read2_fastq_gzipped,
-      output_base_name = output_base_name,
+      output_base_name = input_id,
       whitelist = whitelist
   }
 
@@ -64,7 +64,7 @@ workflow ATAC {
       input:
         read1_fastq = SplitFastq.fastq_R1_output_array[idx],
         read3_fastq = SplitFastq.fastq_R3_output_array[idx],
-        output_base_name = output_base_name + "_" + idx,
+        output_base_name = input_id + "_" + idx,
         monitoring_script = monitoring_script,
         adapter_seq_read1 = adapter_seq_read1,
         adapter_seq_read3 = adapter_seq_read3
@@ -75,14 +75,14 @@ workflow ATAC {
         read1_fastq = TrimAdapters.fastq_trimmed_adapter_output_read1,
         read3_fastq = TrimAdapters.fastq_trimmed_adapter_output_read3,
         tar_bwa_reference = tar_bwa_reference,
-        output_base_name = output_base_name + "_" + idx,
+        output_base_name = input_id + "_" + idx,
         monitoring_script = monitoring_script
     }
 
     call AddCBtags {
       input:
         bam = BWAPairedEndAlignment.bam_aligned_output,
-        output_base_name = output_base_name
+        output_base_name = input_id
     }
 
   }
@@ -90,7 +90,7 @@ workflow ATAC {
   call Merge.MergeSortBamFiles as MergeBam {
     input:
       bam_inputs = AddCBtags.output_cb_bam,
-      output_bam_filename = output_base_name + ".bam",
+      output_bam_filename = input_id + ".bam",
       sort_order = "coordinate"
   }
 

--- a/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
+++ b/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
@@ -1,7 +1,6 @@
 {
   "Multiome.annotations_gtf":"gs://broad-gotc-test-storage/Multiome/input/plumbing/modified_v43.annotation.gtf",
   "Multiome.input_id":"10k_PBMC_downsampled",
-  "Multiome.output_base_name":"scATAC",
   "Multiome.gex_r1_fastq":[
     "gs://broad-gotc-test-storage/Multiome/input/plumbing/fastq_R1_gex.fastq.gz"
   ],

--- a/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
@@ -5,7 +5,6 @@
   "gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/10k_PBMC_Multiome_nextgem_Chromium_Controller_gex_S1_L002_I1_001.fastq.gz"
 ],
   "Multiome.input_id":"10k_PBMC",
-  "Multiome.output_base_name":"scATAC",
   "Multiome.gex_r1_fastq":[
     "gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/10k_PBMC_Multiome_nextgem_Chromium_Controller_gex_S1_L001_R1_001.fastq.gz",
     "gs://broad-gotc-test-storage/Multiome/input/scientific/10k_PBMC_Multiome/10k_PBMC_Multiome_nextgem_Chromium_Controller_gex_S1_L002_R1_001.fastq.gz"

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -34,8 +34,7 @@ workflow TestMultiome {
       Array[File] atac_r1_fastq
       Array[File] atac_r2_fastq
       Array[File] atac_r3_fastq
-      # Output name
-      String output_base_name
+
       # BWA input
       File tar_bwa_reference
       # CreateFragmentFile input

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -9,13 +9,13 @@ import "../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 workflow TestMultiome {
 
     input {
+      String input_id
+
       # Optimus Inputs
       String counting_mode = "sn_rna"
       Array[File] gex_r1_fastq
       Array[File] gex_r2_fastq
       Array[File]? gex_i1_fastq
-      String input_id
-      String output_bam_basename = input_id
       File tar_star_reference
       File annotations_gtf
       File ref_genome_fasta
@@ -39,7 +39,6 @@ workflow TestMultiome {
       # BWA input
       File tar_bwa_reference
       # CreateFragmentFile input
-      File annotations_gtf
       File chrom_sizes
       # Trimadapters input
       String adapter_seq_read1 = "GTCTCGTGGGCTCGGAGATGTGTATAAGAGACAG"
@@ -70,7 +69,6 @@ workflow TestMultiome {
         gex_r2_fastq = gex_r2_fastq,
         gex_i1_fastq = gex_i1_fastq,
         input_id = input_id,
-        output_bam_basename = output_bam_basename,
         tar_star_reference = tar_star_reference,
         annotations_gtf = annotations_gtf,
         ref_genome_fasta = ref_genome_fasta,
@@ -86,7 +84,6 @@ workflow TestMultiome {
         atac_r1_fastq = atac_r1_fastq,
         atac_r2_fastq = atac_r2_fastq,
         atac_r3_fastq = atac_r3_fastq,
-        output_base_name = output_base_name,
         tar_bwa_reference = tar_bwa_reference,
         monitoring_script = monitoring_script,
         adapter_seq_read1 = adapter_seq_read1,
@@ -99,19 +96,20 @@ workflow TestMultiome {
     
     # Collect all of the pipeline outputs into single Array[String]
     Array[String] pipeline_outputs = flatten([
-                                    [ # File outputs
-                                    Multiome.h5ad_output_file,
-                                    Multiome.matrix_col_index,
-                                    Multiome.matrix_row_index,
-                                    Multiome.matrix,
-                                    Multiome.bam,
-                                    Multiome.genomic_reference_version,
-                                    Multiome.fragment_file,
-                                    Multiome.bam_aligned_output,
-                                    Multiome.snap_metrics
+                                    [ # Optimus file outputs
+                                    Multiome.h5ad_output_file_gex,
+                                    Multiome.matrix_col_index_gex,
+                                    Multiome.matrix_row_index_gex,
+                                    Multiome.matrix_gex,
+                                    Multiome.bam_gex,
+                                    Multiome.genomic_reference_version_gex,
+                                    # atac file outputs
+                                    Multiome.fragment_file_atac,
+                                    Multiome.bam_aligned_output_atac,
+                                    Multiome.snap_metrics_atac
                                     ],
                                     # File? outputs
-                                    select_all([Multiome.cell_calls]),
+                                    select_all([Multiome.cell_calls_gex]),
                                     
     ])
 
@@ -119,8 +117,8 @@ workflow TestMultiome {
     # Collect all of the pipeline metrics into single Array[String]
     Array[String] pipeline_metrics = flatten([
                                     [ # File outputs
-                                    Multiome.gene_metrics,
-                                    Multiome.cell_metrics
+                                    Multiome.gene_metrics_gex,
+                                    Multiome.cell_metrics_gex
                                     ],
                                     
     ])
@@ -149,43 +147,43 @@ workflow TestMultiome {
     if (!update_truth){
         call Utilities.GetValidationInputs as GetOptimusH5ad {
           input:
-            input_file = Multiome.h5ad_output_file,
+            input_file = Multiome.h5ad_output_file_gex,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetOptimusBam {
           input:
-            input_file = Multiome.bam,
+            input_file = Multiome.bam_gex,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetGeneMetrics {
           input:
-            input_file = Multiome.gene_metrics,
+            input_file = Multiome.gene_metrics_gex,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetCellMetrics {
           input:
-            input_file = Multiome.cell_metrics,
+            input_file = Multiome.cell_metrics_gex,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetAtacBam {
           input:
-            input_file = Multiome.bam_aligned_output,
+            input_file = Multiome.bam_aligned_output_atac,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetFragmentFile {
           input:
-            input_file = Multiome.fragment_file,
+            input_file = Multiome.fragment_file_atac,
             results_path = results_path,
             truth_path = truth_path
         }
         call Utilities.GetValidationInputs as GetSnapMetrics {
           input:
-            input_file = Multiome.snap_metrics,
+            input_file = Multiome.snap_metrics_atac,
             results_path = results_path,
             truth_path = truth_path
         }


### PR DESCRIPTION
The output file names need to include atac or gex to differentiate where the files came from. For instance,  [input-id]_atac.aligned.bam.

For consistency we can include this in all output file names (even when unique, like the fragment file).

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
