### PR TITLE
PD-2559andPD-2558: UMI filtering and cell barcode correction 

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,15 +1,19 @@
+# 3.4.3
+2024-04-12 (Date of Last Commit)
+
+* Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
 
 # 3.4.2
-20240403 (Date of Last Commit)
+2024-04-03 (Date of Last Commit)
 * Modified adaptor trimming in Paired-tag WDL; this does not impact Multiome
 
 # 3.4.1
-20240326 (Date of Last Commit)
+2024-03-26 (Date of Last Commit)
 
 * Updated the median umi per cell metric for STARsolo library-level metrics
 
 # 3.4.0 
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics
 

--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,7 +1,8 @@
 # 3.4.3
-2024-04-12 (Date of Last Commit)
+2024-04-24 (Date of Last Commit)
 
 * Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+* Added "Uniform" as the default string for STARsolo multimapping parameters
 
 # 3.4.2
 2024-04-03 (Date of Last Commit)

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/c
 
 workflow Multiome {
 
-    String pipeline_version = "3.4.2"
+    String pipeline_version = "3.4.3"
 
     input {
         String input_id

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,11 +1,15 @@
+# 6.6.2
+2024-04-12 (Date of Last Commit)
+
+* Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
 
 # 6.6.1
-20240326 (Date of Last Commit)
+2024-03-26 (Date of Last Commit)
 
 * Updated the median umi per cell metric for STARsolo library-level metrics
 
 # 6.6.0
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics
 

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,7 +1,8 @@
 # 6.6.2
-2024-04-12 (Date of Last Commit)
+2024-04-24 (Date of Last Commit)
 
 * Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+* Added "Uniform" as the default string for STARsolo multimapping parameters
 
 # 6.6.1
 2024-03-26 (Date of Last Commit)

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -65,7 +65,7 @@ workflow Optimus {
   # version of this pipeline
 
 
-  String pipeline_version = "6.6.1"
+  String pipeline_version = "6.6.2"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 0.5.1
+2024-04-12 (Date of Last Commit)
+
+* Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+
 # 0.5.0
 20240403 (Date of Last Commit)
 

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -2,6 +2,7 @@
 2024-04-12 (Date of Last Commit)
 
 * Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+* Added "Uniform" as the default string for STARsolo multimapping parameters
 
 # 0.5.0
 20240403 (Date of Last Commit)

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -5,7 +5,7 @@ import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/skylab/PairedTagUtils.wdl" as Demultiplexing
 workflow PairedTag {
-    String pipeline_version = "0.5.0"
+    String pipeline_version = "0.5.1"
 
     input {
         String input_id

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -1,10 +1,15 @@
+# 3.1.5
+2024-04-12 (Date of Last Commit)
+
+* Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+
 # 3.1.4
-20240326 (Date of Last Commit)
+2024-03-26 (Date of Last Commit)
 
 * Updated the median umi per cell metric for STARsolo library-level metrics
 
 # 3.1.3
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics CSV; this does not impact the slide-seq pipeline
 

--- a/pipelines/skylab/slideseq/SlideSeq.wdl
+++ b/pipelines/skylab/slideseq/SlideSeq.wdl
@@ -23,7 +23,7 @@ import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow SlideSeq {
 
-    String pipeline_version = "3.1.4"
+    String pipeline_version = "3.1.5"
 
     input {
         Array[File] r1_fastq

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,10 +1,15 @@
+# 1.3.4
+2024-04-12 (Date of Last Commit)
+
+* Updated the input parameters for STARsolo in STARsoloFastq task. These include the parameters: soloCBmatchWLtype, soloUMIdedup and soloUMIfiltering
+
 # 1.3.3
-20240326 (Date of Last Commit)
+2024-03-26 (Date of Last Commit)
 
 * Updated the median umi per cell metric for STARsolo library-level metrics
 
 # 1.3.2
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics CSV; this does not impact the Single-nucleus Multi Sample Smartseq pipeline
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.3.3"
+  String pipeline_version = "1.3.4"
 
   if (false) {
      String? none = "None"

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -252,7 +252,7 @@ task STARsoloFastq {
   }
 
   command <<<
-    set -e
+       set -e
 
     UMILen=10
     CBLen=16
@@ -292,7 +292,23 @@ task STARsoloFastq {
         ## single cell or whole cell
         COUNTING_MODE="Gene"
         echo "Running in ~{counting_mode} mode. The Star parameter --soloFeatures will be set to $COUNTING_MODE"
-        STAR \
+    elif [[ "~{counting_mode}" == "sn_rna" ]]
+    then
+        ## single nuclei
+        if [[ ~{count_exons} == false ]]
+        then
+            COUNTING_MODE="GeneFull_Ex50pAS"
+            echo "Running in ~{counting_mode} mode. Count_exons is false and the Star parameter --soloFeatures will be set to $COUNTING_MODE"
+        else
+            COUNTING_MODE="GeneFull_Ex50pAS Gene"
+            echo "Running in ~{counting_mode} mode. Count_exons is true and the Star parameter --soloFeatures will be set to $COUNTING_MODE"     
+        fi
+    else
+        echo Error: unknown counting mode: "$counting_mode". Should be either sn_rna or sc_rna.
+        exit 1;
+    fi
+
+    STAR \
         --soloType Droplet \
         --soloStrand ~{star_strand_mode} \
         --runThreadN ~{cpu} \
@@ -304,67 +320,15 @@ task STARsoloFastq {
         --soloFeatures $COUNTING_MODE \
         --clipAdapterType CellRanger4 \
         --outFilterScoreMin 30  \
-        --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts \
-        --soloUMIdedup 1MM_Directional_UMItools \
+        --soloCBmatchWLtype 1MM_multi \
+        --soloUMIdedup 1MM_CR \
         --outSAMtype BAM SortedByCoordinate \
         --outSAMattributes UB UR UY CR CB CY NH GX GN sF \
         --soloBarcodeReadLength 0 \
         --soloCellReadStats Standard \
-        ~{"--soloMultiMappers " + soloMultiMappers}
-    elif [[ "~{counting_mode}" == "sn_rna" ]]
-    then
-        ## single nuclei
-        if [[ ~{count_exons} == false ]]
-        then
-            COUNTING_MODE="GeneFull_Ex50pAS"
-            echo "Running in ~{counting_mode} mode. Count_exons is false and the Star parameter --soloFeatures will be set to $COUNTING_MODE"
-            STAR \
-            --soloType Droplet \
-            --soloStrand ~{star_strand_mode} \
-            --runThreadN ~{cpu} \
-            --genomeDir genome_reference \
-            --readFilesIn "~{sep=',' r2_fastq}" "~{sep=',' r1_fastq}" \
-            --readFilesCommand "gunzip -c" \
-            --soloCBwhitelist ~{white_list} \
-            --soloUMIlen $UMILen --soloCBlen $CBLen \
-            --soloFeatures $COUNTING_MODE  \
-            --clipAdapterType CellRanger4 \
-            --outFilterScoreMin 30  \
-            --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts \
-            --soloUMIdedup 1MM_Directional_UMItools \
-            --outSAMtype BAM SortedByCoordinate \
-            --outSAMattributes UB UR UY CR CB CY NH GX GN sF \
-            --soloBarcodeReadLength 0 \
-            --soloCellReadStats Standard \
-            ~{"--soloMultiMappers " + soloMultiMappers}
-        else
-            COUNTING_MODE="GeneFull_Ex50pAS Gene"
-            echo "Running in ~{counting_mode} mode. Count_exons is true and the Star parameter --soloFeatures will be set to $COUNTING_MODE"
-            STAR \
-            --soloType Droplet \
-            --soloStrand ~{star_strand_mode} \
-            --runThreadN ~{cpu} \
-            --genomeDir genome_reference \
-            --readFilesIn "~{sep=',' r2_fastq}" "~{sep=',' r1_fastq}" \
-            --readFilesCommand "gunzip -c" \
-            --soloCBwhitelist ~{white_list} \
-            --soloUMIlen $UMILen --soloCBlen $CBLen \
-            --soloFeatures $COUNTING_MODE \
-            --clipAdapterType CellRanger4 \
-            --outFilterScoreMin 30  \
-            --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts \
-            --soloUMIdedup 1MM_Directional_UMItools \
-            --outSAMtype BAM SortedByCoordinate \
-            --outSAMattributes UB UR UY CR CB CY NH GX GN sF \
-            --soloBarcodeReadLength 0 \
-            --soloCellReadStats Standard \
-            ~{"--soloMultiMappers " + soloMultiMappers}
-        fi
-    else
-        echo Error: unknown counting mode: "$counting_mode". Should be either sn_rna or sc_rna.
-        exit 1;
-    fi
-
+        ~{"--soloMultiMappers " + soloMultiMappers} \
+        --soloUMIfiltering MultiGeneUMI_CR
+      
     echo "UMI LEN " $UMILen
 
     touch barcodes_sn_rna.tsv


### PR DESCRIPTION
Combined two tickets into one to test out changes and merge changes combined 

Tackling both UMI filtering and cell barcode correction 

Changed/Added starsolo parameters:
- `soloCBmatchWLtype` is now set to`1MM_multi`
- `soloUMIdedup` is now set to `1MM_CR`
- `soloUMIfiltering` is now set to `MultiGeneUMI_CR`

Smart tests failed on: dev_10k_pbmc_downsampled, pbmc_human_v3, mouse_v2_snRNA_example and snRNA_mouse_v2_snRNA_example

Notebook to compare failed smart tests: https://app.terra.bio/#workspaces/warp-pipelines/Multiome-test-workspace/analysis/launch/PD2559_PD2558_umi_filtering_and_cell_barcode_correction.ipynb?mode=edit 

### Description

_Give your PR a **concise** yet **descriptive** title._
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed, or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
