### PR TITLE
Only use "--no-overlaps" argument for validation of reblocked vcfs 

### DIFF
--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
@@ -182,7 +182,7 @@ workflow VariantCalling {
       ref_dict = ref_dict,
       calling_interval_list = calling_interval_list,
       is_gvcf = make_gvcf,
-      extra_args = "--no-overlaps",
+      extra_args = if (skip_reblocking == false) then "--no-overlaps" else "",
       gatk_docker = "us.gcr.io/broad-gatk/gatk:4.3.0.0",
       preemptible_tries = agg_preemptible_tries
   }


### PR DESCRIPTION
### Description

Remove the "--no-overlaps" argument from VCF validation for non-reblocked VCFs

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
