### PR TITLE
Removed space from exit code on verify tabix verification task

### DIFF
--- a/verification/VerifyTasks.wdl
+++ b/verification/VerifyTasks.wdl
@@ -112,7 +112,7 @@ task CompareTabix {
     File truth_fragment_file
   }
   command <<<
-    exit_code = 0
+    exit_code=0
     a=$(md5sum "~{test_fragment_file}" | awk '{ print $1 }')
     b=$(md5sum ~{truth_fragment_file} | awk '{ print $1 }')
     if [[ $a = $b ]]; then 


### PR DESCRIPTION
### Description
This PR removes a typo in the VerifyTabix task

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
