### PR TITLE
Added bwa-mem2 to BuildIndices

### DIFF
--- a/pipelines/skylab/build_indices/BuildIndices.changelog.md
+++ b/pipelines/skylab/build_indices/BuildIndices.changelog.md
@@ -1,3 +1,8 @@
+# 3.0.0
+2023-12-06 (Date of Last Commit)
+
+* Updated BuildIndices to use bwa-mem2
+
 # 2.2.1
 2023-11-17 (Date of Last Commit)
 * Updated the modify-gtf script to make it compatible with REFSEQ and GENCODE GTFs

--- a/pipelines/skylab/build_indices/BuildIndices.wdl
+++ b/pipelines/skylab/build_indices/BuildIndices.wdl
@@ -166,7 +166,7 @@ task BuildBWAreference {
     String organism
   }
 
-String reference_name = "bwa0.7.17-~{organism}-~{genome_source}-build-~{genome_build}"
+String reference_name = "bwa-mem2-2.2.1-~{organism}-~{genome_source}-build-~{genome_build}"
 
   command <<<
     mkdir genome
@@ -178,12 +178,12 @@ String reference_name = "bwa0.7.17-~{organism}-~{genome_source}-build-~{genome_b
     else
       mv ~{genome_fa} genome/genome.fa
     fi
-    bwa index genome/genome.fa
+    bwa-mem2 index genome/genome.fa
     tar --dereference -cvf - genome/ > ~{reference_name}.tar
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/bwa:1.0.0-0.7.17-1660770463"
+    docker: "us.gcr.io/broad-gotc-prod/samtools-bwa-mem-2:1.0.0-2.2.1_x64-linux-1685469504"
     memory: "96GB"
     disks: "local-disk 100 HDD"
     disk: "100 GB" # TES
@@ -194,5 +194,4 @@ String reference_name = "bwa0.7.17-~{organism}-~{genome_source}-build-~{genome_b
     File reference_bundle = "~{reference_name}.tar"
   }
 }
-
 

--- a/pipelines/skylab/build_indices/BuildIndices.wdl
+++ b/pipelines/skylab/build_indices/BuildIndices.wdl
@@ -16,7 +16,7 @@ workflow BuildIndices {
   }
 
   # version of this pipeline
-  String pipeline_version = "2.2.1"
+  String pipeline_version = "3.0.0"
 
 
   parameter_meta {


### PR DESCRIPTION
### Description
This PR updates the BuildIndices pipeline to use bwa-mem2 instead of bwa-mem. 
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
