### PR TITLE
Escape double quotes in changelogs

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,7 +1,7 @@
 # 3.1.11
 2023-08-23 (Date of Last Commit)
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.  
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 3.1.10
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 3.1.11
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 2.1.10
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 3.1.10
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 3.1.12
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 2.1.12
 2023-03-20 (Date of Last Commit)

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -2,7 +2,7 @@
 2023-08-23 (Date of Last Commit)
 
 * Updated VerifyBamID docker image in BamProcessing.wdl to fix security vulnerabilities, this update has no effect on this pipeline.
-* Updated the VCF validation step to only use "--no-overlaps" argument for reblocked vcfs
+* Updated the VCF validation step to only use \"--no-overlaps\" argument for reblocked vcfs
 
 # 3.1.11
 2023-03-20 (Date of Last Commit)


### PR DESCRIPTION
### Description

For some reason we need to escape double quotes in our changelog entries. The release for these failed. This should address the issue. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
