### PR TITLE
added exit code to CompareTabix

### DIFF
--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -111,9 +111,9 @@ task CompareTabix {
     File test_fragment_file
     File truth_fragment_file
   }
-  command {
+  command <<<
     exit_code = 0
-    a=$(md5sum ~{test_fragment_file} | awk '{ print $1 }')
+    a=$(md5sum "~{test_fragment_file}" | awk '{ print $1 }')
     b=$(md5sum ~{truth_fragment_file} | awk '{ print $1 }')
     if [[ a = b ]]; then 
       echo equal 
@@ -129,7 +129,7 @@ task CompareTabix {
     memory: "50 GiB"
     preemptible: 3
   }   
-}
+>>>
 task CompareTextFiles {
   input {
     Array[File] test_text_files

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -122,14 +122,15 @@ task CompareTabix {
       exit_code=1
     fi
     exit $exit_code
-  }
+  >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/snapatac2:1.0.4-2.3.1-1700590229"
     disks: "local-disk 100 HDD"
     memory: "50 GiB"
     preemptible: 3
   }   
->>>
+}
+
 task CompareTextFiles {
   input {
     Array[File] test_text_files

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -112,6 +112,7 @@ task CompareTabix {
     File truth_fragment_file
   }
   command {
+    exit_code = 0
     a="md5sum ~{test_fragment_file}"
     b="md5sum ~{truth_fragment_file}"
     if [[ a = b ]]; then 
@@ -120,6 +121,7 @@ task CompareTabix {
       echo different
       exit_code=1
     fi
+    exit $exit_code
   }
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/snapatac2:1.0.4-2.3.1-1700590229"

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -113,8 +113,8 @@ task CompareTabix {
   }
   command {
     exit_code = 0
-    a="md5sum ~{test_fragment_file}"
-    b="md5sum ~{truth_fragment_file}"
+    a=$(md5sum ~{test_fragment_file} | awk '{ print $1 }')
+    b=$(md5sum ~{truth_fragment_file} | awk '{ print $1 }')
     if [[ a = b ]]; then 
       echo equal 
     else 

--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -115,7 +115,7 @@ task CompareTabix {
     exit_code = 0
     a=$(md5sum "~{test_fragment_file}" | awk '{ print $1 }')
     b=$(md5sum ~{truth_fragment_file} | awk '{ print $1 }')
-    if [[ a = b ]]; then 
+    if [[ $a = $b ]]; then 
       echo equal 
     else 
       echo different


### PR DESCRIPTION
### Description
This PR adds an exit code to the CompareTabix task to use with our multiome ATAC fragment files.
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
