### PR TITLE
Add VariantCalling to Dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -122,4 +122,3 @@ workflows:
   - name: VariantCalling
     subclass: WDL
     primaryDescriptorPath: /pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
-

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -119,3 +119,7 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipelines/skylab/multiome/atac.wdl
 
+  - name: VariantCalling
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+


### PR DESCRIPTION
### Description
A user wants to run VariantCalling directly in Terra. Apparently we don't currently have this one in our Dockstore integration. This addresses that issue. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
