### PR TITLE
Remove the dropna and MATCH columns from JoinBarcodes

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,5 +1,7 @@
-# 2.2.1
-2023-10-13 (Date of Last Commit)
+# 2.2.2
+2023-10-20 (Date of Last Commit)
+
+* Removed Dropna from JoinBarcodes subtask of the H5adUtils task, which was causing the JoinBarcodes to fail for some gene expression matrices
 
 * Updated path to Multiome whitelists to reflect location in public storage.
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -4,7 +4,7 @@ import "../../../pipelines/skylab/multiome/atac.wdl" as atac
 import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 workflow Multiome {
-    String pipeline_version = "2.2.1"
+    String pipeline_version = "2.2.2"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,5 +1,6 @@
-# 1.1.0
-2023-09-21 (Date of Last Commit)
+# 1.1.1
+2023-10-20 (Date of Last Commit)
+* Removed the dropna from the JoinBarcodes subtask of the H5adUtils WDL; this change does not impact ATAC outputs
 * Added dynamic barcode selection to the ATAC FastqProcess task
 
 # 1.0.1

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -34,7 +34,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "1.1.0"
+  String pipeline_version = "1.1.1"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,7 +1,8 @@
 
-# 6.1.1
-2023-10-05 (Date of Last Commit)
+# 6.1.2
+2023-10-20 (Date of Last Commit)
 
+* Removed the dropna from the H5adUtils WDL for the JoinBarcodes task; this change does not impact Optimus outputs
 * Added a new task to the H5adUtils WDL to combine Multiome barcodes in h5ad outputs; this does not impact the individual Optimus workflow
 
 # 6.1.0

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -64,7 +64,7 @@ workflow Optimus {
 
   # version of this pipeline
 
-  String pipeline_version = "6.1.1"
+  String pipeline_version = "6.1.2"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -235,9 +235,6 @@ task JoinMultiomeBarcodes {
     print(df_gex)
 
     # Idenitfy the barcodes in the whitelist that match barcodes in datasets
-    whitelist_atac["MATCH_ATAC"] = whitelist_atac.isin(df_atac.index).astype(int)
-    whitelist_gex["MATCH_GEX"] = whitelist_gex.isin(df_gex.index).astype(int)
-
     print("Printing whitelist_gex")
     print(whitelist_gex[1:10])
 
@@ -246,10 +243,8 @@ task JoinMultiomeBarcodes {
     df_both_atac = df_all.copy()
     df_both_atac.set_index("atac_barcodes", inplace=True)
     df_both_gex.set_index("gex_barcodes", inplace=True)
-    df_both_gex.drop(["MATCH_GEX", "MATCH_ATAC"], axis=1, inplace=True)
-    df_both_atac.drop(["MATCH_GEX", "MATCH_ATAC"], axis=1, inplace=True)
-    df_atac = atac_data.obs.join(df_both_atac).dropna()
-    df_gex = gex_data.obs.join(df_both_gex).dropna()
+    df_atac = atac_data.obs.join(df_both_atac)
+    df_gex = gex_data.obs.join(df_both_gex)
     # set atac_data.obs to new dataframe
     print("Setting ATAC obs to new dataframe")
     atac_data.obs = df_atac


### PR DESCRIPTION
### Description

This PR removes the dropna from JoinBarcodes subtask of the h5ad utils. The dropna was causing an issue with some gene expression matrices.
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
