### PR TITLE
Less wall clock time to run Imputation WDL

### DIFF
--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.11
+2023-08-01 (Date of last Commit)
+
+* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatter to help with wall clock time
+
 # 1.1.10
 2023-03-03 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,7 +1,7 @@
 # 1.1.11
 2023-08-01 (Date of last Commit)
 
-* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatter to help with wall clock time
+* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatters to help with wall clock time
 
 # 1.1.10
 2023-03-03 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -305,18 +305,20 @@ workflow Imputation {
           vcf = SetIDsMissingContigs.output_vcf,
           basename = "unimputed_contigs_" + missing_contig +"_"+ i_missing_contig + "_annotations_removed"
       }
-
-      call tasks.ReplaceHeader {
-        input:
-          vcf_to_replace_header = RemoveAnnotationsMissingContigs.output_vcf,
-          vcf_with_new_header = phased_vcfs[0]
-      }
     }
   }
 
-  Array[String] missing_contig_vcfs = flatten(ReplaceHeader.output_vcf)
+  Array[String] missing_remove_annotation_vcfs = flatten(RemoveAnnotationsMissingContigs.output_vcf)
 
+  scatter(missing_remove_annotation_vcf in missing_remove_annotation_vcfs){
+    call tasks.ReplaceHeader {
+      input:
+        vcf_to_replace_header = missing_remove_annotation_vcf,
+        vcf_with_new_header = phased_vcfs[0]
+    }
+  }
 
+  Array[String] missing_contig_vcfs = ReplaceHeader.output_vcf
   Array[String] unsorted_vcfs = flatten([phased_vcfs, missing_contig_vcfs])
 
   call tasks.GatherVcfs {

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Imputation {
 
-  String pipeline_version = "1.1.10"
+  String pipeline_version = "1.1.11"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
+++ b/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.9
+2023-08-01 (Date of Last Commit)
+
+* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatter to help with wall clock time
+
 # 1.1.8
 2023-03-31 (Date of Last Commit)
 

--- a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
+++ b/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.changelog.md
@@ -1,7 +1,7 @@
 # 1.1.9
 2023-08-01 (Date of Last Commit)
 
-* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatter to help with wall clock time
+* Moved ReplaceHeader to its own scatter to remove dependency between the two nested scatters to help with wall clock time
 
 # 1.1.8
 2023-03-31 (Date of Last Commit)

--- a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl
+++ b/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl
@@ -9,7 +9,7 @@ workflow BroadInternalImputation {
         description: "Push outputs of Imputation.wdl to TDR dataset table ImputationOutputsTable and split out Imputation arrays into ImputationWideOutputsTable."
         allowNestedInputs: true
     }
-    String pipeline_version = "1.1.8"
+    String pipeline_version = "1.1.9"
     
     input {
         # inputs to wrapper task 


### PR DESCRIPTION

### Description
There was a dependency between the two nested scatters in this wdl which was causing the downstream nested scatter to not be able to start until the first nested scatter was comlpletely done.  With this change both nested scatters will run in parallel and that one task (ReplaceHeader) will run in its own scatter and that wont run until both nested scatters are complete.  Here is the new dependency graph of this wdl compared to the previous one.

previous version

![graphviz (1)](https://github.com/broadinstitute/warp/assets/13023616/94730d9e-cebb-4a5c-bbac-2a2ba83ac1bd)

with these changes

![graphviz](https://github.com/broadinstitute/warp/assets/13023616/1a939fa0-35f7-45aa-affc-e80476677623)

This should purely be a cosmetic change as far as results go and should only affect wall clock time.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
