### PR TITLE
Lk paired tag trimming

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,4 +1,8 @@
 
+# 3.4.2
+20240403 (Date of Last Commit)
+* Modified adaptor trimming in Paired-tag WDL; this does not impact Multiome
+
 # 3.4.1
 20240326 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/c
 
 workflow Multiome {
 
-    String pipeline_version = "3.4.1"
+    String pipeline_version = "3.4.2"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,3 +1,7 @@
+# 1.2.1
+20240403 (Date of Last Commit)
+* Modified adaptor trimming in Paired-tag WDL; this does not impact ATAC
+
 # 1.2.0
 20240315 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -41,7 +41,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "1.2.0"
+  String pipeline_version = "1.2.1"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,4 +1,4 @@
-# 0.5.1
+# 0.5.0
 20240403 (Date of Last Commit)
 
 * Modified adaptor trimming to trim last 3 bp (instead of first) in read2 length is 27 bp and preindex is false

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 0.5.1
+20240403 (Date of Last Commit)
+
+* Modified adaptor trimming to trim last 3 bp (instead of first) in read2 length is 27 bp and preindex is false
+
 # 0.4.1
 20240326 (Date of Last Commit)
 

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -5,7 +5,7 @@ import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/skylab/PairedTagUtils.wdl" as Demultiplexing
 workflow PairedTag {
-    String pipeline_version = "0.4.1"
+    String pipeline_version = "0.5.0"
 
     input {
         String input_id

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -49,7 +49,7 @@ task PairedTagDemultiplex {
           then
           echo "Preindex is false and length is 27 bp"
           echo "Trimming last 3 bp with UPStools"
-          upstools trimfq ~{input_id}_R2.fq.gz 1 23
+          upstools trimfq ~{input_id}_R2.fq.gz 1 24
           echo "Running orientation check"
           file="~{input_id}_R2_trim.fq.gz"
           zcat "$file" | sed -n '2~4p' | shuf -n 1000 > downsample.fq

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -44,12 +44,12 @@ task PairedTagDemultiplex {
         mv ~{read1_fastq} "~{input_id}_R1.fq.gz"
         mv ~{barcodes_fastq} "~{input_id}_R2.fq.gz"
         mv ~{read3_fastq} "~{input_id}_R3.fq.gz"
-        echo performing read2 length and orientation checks 
+        echo "performing read2 length, trimming, and orientation checks" 
         if [[ $COUNT == 27 && ~{preindex} == "false" ]]
           then
           echo "Preindex is false and length is 27 bp"
-          echo "Trimming first 3 bp with UPStools"
-          upstools trimfq ~{input_id}_R2.fq.gz 4 26
+          echo "Trimming last 3 bp with UPStools"
+          upstools trimfq ~{input_id}_R2.fq.gz 1 23
           echo "Running orientation check"
           file="~{input_id}_R2_trim.fq.gz"
           zcat "$file" | sed -n '2~4p' | shuf -n 1000 > downsample.fq


### PR DESCRIPTION
### Description
This modifies the adaptor trimming step for paired-tag when the read2 length is 27 bp and preindex is false. It now trims the last 3 bp of the read instead of the first. 
