### PR TITLE
trying to re trigger dockstore pull

### DIFF
--- a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.changelog.md
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 2.1.6
+2023-08-14 (Date of Last Commit)
+
+* Re-releasing the pipeline
+
 # 2.1.5
 2023-03-20 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl
@@ -5,7 +5,7 @@ import "../../../../../../tasks/broad/Qc.wdl" as QC
 
 workflow ReblockGVCF {
 
-  String pipeline_version = "2.1.5"
+  String pipeline_version = "2.1.6"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,5 +1,11 @@
+# 3.1.12
+2023-08-14 (Date of Last Commit)
+
+* Re-releasing the pipeline
+
 # 3.1.11
 2023-03-20 (Date of Last Commit)
+
 * CheckFingerprint can allow LOD 0
 
 # 3.1.10

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -40,7 +40,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 workflow WholeGenomeGermlineSingleSample {
 
 
-  String pipeline_version = "3.1.11"
+  String pipeline_version = "3.1.12"
 
 
   input {

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,3 +1,8 @@
+# 1.12.14
+2023-08-14 (Date of Last Commit)
+
+* CheckFingerprint can allow LOD 0
+
 # 1.12.13
 2023-03-30 (Date of Last Commit)
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,7 +1,7 @@
 # 1.12.14
 2023-08-14 (Date of Last Commit)
 
-* CheckFingerprint can allow LOD 0
+* Re-releasing the pipeline
 
 # 1.12.13
 2023-03-30 (Date of Last Commit)

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/Qc.wdl" as Qc
 
 workflow IlluminaGenotypingArray {
 
-  String pipeline_version = "1.12.13"
+  String pipeline_version = "1.12.14"
 
   input {
     String sample_alias


### PR DESCRIPTION
### Description

Dockstore is not showing the latest versions of ReblockGVCF, WholeGenomeGermlineSingleSample and IlluminaGenotypingArrays. Trying to merge this up to master so we can possible retrigger the dockstore pull from github.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
