### PR TITLE
Lk paired tag naming collision

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 3.4.4
+2024-05-10 (Date of Last Commit)
+
+* Updated the Paired-tag Demultiplex task; this change does not impact the Multiome workflow
+
 # 3.4.3
 2024-04-24 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/c
 
 workflow Multiome {
 
-    String pipeline_version = "3.4.3"
+    String pipeline_version = "3.4.4"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,9 +1,14 @@
+# 1.2.2
+2024-05-10 (Date of Last Commit)
+
+* Updated the Paired-tag Demultiplex task; this does not impact the ATAC workflow
+
 # 1.2.1
-20240403 (Date of Last Commit)
+2024-04-03 (Date of Last Commit)
 * Modified adaptor trimming in Paired-tag WDL; this does not impact ATAC
 
 # 1.2.0
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics
 

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -41,7 +41,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "1.2.1"
+  String pipeline_version = "1.2.2"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,9 @@
+# 0.6.0
+2024-05-10 (Date)
+
+* Updated the UPStools docker to version 2.0.0 which reinstates a barcode orientation check script
+* Updated the demultiplex task so that output FASTQ files are renamed according to the original input file name, avoiding naming collisions in downstream tasks
+
 # 0.5.1
 2024-04-12 (Date of Last Commit)
 
@@ -5,17 +11,17 @@
 * Added "Uniform" as the default string for STARsolo multimapping parameters
 
 # 0.5.0
-20240403 (Date of Last Commit)
+2024-04-03 (Date of Last Commit)
 
 * Modified adaptor trimming to trim last 3 bp (instead of first) in read2 length is 27 bp and preindex is false
 
 # 0.4.1
-20240326 (Date of Last Commit)
+2024-03-26 (Date of Last Commit)
 
 * Updated the median umi per cell metric for STARsolo library-level metrics
 
 # 0.4.0
-20240315 (Date of Last Commit)
+2024-03-15 (Date of Last Commit)
 
 * Added cell metrics to the library-level metrics
 

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -5,7 +5,7 @@ import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/skylab/PairedTagUtils.wdl" as Demultiplexing
 workflow PairedTag {
-    String pipeline_version = "0.5.1"
+    String pipeline_version = "0.6.0"
 
     input {
         String input_id

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -78,6 +78,8 @@ task PairedTagDemultiplex {
             echo "Incorrect barcode orientation"
           fi
           mv "~{input_id}_R2_trim.fq.gz" "~{r2_base}.fq.gz"
+          mv "~{input_id}_R1.fq.gz" "~{r1_base}.fq.gz"
+          mv "~{input_id}_R3.fq.gz" "{r3_base}.fq.gz"
 
         elif [[ $COUNT == 27 && ~{preindex} == "true" ]]
           then
@@ -106,6 +108,9 @@ task PairedTagDemultiplex {
         elif [[ $COUNT == 24 && ~{preindex} == "false" ]]
           then
           echo "FASTQ has correct index length, no modification necessary"
+          mv "~{input_id}_R2_prefix.fq.gz" "~{r2_base}.fq.gz"
+          mv "~{input_id}_R1_prefix.fq.gz" "~{r1_base}.fq.gz"
+          mv "~{input_id}_R3_prefix.fq.gz" "~{r3_base}.fq.gz"
         elif [[ $COUNT == 24 && ~{preindex} == "true" ]]
           then
           pass="false"

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -7,7 +7,7 @@ task PairedTagDemultiplex {
         String input_id
         Boolean preindex
         File whitelist
-        String docker = "us.gcr.io/broad-gotc-prod/upstools:1.2.0-2023.03.03-1704723060"
+        String docker = "us.gcr.io/broad-gotc-prod/upstools:2.0.0"
         Int cpu = 1
         Int disk_size = ceil(2 * (size(read1_fastq, "GiB") + size(read3_fastq, "GiB") + size(barcodes_fastq, "GiB") )) + 400
         Int preemptible = 3

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -13,9 +13,9 @@ task PairedTagDemultiplex {
         Int preemptible = 3
         Int mem_size = 8
     }
-    String r1_base = basename(read1_fastq, "fastq.gz")
-    String r2_base = basename(barcodes_fastq, "fastq.gz")
-    String r3_base = basename(read3_fastq, "fastq.gz")
+    String r1_base = basename(read1_fastq, ".fastq.gz")
+    String r2_base = basename(barcodes_fastq, ".fastq.gz")
+    String r3_base = basename(read3_fastq, ".fastq.gz")
     meta {
         description: "Checks read2 FASTQ length and orientation and performs trimming."
     }

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -53,9 +53,9 @@ task PairedTagDemultiplex {
         echo 'this is the read:' $R2
         echo 'this is the barcode count:' $COUNT
         echo "Renaming files for UPS tools"
-        mv ~{read1_fastq} "~{r1_base}.fq.gz"
-        mv ~{barcodes_fastq} "~{r2_base}.fq.gz"
-        mv ~{read3_fastq} "~{r3_base}.fq.gz"
+        mv ~{read1_fastq} "~{input_id}_R1.fq.gz"
+        mv ~{barcodes_fastq} "~{input_id}_R2.fq.gz"
+        mv ~{read3_fastq} "~{input_id}_R3.fq.gz"
         echo "performing read2 length, trimming, and orientation checks" 
         if [[ $COUNT == 27 && ~{preindex} == "false" ]]
           then

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -13,6 +13,9 @@ task PairedTagDemultiplex {
         Int preemptible = 3
         Int mem_size = 8
     }
+    String r1_base = basename(read1_fastq)
+    String r2_base = basename(barcodes_fastq)
+    String r3_base = basename(read3_fastq)
     meta {
         description: "Checks read2 FASTQ length and orientation and performs trimming."
     }
@@ -41,9 +44,9 @@ task PairedTagDemultiplex {
         echo 'this is the read:' $R2
         echo 'this is the barcode count:' $COUNT
         echo "Renaming files for UPS tools"
-        mv ~{read1_fastq} "~{input_id}_R1.fq.gz"
-        mv ~{barcodes_fastq} "~{input_id}_R2.fq.gz"
-        mv ~{read3_fastq} "~{input_id}_R3.fq.gz"
+        mv ~{read1_fastq} "~{r1_base}.fq.gz"
+        mv ~{barcodes_fastq} "~{r2_base}.fq.gz"
+        mv ~{read3_fastq} "~{r3_base}.fq.gz"
         echo "performing read2 length, trimming, and orientation checks" 
         if [[ $COUNT == 27 && ~{preindex} == "false" ]]
           then
@@ -65,7 +68,7 @@ task PairedTagDemultiplex {
             pass="false"
             echo "Incorrect barcode orientation"
           fi
-          mv "~{input_id}_R2_trim.fq.gz" "~{input_id}_R2.fq.gz"
+          mv "~{input_id}_R2_trim.fq.gz" "~{r2_base}.fq.gz"
 
         elif [[ $COUNT == 27 && ~{preindex} == "true" ]]
           then
@@ -88,9 +91,9 @@ task PairedTagDemultiplex {
             echo "Incorrect barcode orientation"
           fi
           # rename files to original name
-          mv "~{input_id}_R2_prefix.fq.gz" "~{input_id}_R2.fq.gz"
-          mv "~{input_id}_R1_prefix.fq.gz" "~{input_id}_R1.fq.gz"
-          mv "~{input_id}_R3_prefix.fq.gz" "~{input_id}_R3.fq.gz"
+          mv "~{input_id}_R2_prefix.fq.gz" "~{r2_base}.fq.gz"
+          mv "~{input_id}_R1_prefix.fq.gz" "~{r1_base}.fq.gz"
+          mv "~{input_id}_R3_prefix.fq.gz" "~{r3_base}.fq.gz"
         elif [[ $COUNT == 24 && ~{preindex} == "false" ]]
           then
           echo "FASTQ has correct index length, no modification necessary"
@@ -120,9 +123,9 @@ task PairedTagDemultiplex {
     }
 
     output {
-        File fastq1 = "~{input_id}_R1.fq.gz"
-        File barcodes = "~{input_id}_R2.fq.gz"
-        File fastq3 = "~{input_id}_R3.fq.gz"
+        File fastq1 = "~{r1_base}.fq.gz"
+        File barcodes = "~{r2_base}.fq.gz"
+        File fastq3 = "~{r3_base}.fq.gz"
     }
 }
 

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -40,9 +40,6 @@ task PairedTagDemultiplex {
         echo "r2_base is: ~{r2_base}"
         echo "r3_base is: ~{r3_base}"
 
-        # do an ls
-        ls -lh
-
         ## Need to gunzip the r1_fastq
         pass="true"
         zcat ~{barcodes_fastq} | head -n2 > r2.fastq

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -13,9 +13,9 @@ task PairedTagDemultiplex {
         Int preemptible = 3
         Int mem_size = 8
     }
-    String r1_base = basename(read1_fastq)
-    String r2_base = basename(barcodes_fastq)
-    String r3_base = basename(read3_fastq)
+    String r1_base = basename(read1_fastq, "fastq.gz")
+    String r2_base = basename(barcodes_fastq, "fastq.gz")
+    String r3_base = basename(read3_fastq, "fastq.gz")
     meta {
         description: "Checks read2 FASTQ length and orientation and performs trimming."
     }

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -77,9 +77,10 @@ task PairedTagDemultiplex {
             pass="false"
             echo "Incorrect barcode orientation"
           fi
+          echo renaming files
           mv "~{input_id}_R2_trim.fq.gz" "~{r2_base}.fq.gz"
           mv "~{input_id}_R1.fq.gz" "~{r1_base}.fq.gz"
-          mv "~{input_id}_R3.fq.gz" "{r3_base}.fq.gz"
+          mv "~{input_id}_R3.fq.gz" "~{r3_base}.fq.gz"
 
         elif [[ $COUNT == 27 && ~{preindex} == "true" ]]
           then

--- a/tasks/skylab/PairedTagUtils.wdl
+++ b/tasks/skylab/PairedTagUtils.wdl
@@ -34,6 +34,15 @@ task PairedTagDemultiplex {
     }
     command <<<
         set -e
+
+        # echo the basenames
+        echo "r1_base is: ~{r1_base}"
+        echo "r2_base is: ~{r2_base}"
+        echo "r3_base is: ~{r3_base}"
+
+        # do an ls
+        ls -lh
+
         ## Need to gunzip the r1_fastq
         pass="true"
         zcat ~{barcodes_fastq} | head -n2 > r2.fastq


### PR DESCRIPTION
### Description
This PR corrects a naming collision that occurs when multiple fastq lanes are used as input to the pipeline. As part of the demultiplexing step, we have to rename files so that software UPStools can perform trimming and preindex demultiplexing. This PR adds an additional renaming step using the basename of the original fastq after trimming to ensure that files do not have collisions in downstream workflow tasks. 

A test run of this in on terra here: https://app.terra.bio/#workspaces/warp-pipelines/Multiome-test-workspace/job_history/4e1c5218-3873-4548-b2e6-8517a77b10a7
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
