### PR TITLE
Update inputs to CramToUnmappedBam test

### DIFF
--- a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.exome.inputs.json
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.exome.inputs.json
@@ -1,6 +1,6 @@
 {
-  "ReblockGVCF.gvcf": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/truth/develop/RP-929.NA12878/NA12878_PLUMBING.g.vcf.gz",
-  "ReblockGVCF.gvcf_index": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/truth/develop/RP-929.NA12878/NA12878_PLUMBING.g.vcf.gz.tbi",
+  "ReblockGVCF.gvcf": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/plumbing/master/RP-929.NA12878/NA12878_PLUMBING.rb.g.vcf.gz",
+  "ReblockGVCF.gvcf_index": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/plumbing/master/RP-929.NA12878/NA12878_PLUMBING.rb.g.vcf.gz.tbi",
   "ReblockGVCF.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "ReblockGVCF.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "ReblockGVCF.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict"

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/test_inputs/Plumbing/plumbing.input.json
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/test_inputs/Plumbing/plumbing.input.json
@@ -1,5 +1,5 @@
 {
-  "JointGenotyping.sample_name_map": "gs://broad-gotc-test-storage/JointGenotyping/inputs/plumbing/wgs/sample_name_map",
+  "JointGenotyping.sample_name_map": "gs://broad-gotc-test-storage/joint_genotyping/wgs/plumbing/callset/public_sample_name_map",
   "JointGenotyping.callset_name": "wgs_joint_genotyping_plumbing",
   "JointGenotyping.unbounded_scatter_count_scale_factor": 2.5,
   "JointGenotyping.SplitIntervalList.scatter_mode": "INTERVAL_SUBDIVISION",

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/test_inputs/Plumbing/plumbing.input.json
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/test_inputs/Plumbing/plumbing.input.json
@@ -1,5 +1,5 @@
 {
-  "JointGenotyping.sample_name_map": "gs://broad-gotc-test-storage/joint_genotyping/wgs/plumbing/callset/public_sample_name_map",
+  "JointGenotyping.sample_name_map": "gs://broad-gotc-test-storage/JointGenotyping/inputs/plumbing/wgs/sample_name_map",
   "JointGenotyping.callset_name": "wgs_joint_genotyping_plumbing",
   "JointGenotyping.unbounded_scatter_count_scale_factor": 2.5,
   "JointGenotyping.SplitIntervalList.scatter_mode": "INTERVAL_SUBDIVISION",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/input_files/ExampleCramToUnmappedBams.plumbing.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/input_files/ExampleCramToUnmappedBams.plumbing.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/plumbing/truth/develop/G96830.NA12878/NA12878_PLUMBING.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/WholeGenomeGermlineSingleSample/truth/plumbing/master/G96830.NA12878/NA12878_PLUMBING.cram",
   "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "CramToUnmappedBams.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "CramToUnmappedBams.base_file_name": "G96830.NA12878"

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/input_files/ExampleCramToUnmappedBams_huge.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/input_files/ExampleCramToUnmappedBams_huge.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/develop/G96830.NA12878/NA12878.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/WholeGenomeGermlineSingleSample/truth/scientific/master/G96830.NA12878/NA12878.cram",
   "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "CramToUnmappedBams.ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "CramToUnmappedBams.base_file_name": "G96830.NA12878"

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Plumbing/RP-929.NA12878.Exome.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Plumbing/RP-929.NA12878.Exome.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/truth/{TRUTH_BRANCH}/RP-929.NA12878/NA12878_PLUMBING.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/plumbing/master/RP-929.NA12878/NA12878_PLUMBING.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/bams/RP-929.NA12878/readgroupid_to_bamfilename_map.txt",
   "CramToUnmappedBams.base_file_name": "RP-929.NA12878.Exome",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/C1963.CHMI_CHMI3_Nex1.Exome.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/C1963.CHMI_CHMI3_Nex1.Exome.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/truth/{TRUTH_BRANCH}/C1963.CHMI_CHMI3_Nex1/CHMI_CHMI3_Nex1.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/scientific/master/C1963.CHMI_CHMI3_Nex1/CHMI_CHMI3_Nex1.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/bams/C1963.CHMI_CHMI3_Nex1/readgroupid_to_bamfilename_map.txt",
   "CramToUnmappedBams.base_file_name": "C1963.CHMI_CHMI3_Nex1.Exome",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/D5327.NA12878.Exome.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/D5327.NA12878.Exome.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/truth/{TRUTH_BRANCH}/D5327.NA12878/NA12878.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/scientific/master/D5327.NA12878/NA12878.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/bams/D5327.NA12878/readgroupid_to_bamfilename_map.txt",
   "CramToUnmappedBams.base_file_name": "D5327.NA12878.Exome",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G94794.CHMI_CHMI3_WGS2.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G94794.CHMI_CHMI3_WGS2.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/G94794.CHMI_CHMI3_WGS2/CHMI_CHMI3_WGS2.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/WholeGenomeGermlineSingleSample/truth/scientific/master/G94794.CHMI_CHMI3_WGS2/CHMI_CHMI3_WGS2.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/G94794.CHMI_CHMI3_WGS2/readgroupid_to_bamfilename_map.txt",
 
   "CramToUnmappedBams.base_file_name": "G94794.CHMI_CHMI3_WGS2",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G94982.NA12878.WGS.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G94982.NA12878.WGS.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/G94982.NA12878/NA12878.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/WholeGenomeGermlineSingleSample/truth/scientific/master/G94982.NA12878/NA12878.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/G94982.NA12878/readgroupid_to_bamfilename_map.txt",
   "CramToUnmappedBams.base_file_name": "G94982.NA12878.WGS",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/G96830.NA12878.WGS.json
@@ -1,7 +1,6 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/truth/{TRUTH_BRANCH}/G96830.NA12878/NA12878.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/WholeGenomeGermlineSingleSample/truth/scientific/master/G96830.NA12878/NA12878.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/wgs/scientific/bams/G96830.NA12878/readgroupid_to_bamfilename_map.txt",
-
   "CramToUnmappedBams.base_file_name": "G96830.NA12878.WGS",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",
   "CramToUnmappedBams.ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",

--- a/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/RP-1535.NA17-308.Exome.json
+++ b/pipelines/broad/reprocessing/cram_to_unmapped_bams/test_inputs/Scientific/RP-1535.NA17-308.Exome.json
@@ -1,5 +1,5 @@
 {
-  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/truth/{TRUTH_BRANCH}/RP-1535.NA17-308/NA17-308.cram",
+  "CramToUnmappedBams.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/scientific/master/RP-1535.NA17-308/NA17-308.cram",
   "CramToUnmappedBams.output_map": "gs://broad-gotc-test-storage/germline_single_sample/exome/scientific/bams/RP-1535.NA17-308/readgroupid_to_bamfilename_map.txt",
   "CramToUnmappedBams.base_file_name": "RP-1535.NA17-308.Exome",
   "CramToUnmappedBams.unmapped_bam_suffix": ".unmapped.bam",

--- a/pipelines/broad/reprocessing/exome/test_inputs/Plumbing/RP-929.NA12878.json
+++ b/pipelines/broad/reprocessing/exome/test_inputs/Plumbing/RP-929.NA12878.json
@@ -1,5 +1,5 @@
 {
-  "ExomeReprocessing.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/truth/{TRUTH_BRANCH}/RP-929.NA12878/NA12878_PLUMBING.cram",
+  "ExomeReprocessing.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/plumbing/master/RP-929.NA12878/NA12878_PLUMBING.cram",
   "ExomeReprocessing.output_map": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/bams/RP-929.NA12878/readgroupid_to_bamfilename_map.txt",
 
   "ExomeReprocessing.sample_name": "NA12878 PLUMBING",

--- a/pipelines/broad/reprocessing/external/exome/test_inputs/Plumbing/RP-929.NA12878.json
+++ b/pipelines/broad/reprocessing/external/exome/test_inputs/Plumbing/RP-929.NA12878.json
@@ -1,5 +1,5 @@
 {
-  "ExternalExomeReprocessing.input_cram": "gs://broad-gotc-test-storage/germline_single_sample/exome/plumbing/truth/develop/RP-929.NA12878/NA12878_PLUMBING.cram",
+  "ExternalExomeReprocessing.input_cram": "gs://broad-gotc-test-storage/ExomeGermlineSingleSample/truth/plumbing/master/RP-929.NA12878/NA12878_PLUMBING.cram",
 
   "ExternalExomeReprocessing.sample_name": "NA12878 PLUMBING",
   "ExternalExomeReprocessing.base_file_name": "RP-929.NA12878",


### PR DESCRIPTION
### Description

We cleaned up old truth files in an effort to reduces storage cost. This updates the input files for CramToUnmappedBams (as well as the reprocessing tests) to point to the equivalent files in the new locations
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [X] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
