### PR TITLE
added nhash_id to multiome, optimus, paired-tag, and atac

### DIFF
--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,3 +1,9 @@
+# 5.1.0
+2024-06-28 (Date of Last Commit)
+
+* Updated the STARsolo parameters for estimating cells to Emptydrops_CR
+* Added an optional input for expected cells which is used for metric calculation
+
 # 5.0.0
 2024-05-20 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 5.2.0
+2024-07-09 (Date of Last Commit)
+
+* Added new optional input parameter of nhash_id, an optional identifier for a library aliquot that is echoed in the ATAC fragment h5ad, the gene expression h5ad (in the data.uns), and the gene expression library metrics CSV output; default is set to null
+
 # 5.1.0
 2024-06-28 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -11,6 +11,8 @@ workflow Multiome {
 
     input {
         String input_id
+        # Additional library aliquot ID
+        String nhash_id = "1"
 
         # Optimus Inputs
         String counting_mode = "sn_rna"
@@ -58,6 +60,7 @@ workflow Multiome {
             i1_fastq = gex_i1_fastq,
             input_id = input_id + "_gex",
             output_bam_basename = input_id + "_gex",
+            gex_nhash_id = nhash_id,
             tar_star_reference = tar_star_reference,
             annotations_gtf = annotations_gtf,
             mt_genes = mt_genes,
@@ -83,6 +86,7 @@ workflow Multiome {
             whitelist = atac_whitelist,
             adapter_seq_read1 = adapter_seq_read1,
             annotations_gtf = annotations_gtf,
+            atac_nhash_id = nhash_id,
             adapter_seq_read3 = adapter_seq_read3
     }
     call H5adUtils.JoinMultiomeBarcodes as JoinBarcodes {

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/c
 
 workflow Multiome {
 
-    String pipeline_version = "5.0.0"
+    String pipeline_version = "5.1.0"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -12,7 +12,7 @@ workflow Multiome {
     input {
         String input_id
         # Additional library aliquot ID
-        String nhash_id = "1"
+        String? nhash_id
 
         # Optimus Inputs
         String counting_mode = "sn_rna"

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/c
 
 workflow Multiome {
 
-    String pipeline_version = "5.1.0"
+    String pipeline_version = "5.2.0"
 
     input {
         String input_id

--- a/pipelines/skylab/multiome/atac.changelog.md
+++ b/pipelines/skylab/multiome/atac.changelog.md
@@ -1,3 +1,8 @@
+# 2.1.0
+2024-07-09 (Date of Last Commit)
+
+* Added new optional input parameter of atac_nhash_id, an identifier for a library aliquot that is echoed in the atac fragment metrics h5ad (in the data.uns); default is set to null 
+
 # 2.0.0
 2024-05-20 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -471,6 +471,7 @@ task CreateFragmentFile {
     chrom_sizes = "~{chrom_sizes}"
     atac_gtf = "~{annotations_gtf}"
     preindex = "~{preindex}"
+    atac_nhash_id = "~{atac_nhash_id}"
 
     # calculate chrom size dictionary based on text file
     chrom_size_dict={}
@@ -496,7 +497,7 @@ task CreateFragmentFile {
     pp.import_data("~{bam_base_name}.fragments.tsv", file="temp_metrics.h5ad", chrom_sizes=chrom_size_dict, min_num_fragments=0)
     atac_data = ad.read_h5ad("temp_metrics.h5ad")
     # Add nhash_id to h5ad file as unstructured metadata
-    data_data.uns['NHashID'] = ~{atac_nhash_id}
+    data_data.uns['NHashID'] = atac_nhash_id
     # calculate tsse metrics
     snap.metrics.tsse(atac_data, atac_gtf)
     # Write new atac file

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -497,7 +497,7 @@ task CreateFragmentFile {
     pp.import_data("~{bam_base_name}.fragments.tsv", file="temp_metrics.h5ad", chrom_sizes=chrom_size_dict, min_num_fragments=0)
     atac_data = ad.read_h5ad("temp_metrics.h5ad")
     # Add nhash_id to h5ad file as unstructured metadata
-    data_data.uns['NHashID'] = atac_nhash_id
+    atac_data.uns['NHashID'] = atac_nhash_id
     # calculate tsse metrics
     snap.metrics.tsse(atac_data, atac_gtf)
     # Write new atac file

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -43,7 +43,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "2.0.0"
+  String pipeline_version = "2.1.0"
 
   parameter_meta {
     read1_fastq_gzipped: "read 1 FASTQ file as input for the pipeline, contains read 1 of paired reads"

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -18,6 +18,8 @@ workflow ATAC {
 
     # Output prefix/base name for all intermediate files and pipeline outputs
     String input_id
+    # Additional library aliquot ID
+    String atac_nhash_id = "1"
 
     # Option for running files with preindex
     Boolean preindex = false
@@ -105,7 +107,8 @@ workflow ATAC {
         bam = BBTag.bb_bam,
         chrom_sizes = chrom_sizes,
         annotations_gtf = annotations_gtf,
-        preindex = preindex
+        preindex = preindex,
+        atac_nhash_id = atac_nhash_id
     }
   }
   if (!preindex) {
@@ -114,7 +117,8 @@ workflow ATAC {
         bam = BWAPairedEndAlignment.bam_aligned_output,
         chrom_sizes = chrom_sizes,
         annotations_gtf = annotations_gtf,
-        preindex = preindex
+        preindex = preindex,
+        atac_nhash_id = atac_nhash_id
 
     }
   }
@@ -443,6 +447,7 @@ task CreateFragmentFile {
     Int mem_size = 16
     Int nthreads = 4
     String cpuPlatform = "Intel Cascade Lake"
+    String atac_nhash_id
   }
 
   String bam_base_name = basename(bam, ".bam")
@@ -490,6 +495,8 @@ task CreateFragmentFile {
     # those settings allow us to retain all barcodes
     pp.import_data("~{bam_base_name}.fragments.tsv", file="temp_metrics.h5ad", chrom_sizes=chrom_size_dict, min_num_fragments=0)
     atac_data = ad.read_h5ad("temp_metrics.h5ad")
+    # Add nhash_id to h5ad file as unstructured metadata
+    data_data.uns['NHashID'] = ~{atac_nhash_id}
     # calculate tsse metrics
     snap.metrics.tsse(atac_data, atac_gtf)
     # Write new atac file

--- a/pipelines/skylab/multiome/atac.wdl
+++ b/pipelines/skylab/multiome/atac.wdl
@@ -19,7 +19,7 @@ workflow ATAC {
     # Output prefix/base name for all intermediate files and pipeline outputs
     String input_id
     # Additional library aliquot ID
-    String atac_nhash_id = "1"
+    String? atac_nhash_id
 
     # Option for running files with preindex
     Boolean preindex = false
@@ -447,7 +447,7 @@ task CreateFragmentFile {
     Int mem_size = 16
     Int nthreads = 4
     String cpuPlatform = "Intel Cascade Lake"
-    String atac_nhash_id
+    String atac_nhash_id = ""
   }
 
   String bam_base_name = basename(bam, ".bam")

--- a/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
+++ b/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
@@ -23,5 +23,6 @@
   "Multiome.Atac.cpu_platform_bwa":"Intel Cascade Lake",
   "Multiome.Atac.num_threads_bwa":"16",
   "Multiome.Atac.mem_size_bwa":"64", 
-  "Multiome.soloMultiMappers":"Uniform"
+  "Multiome.soloMultiMappers":"Uniform",
+  "Multiome.nhash_id":"1234-example"
 }

--- a/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
+++ b/pipelines/skylab/multiome/test_inputs/Plumbing/10k_pbmc_downsampled.json
@@ -24,5 +24,5 @@
   "Multiome.Atac.num_threads_bwa":"16",
   "Multiome.Atac.mem_size_bwa":"64", 
   "Multiome.soloMultiMappers":"Uniform",
-  "Multiome.nhash_id":"1234-example"
+  "Multiome.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
@@ -31,5 +31,5 @@
   "Multiome.Atac.cpu_platform_bwa":"Intel Cascade Lake",
   "Multiome.Atac.num_threads_bwa":"24",
   "Multiome.Atac.mem_size_bwa":"175",
-  "Multiome.nhash_id":"1234-example"
+  "Multiome.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/multiome/test_inputs/Scientific/10k_pbmc.json
@@ -30,5 +30,6 @@
   "Multiome.chrom_sizes":"gs://broad-gotc-test-storage/Multiome/input/hg38.chrom.sizes",
   "Multiome.Atac.cpu_platform_bwa":"Intel Cascade Lake",
   "Multiome.Atac.num_threads_bwa":"24",
-  "Multiome.Atac.mem_size_bwa":"175"
+  "Multiome.Atac.mem_size_bwa":"175",
+  "Multiome.nhash_id":"1234-example"
 }

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,9 @@
+# 7.2.0
+2024-06-28 (Date of Last Commit)
+
+* Updated the STARsolo parameters for estimating cells to Emptydrops_CR
+* Added an optional input for expected cells which is used for metric calculation
+
 # 7.1.0
 2024-05-20 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.changelog.md
+++ b/pipelines/skylab/optimus/Optimus.changelog.md
@@ -1,3 +1,8 @@
+# 7.3.0
+2024-07-09 (Date of Last Commit)
+
+* Added new optional input parameter of gex_nhash_id, a string identifier for a library aliquot that is echoed in the h5ad cell by gene matrix (in the data.uns) and the library metrics CSV output; default is set to null 
+
 # 7.2.0
 2024-06-28 (Date of Last Commit)
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -23,7 +23,7 @@ workflow Optimus {
     Array[File]? i1_fastq
     String input_id
     # String for additional library aliquot ID
-    String gex_nhash_id = ""
+    String? gex_nhash_id = ""
     String output_bam_basename = input_id
     String? input_name
     String? input_id_metadata_field
@@ -172,7 +172,8 @@ workflow Optimus {
       umipercell = STARsoloFastq.umipercell,
       input_id = input_id,
       counting_mode = counting_mode,
-      expected_cells = expected_cells
+      expected_cells = expected_cells,
+      gex_nhash_id = gex_nhash_id
   }
   if (counting_mode == "sc_rna"){
     call RunEmptyDrops.RunEmptyDrops {
@@ -216,7 +217,7 @@ workflow Optimus {
         align_features = STARsoloFastq.align_features_sn_rna,
         umipercell = STARsoloFastq.umipercell_sn_rna,
         input_id = input_id,
-        gex_nhash_id = gex_nhash_id,     
+        gex_nhash_id = gex_nhash_id     
     }
     call H5adUtils.SingleNucleusOptimusH5adOutput as OptimusH5adGenerationWithExons{
       input:

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -22,6 +22,8 @@ workflow Optimus {
     Array[File] r2_fastq
     Array[File]? i1_fastq
     String input_id
+    # String for additional library aliquot ID
+    String gex_nhash_id = ""
     String output_bam_basename = input_id
     String? input_name
     String? input_id_metadata_field
@@ -186,6 +188,7 @@ workflow Optimus {
     call H5adUtils.OptimusH5adGeneration{
       input:
         input_id = input_id,
+        gex_nhash_id = gex_nhash_id,
         input_name = input_name,
         input_id_metadata_field = input_id_metadata_field,
         input_name_metadata_field = input_name_metadata_field,
@@ -212,11 +215,13 @@ workflow Optimus {
         summary = STARsoloFastq.summary_sn_rna,
         align_features = STARsoloFastq.align_features_sn_rna,
         umipercell = STARsoloFastq.umipercell_sn_rna,
-        input_id = input_id     
+        input_id = input_id,
+        gex_nhash_id = gex_nhash_id,     
     }
     call H5adUtils.SingleNucleusOptimusH5adOutput as OptimusH5adGenerationWithExons{
       input:
         input_id = input_id,
+        gex_nhash_id = gex_nhash_id,
         input_name = input_name,
         input_id_metadata_field = input_id_metadata_field,
         input_name_metadata_field = input_name_metadata_field,

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -31,6 +31,7 @@ workflow Optimus {
     File annotations_gtf
     File? mt_genes
     String? soloMultiMappers = "Uniform"
+    Int? expected_cells
 
     # Chemistry options include: 2 or 3
     Int tenx_chemistry_version
@@ -65,7 +66,7 @@ workflow Optimus {
   # version of this pipeline
 
 
-  String pipeline_version = "7.1.0"
+  String pipeline_version = "7.2.0"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
@@ -168,7 +169,8 @@ workflow Optimus {
       align_features = STARsoloFastq.align_features,
       umipercell = STARsoloFastq.umipercell,
       input_id = input_id,
-      counting_mode = counting_mode
+      counting_mode = counting_mode,
+      expected_cells = expected_cells
   }
   if (counting_mode == "sc_rna"){
     call RunEmptyDrops.RunEmptyDrops {

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -68,7 +68,7 @@ workflow Optimus {
   # version of this pipeline
 
 
-  String pipeline_version = "7.2.0"
+  String pipeline_version = "7.3.0"
 
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
@@ -15,5 +15,6 @@
   "Optimus.input_id": "pbmc_human_v3",
   "Optimus.tenx_chemistry_version": "3",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf",
-  "Optimus.star_strand_mode": "Forward"
+  "Optimus.star_strand_mode": "Forward",
+  "Optimus.nhash_id":"1234-example"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
@@ -16,5 +16,5 @@
   "Optimus.tenx_chemistry_version": "3",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf",
   "Optimus.star_strand_mode": "Forward",
-  "Optimus.gex_nhash_id":"1234-example"
+  "Optimus.gex_nhash_id":"example_1234"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/human_v3_example.json
@@ -16,5 +16,5 @@
   "Optimus.tenx_chemistry_version": "3",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf",
   "Optimus.star_strand_mode": "Forward",
-  "Optimus.nhash_id":"1234-example"
+  "Optimus.gex_nhash_id":"1234-example"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
@@ -27,6 +27,6 @@
   "Optimus.input_id": "neurons2k_mouse",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Unstranded",
-  "Optimus.nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"1234-example",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
@@ -27,6 +27,6 @@
   "Optimus.input_id": "neurons2k_mouse",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Unstranded",
-  "Optimus.gex_nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"example_1234",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_example.json
@@ -27,5 +27,6 @@
   "Optimus.input_id": "neurons2k_mouse",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Unstranded",
+  "Optimus.nhash_id":"1234-example",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf"
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
@@ -25,6 +25,6 @@
   "Optimus.star_strand_mode": "Unstranded",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf",
   "Optimus.counting_mode": "sn_rna",
-  "Optimus.gex_nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"example_1234",
   "Optimus.count_exons": true
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
@@ -25,5 +25,6 @@
   "Optimus.star_strand_mode": "Unstranded",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf",
   "Optimus.counting_mode": "sn_rna",
+  "Optimus.nhash_id":"1234-example",
   "Optimus.count_exons": true
 }

--- a/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
+++ b/pipelines/skylab/optimus/test_inputs/Plumbing/mouse_v2_snRNA_example.json
@@ -25,6 +25,6 @@
   "Optimus.star_strand_mode": "Unstranded",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/GRCm39/star/v2_7_10a/modified_vM32.annotation.gtf",
   "Optimus.counting_mode": "sn_rna",
-  "Optimus.nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"1234-example",
   "Optimus.count_exons": true
 }

--- a/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc.json
+++ b/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc.json
@@ -15,6 +15,7 @@
   "Optimus.input_id": "8k_pbmc",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Unstranded",
+  "Optimus.nhash_id":"1234-example",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf"
 }
 

--- a/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc.json
+++ b/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc.json
@@ -15,7 +15,7 @@
   "Optimus.input_id": "8k_pbmc",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Unstranded",
-  "Optimus.nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"example_1234",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf"
 }
 

--- a/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc_stranded.json
+++ b/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc_stranded.json
@@ -15,7 +15,7 @@
   "Optimus.input_id": "8k_pbmc",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Forward",
-  "Optimus.nhash_id":"1234-example",
+  "Optimus.gex_nhash_id":"example_1234",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/gencode.v27.primary_assembly.annotation.gtf"
 }
 

--- a/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc_stranded.json
+++ b/pipelines/skylab/optimus/test_inputs/Scientific/inputs_8k_pbmc_stranded.json
@@ -15,6 +15,7 @@
   "Optimus.input_id": "8k_pbmc",
   "Optimus.tenx_chemistry_version": "2",
   "Optimus.star_strand_mode": "Forward",
+  "Optimus.nhash_id":"1234-example",
   "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/gencode.v27.primary_assembly.annotation.gtf"
 }
 

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 1.2.0
+2024-07-09 (Date of Last Commit)
+
+* Added new optional input parameter of nhash_id, an optional identifier for a library aliquot that is echoed in the  workflow fragment h5ad, the Optimus workflow gene expression h5ad (in the data.uns), and the Optimus gene expression library metrics CSV output; default is set to null
+
 # 1.1.0
 2024-06-28 (Date of Last Commit)
 

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,9 @@
+# 1.1.0
+2024-06-28 (Date of Last Commit)
+
+* Updated the STARsolo parameters for estimating cells to Emptydrops_CR
+* Added an optional input for expected cells which is used for metric calculation
+
 # 1.0.0
 2024-06-26
 

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -5,7 +5,7 @@ import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/skylab/PairedTagUtils.wdl" as Demultiplexing
 workflow PairedTag {
-    String pipeline_version = "1.0.0"
+    String pipeline_version = "1.1.0"
 
     input {
         String input_id

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -5,7 +5,7 @@ import "../../../pipelines/skylab/optimus/Optimus.wdl" as optimus
 import "../../../tasks/skylab/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/skylab/PairedTagUtils.wdl" as Demultiplexing
 workflow PairedTag {
-    String pipeline_version = "1.1.0"
+    String pipeline_version = "1.2.0"
 
     input {
         String input_id

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -10,7 +10,7 @@ workflow PairedTag {
     input {
         String input_id
         # Additional library aliquot id
-        String nhash_id = "1"
+        String? nhash_id
 
         # Optimus Inputs
         String counting_mode = "sn_rna"

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -9,6 +9,8 @@ workflow PairedTag {
 
     input {
         String input_id
+        # Additional library aliquot id
+        String nhash_id = "1"
 
         # Optimus Inputs
         String counting_mode = "sn_rna"
@@ -63,7 +65,8 @@ workflow PairedTag {
             ignore_r1_read_length = ignore_r1_read_length,
             star_strand_mode = star_strand_mode,
             count_exons = count_exons,
-            soloMultiMappers = soloMultiMappers
+            soloMultiMappers = soloMultiMappers,
+            gex_nhash_id = nhash_id
     }
 
     # Call the ATAC workflow
@@ -91,7 +94,8 @@ workflow PairedTag {
             adapter_seq_read1 = adapter_seq_read1,
             adapter_seq_read3 = adapter_seq_read3,
             annotations_gtf = annotations_gtf,
-            preindex = preindex
+            preindex = preindex,
+            atac_nhash_id = nhash_id
     }
 
     if (preindex) {

--- a/pipelines/skylab/paired_tag/test_inputs/Plumbing/10k_pbmc_downsampled.json
+++ b/pipelines/skylab/paired_tag/test_inputs/Plumbing/10k_pbmc_downsampled.json
@@ -23,5 +23,6 @@
   "PairedTag.Atac_preindex.cpu_platform_bwa":"Intel Cascade Lake",
   "PairedTag.Atac_preindex.num_threads_bwa":"16",
   "PairedTag.Atac_preindex.mem_size_bwa":"64", 
-  "PairedTag.soloMultiMappers":"Uniform"
+  "PairedTag.soloMultiMappers":"Uniform",
+  "PairedTag.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/paired_tag/test_inputs/Plumbing/BC011_BC015_downsampled.json
+++ b/pipelines/skylab/paired_tag/test_inputs/Plumbing/BC011_BC015_downsampled.json
@@ -23,5 +23,6 @@
   "PairedTag.Atac_preindex.cpu_platform_bwa":"Intel Cascade Lake",
   "PairedTag.Atac_preindex.num_threads_bwa":"16",
   "PairedTag.Atac_preindex.mem_size_bwa":"64", 
-  "PairedTag.soloMultiMappers":"Uniform"
+  "PairedTag.soloMultiMappers":"Uniform",
+  "PairedTag.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/paired_tag/test_inputs/Plumbing/BI015_downsampled.json
+++ b/pipelines/skylab/paired_tag/test_inputs/Plumbing/BI015_downsampled.json
@@ -23,5 +23,6 @@
   "PairedTag.Atac_preindex.cpu_platform_bwa":"Intel Cascade Lake",
   "PairedTag.Atac_preindex.num_threads_bwa":"16",
   "PairedTag.Atac_preindex.mem_size_bwa":"64", 
-  "PairedTag.soloMultiMappers":"Uniform"
+  "PairedTag.soloMultiMappers":"Uniform",
+  "PairedTag.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/paired_tag/test_inputs/Scientific/10k_pbmc.json
+++ b/pipelines/skylab/paired_tag/test_inputs/Scientific/10k_pbmc.json
@@ -32,5 +32,6 @@
   "PairedTag.Atac_preindex.cpu_platform_bwa":"Intel Cascade Lake",
   "PairedTag.Atac_preindex.num_threads_bwa":"24",
   "PairedTag.Atac_preindex.mem_size_bwa":"175", 
-  "PairedTag.soloMultiMappers":"Uniform"
+  "PairedTag.soloMultiMappers":"Uniform",
+  "PairedTag.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/paired_tag/test_inputs/Scientific/BC011_10kPBMC.json
+++ b/pipelines/skylab/paired_tag/test_inputs/Scientific/BC011_10kPBMC.json
@@ -29,5 +29,6 @@
   "PairedTag.Atac_preindex.cpu_platform_bwa":"Intel Cascade Lake",
   "PairedTag.Atac_preindex.num_threads_bwa":"16",
   "PairedTag.Atac_preindex.mem_size_bwa":"64", 
-  "PairedTag.soloMultiMappers":"Uniform"
+  "PairedTag.soloMultiMappers":"Uniform",
+  "PairedTag.nhash_id":"example_1234"
 }

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.7
+2024-06-28 (Date of Last Commit)
+
+* Updated the STARsolo parameters for estimating cells to Emptydrops_CR; this does not affect the slideseq pipeline
+
 # 3.1.6
 2024-05-20 (Date of Last Commit)
 

--- a/pipelines/skylab/slideseq/SlideSeq.changelog.md
+++ b/pipelines/skylab/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.8
+2024-07-09 (Date of Last Commit)
+
+* Added new optional input parameter of gex_nhash_id to the STARAlign task; this does not impact the SlideSeq workflow 
+
 # 3.1.7
 2024-06-28 (Date of Last Commit)
 

--- a/pipelines/skylab/slideseq/SlideSeq.wdl
+++ b/pipelines/skylab/slideseq/SlideSeq.wdl
@@ -23,7 +23,7 @@ import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow SlideSeq {
 
-    String pipeline_version = "3.1.7"
+    String pipeline_version = "3.1.8"
 
     input {
         Array[File] r1_fastq

--- a/pipelines/skylab/slideseq/SlideSeq.wdl
+++ b/pipelines/skylab/slideseq/SlideSeq.wdl
@@ -23,7 +23,7 @@ import "../../../tasks/skylab/MergeSortBam.wdl" as Merge
 
 workflow SlideSeq {
 
-    String pipeline_version = "3.1.6"
+    String pipeline_version = "3.1.7"
 
     input {
         Array[File] r1_fastq

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,7 @@
+# 1.3.6
+2024-07-09 (Date of Last Commit)
+* Added new optional input parameter of gex_nhash_id to the STARAlign task; this does not impact the MultiSampleSmartSeq2SingleNucleus workflow 
+
 # 1.3.5
 2024-06-28 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 1.3.5
+2024-06-28 (Date of Last Commit)
+
+* Updated the STARsolo parameters for estimating cells to Emptydrops_CR; this does not impact the snSS2 pipeline
+
 # 1.3.4
 2024-04-12 (Date of Last Commit)
 

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.3.4"
+  String pipeline_version = "1.3.5"
 
   if (false) {
      String? none = "None"

--- a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -40,7 +40,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
       String? input_id_metadata_field
   }
   # Version of this pipeline
-  String pipeline_version = "1.3.5"
+  String pipeline_version = "1.3.6"
 
   if (false) {
      String? none = "None"

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -92,6 +92,7 @@ task OptimusH5adGeneration {
 
     # set parameters
     gex_h5ad = "~{input_id}.h5ad"
+    gex_nhash_id = "~{gex_nhash_id}"
 
     # import anndata to manipulate h5ad files
     import anndata as ad
@@ -99,7 +100,7 @@ task OptimusH5adGeneration {
     print("Reading Optimus h5ad:")
     print(gex_h5ad)
     gex_data = ad.read_h5ad(gex_h5ad)
-    gex_data.uns['NHashID'] = ~{gex_nhash_id}
+    gex_data.uns['NHashID'] = gex_nhash_id
     gex_data.write("~{input_id}.h5ad")
     CODE 
   >>>
@@ -192,6 +193,7 @@ task SingleNucleusOptimusH5adOutput {
 
         # set parameters
         gex_h5ad = "~{input_id}.h5ad"
+        gex_nhash_id = "~{gex_nhash_id}"
 
         # import anndata to manipulate h5ad files
         import anndata as ad
@@ -199,7 +201,7 @@ task SingleNucleusOptimusH5adOutput {
         print("Reading Optimus h5ad:")
         print(gex_h5ad)
         gex_data = ad.read_h5ad(gex_h5ad)
-        gex_data.uns['NHashID'] = ~{gex_nhash_id}
+        gex_data.uns['NHashID'] = gex_nhash_id
         gex_data.write("~{input_id}.h5ad")
         CODE
     }

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -101,6 +101,7 @@ task OptimusH5adGeneration {
     gex_data = ad.read_h5ad(gex_h5ad)
     gex_data.uns['NHashID'] = ~{gex_nhash_id}
     gex_data.write("~{input_id}.h5ad")
+    CODE 
   >>>
 
   runtime {
@@ -200,6 +201,7 @@ task SingleNucleusOptimusH5adOutput {
         gex_data = ad.read_h5ad(gex_h5ad)
         gex_data.uns['NHashID'] = ~{gex_nhash_id}
         gex_data.write("~{input_id}.h5ad")
+        CODE
     }
 
     runtime {

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -9,6 +9,7 @@ task OptimusH5adGeneration {
     String docker = "us.gcr.io/broad-gotc-prod/warp-tools:2.0.1"
     # name of the sample
     String input_id
+    String gex_nhash_id
     # user provided id
     String? input_name
     String? input_id_metadata_field
@@ -85,6 +86,21 @@ task OptimusH5adGeneration {
           --expression_data_type "whole_transcript"\
           --pipeline_version ~{pipeline_version}
     fi
+
+    # modify h5ad
+    python3 <<CODE
+
+    # set parameters
+    gex_h5ad = "~{input_id}.h5ad"
+
+    # import anndata to manipulate h5ad files
+    import anndata as ad
+    import pandas as pd
+    print("Reading Optimus h5ad:")
+    print(gex_h5ad)
+    gex_data = ad.read_h5ad(gex_h5ad)
+    gex_data.uns['NHashID'] = ~{gex_nhash_id}
+    gex_data.write("~{input_id}.h5ad")
   >>>
 
   runtime {
@@ -108,6 +124,8 @@ task SingleNucleusOptimusH5adOutput {
         String docker = "us.gcr.io/broad-gotc-prod/warp-tools:2.0.1"
         # name of the sample
         String input_id
+        # additional aliquot id
+        String gex_nhash_id
         # user provided id
         String? input_name
         String? input_id_metadata_field
@@ -167,6 +185,21 @@ task SingleNucleusOptimusH5adOutput {
         ~{"--input_name_metadata_field " + input_name_metadata_field} \
         --expression_data_type "whole_transcript" \
         --pipeline_version ~{pipeline_version}
+
+        # modify h5ad
+        python3 <<CODE
+
+        # set parameters
+        gex_h5ad = "~{input_id}.h5ad"
+
+        # import anndata to manipulate h5ad files
+        import anndata as ad
+        import pandas as pd
+        print("Reading Optimus h5ad:")
+        print(gex_h5ad)
+        gex_data = ad.read_h5ad(gex_h5ad)
+        gex_data.uns['NHashID'] = ~{gex_nhash_id}
+        gex_data.write("~{input_id}.h5ad")
     }
 
     runtime {

--- a/tasks/skylab/H5adUtils.wdl
+++ b/tasks/skylab/H5adUtils.wdl
@@ -9,7 +9,7 @@ task OptimusH5adGeneration {
     String docker = "us.gcr.io/broad-gotc-prod/warp-tools:2.0.1"
     # name of the sample
     String input_id
-    String gex_nhash_id
+    String gex_nhash_id = ""
     # user provided id
     String? input_name
     String? input_id_metadata_field
@@ -125,7 +125,7 @@ task SingleNucleusOptimusH5adOutput {
         # name of the sample
         String input_id
         # additional aliquot id
-        String gex_nhash_id
+        String gex_nhash_id = ""
         # user provided id
         String? input_name
         String? input_id_metadata_field

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -443,6 +443,8 @@ task MergeStarOutput {
     String? counting_mode
     
     String input_id
+    # additional library aliquot id
+    String gex_nhash_id = ""
     Int expected_cells = 3000
     File barcodes_single = barcodes[0]
     File features_single = features[0]
@@ -583,6 +585,11 @@ task MergeStarOutput {
         --features ${features_files[@]} \
         --matrix ${matrix_files[@]} \
         --input_id ~{input_id}
+    
+    cp ~{input_id}_library_metrics.csv ~{input_id}_library_metrics_backup.csv
+
+    # Add the header and append the original file content
+    { echo ~{gex_nhash_id}; cat ~{input_id}_library_metrics.csv; } > ~{input_id}_{gex_nhash_id}_library_metrics.csv
   >>>
 
   runtime {
@@ -599,7 +606,7 @@ task MergeStarOutput {
     File col_index = "~{input_id}_sparse_counts_col_index.npy"
     File sparse_counts = "~{input_id}_sparse_counts.npz"
     File? cell_reads_out = "~{input_id}.star_metrics.tar"
-    File? library_metrics="~{input_id}_library_metrics.csv"
+    File? library_metrics="~{input_id}_{gex_nhash_id}_library_metrics.csv"
     File? mtx_files ="~{input_id}.mtx_files.tar"
   }
 }

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -575,7 +575,7 @@ task MergeStarOutput {
       ~{expected_cells}
       echo "Adding NHashID to library metrics"
       cp ~{input_id}_library_metrics.csv ~{input_id}_library_metrics_backup.csv
-      { echo ~{gex_nhash_id}; cat ~{input_id}_library_metrics.csv; } > ~{input_id}_{gex_nhash_id}_library_metrics.csv
+      { echo -e "~{gex_nhash_id}\n"; cat ~{input_id}_library_metrics.csv; } > ~{input_id}_~{gex_nhash_id}_library_metrics.csv
       echo "tarring STAR txt files"
       tar -zcvf ~{input_id}.star_metrics.tar *.txt
     else
@@ -605,7 +605,7 @@ task MergeStarOutput {
     File col_index = "~{input_id}_sparse_counts_col_index.npy"
     File sparse_counts = "~{input_id}_sparse_counts.npz"
     File? cell_reads_out = "~{input_id}.star_metrics.tar"
-    File? library_metrics="~{input_id}_{gex_nhash_id}_library_metrics.csv"
+    File? library_metrics="~{input_id}_~{gex_nhash_id}_library_metrics.csv"
     File? mtx_files ="~{input_id}.mtx_files.tar"
   }
 }

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -573,6 +573,10 @@ task MergeStarOutput {
       outputbarcodes.tsv \
       outputmatrix.mtx \
       ~{expected_cells}
+      echo "Adding NHashID to library metrics"
+      cp ~{input_id}_library_metrics.csv ~{input_id}_library_metrics_backup.csv
+      { echo ~{gex_nhash_id}; cat ~{input_id}_library_metrics.csv; } > ~{input_id}_{gex_nhash_id}_library_metrics.csv
+      echo "tarring STAR txt files"
       tar -zcvf ~{input_id}.star_metrics.tar *.txt
     else
       echo "No text files found in the folder."
@@ -585,11 +589,6 @@ task MergeStarOutput {
         --features ${features_files[@]} \
         --matrix ${matrix_files[@]} \
         --input_id ~{input_id}
-    
-    cp ~{input_id}_library_metrics.csv ~{input_id}_library_metrics_backup.csv
-
-    # Add the header and append the original file content
-    { echo ~{gex_nhash_id}; cat ~{input_id}_library_metrics.csv; } > ~{input_id}_{gex_nhash_id}_library_metrics.csv
   >>>
 
   runtime {

--- a/tasks/skylab/StarAlign.wdl
+++ b/tasks/skylab/StarAlign.wdl
@@ -327,7 +327,8 @@ task STARsoloFastq {
         --soloBarcodeReadLength 0 \
         --soloCellReadStats Standard \
         ~{"--soloMultiMappers " + soloMultiMappers} \
-        --soloUMIfiltering MultiGeneUMI_CR
+        --soloUMIfiltering MultiGeneUMI_CR \
+        --soloCellFilter EmptyDrops_CR
       
     echo "UMI LEN " $UMILen
 
@@ -442,11 +443,12 @@ task MergeStarOutput {
     String? counting_mode
     
     String input_id
+    Int expected_cells = 3000
     File barcodes_single = barcodes[0]
     File features_single = features[0]
 
     #runtime values
-    String docker = "us.gcr.io/broad-gotc-prod/star-merge-npz:1.1"
+    String docker = "us.gcr.io/broad-gotc-prod/star-merge-npz:1.2"
     Int machine_mem_gb = 20
     Int cpu = 1
     Int disk = ceil(size(matrix, "Gi") * 2) + 10
@@ -491,7 +493,7 @@ task MergeStarOutput {
 
     # Running star for combined cell matrix
     # outputs will be called outputbarcodes.tsv. outputmatrix.mtx, and outputfeatures.tsv
-    STAR --runMode soloCellFiltering ./matrix ./output --soloCellFilter CellRanger2.2
+    STAR --runMode soloCellFiltering ./matrix ./output --soloCellFilter EmptyDrops_CR
     
     #list files
     echo "listing files"
@@ -567,7 +569,8 @@ task MergeStarOutput {
       ~{counting_mode} \
       ~{input_id} \
       outputbarcodes.tsv \
-      outputmatrix.mtx 
+      outputmatrix.mtx \
+      ~{expected_cells}
       tar -zcvf ~{input_id}.star_metrics.tar *.txt
     else
       echo "No text files found in the folder."

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -87,9 +87,7 @@ workflow TestMultiome {
         atac_whitelist = atac_whitelist,
         run_cellbender = run_cellbender,
         soloMultiMappers = soloMultiMappers,
-        nhash_id = nhash_id,
         nhash_id = nhash_id
-  
     }
 
     

--- a/verification/test-wdls/TestMultiome.wdl
+++ b/verification/test-wdls/TestMultiome.wdl
@@ -10,6 +10,7 @@ workflow TestMultiome {
 
     input {
       String input_id
+      String nhash_id
 
       # Optimus Inputs
       String counting_mode = "sn_rna"
@@ -85,7 +86,9 @@ workflow TestMultiome {
         chrom_sizes = chrom_sizes,
         atac_whitelist = atac_whitelist,
         run_cellbender = run_cellbender,
-        soloMultiMappers = soloMultiMappers
+        soloMultiMappers = soloMultiMappers,
+        nhash_id = nhash_id,
+        nhash_id = nhash_id
   
     }
 

--- a/verification/test-wdls/TestOptimus.wdl
+++ b/verification/test-wdls/TestOptimus.wdl
@@ -17,6 +17,7 @@ workflow TestOptimus {
     Array[File] r2_fastq
     Array[File]? i1_fastq
     String input_id
+    String gex_nhash_id
     String output_bam_basename = input_id
     String? input_name
     String? input_id_metadata_field
@@ -84,7 +85,8 @@ workflow TestOptimus {
       star_strand_mode           = star_strand_mode,
       count_exons                = count_exons,
       ignore_r1_read_length      = ignore_r1_read_length,
-      soloMultiMappers           = soloMultiMappers
+      soloMultiMappers           = soloMultiMappers,
+      gex_nhash_id               = gex_nhash_id
   }
 
   # Collect all of the pipeling output into single Array

--- a/verification/test-wdls/TestPairedTag.wdl
+++ b/verification/test-wdls/TestPairedTag.wdl
@@ -10,6 +10,7 @@ workflow TestPairedTag {
 
     input {
       String input_id
+      String nhash_id
 
       # Optimus Inputs
       String counting_mode = "sn_rna"
@@ -86,7 +87,8 @@ workflow TestPairedTag {
         adapter_seq_read3 = adapter_seq_read3,
         chrom_sizes = chrom_sizes,
         atac_whitelist = atac_whitelist,
-        soloMultiMappers = soloMultiMappers
+        soloMultiMappers = soloMultiMappers,
+        nhash_id = nhash_id
     }
 
     

--- a/website/docs/Pipelines/ATAC/README.md
+++ b/website/docs/Pipelines/ATAC/README.md
@@ -50,6 +50,7 @@ The following describes the inputs of the ATAC workflow. For more details on how
 | read2_fastq_gzipped | Fastq inputs (array of compressed read 2 FASTQ files containing cellular barcodes). |
 | read3_fastq_gzipped | Fastq inputs (array of compressed read 3 FASTQ files). |
 | input_id | Output prefix/base name for all intermediate files and pipeline outputs. |
+| atac_nhash_id | String that represents an optional library aliquot identifier. When used, it is echoed in the h5ad unstructured data. |
 | preindex | Boolean used for paired-tag data and not applicable to ATAC data types; default is set to false. | 
 | tar_bwa_reference | BWA reference (tar file containing reference fasta and corresponding files). |
 | num_threads_bwa | Optional integer defining the number of CPUs per node for the BWA-mem alignment task (default: 128). |

--- a/website/docs/Pipelines/ATAC/count-matrix-overview.md
+++ b/website/docs/Pipelines/ATAC/count-matrix-overview.md
@@ -18,6 +18,7 @@ The global attributes (unstuctured metadata) in the h5ad apply to the whole file
 | Attribute | Program | Details |
 | --- | --- | --- |
 | `reference_sequences` | [SnapATAC2](https://github.com/kaizhang/SnapATAC2) | Data frame containing the chromosome sizes for the genome build (i.e., hg38); created using the [`chrom_sizes` pipeline input](README.md). |
+| `NHashID` | N/A | A string that represents the NHashID if specified in the workflow |
 
 
 ## Table 2. Cell metrics

--- a/website/docs/Pipelines/Multiome_Pipeline/README.md
+++ b/website/docs/Pipelines/Multiome_Pipeline/README.md
@@ -55,6 +55,7 @@ Multiome can be deployed using [Cromwell](https://cromwell.readthedocs.io/en/sta
 | Input name | Description | Type |
 | --- | --- | --- |
 | input_id | Unique identifier describing the biological sample or replicate that corresponds with the FASTQ files; can be a human-readable name or UUID. | String |
+| nhash_id | Optional identifier for the library aliquot; when specified, the workflow will echo the ID in the ATAC and gene expression output h5ads (in the adata.uns section) and in the library-level metrics CSV. |
 | annotations_gtf | GTF file containing gene annotations used for GEX cell metric calculation and ATAC fragment metrics; must match the GTF used to build the STAR aligner. | File |
 | gex_r1_fastq | Array of read 1 FASTQ files representing a single GEX 10x library. | Array[File] |
 | gex_r2_fastq | Array of read 2 FASTQ files representing a single GEX 10x library.| Array[File] |
@@ -120,7 +121,7 @@ The Multiome workflow calls two WARP subworkflows, one external subworkflow (opt
 | multimappers_PropUnique_matrix | `UniqueAndMult-PropUnique.mtx` | Optional output produced when `soloMultiMappers` is "PropUnique"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information.|
 | gex_aligner_metrics | `<input_id>.star_metrics.tar` | Text file containing per barcode metrics (`CellReads.stats`) produced by the GEX pipeline STARsolo aligner. |
 | mtx_files | `<input_id>.mtx_files.tar` | TAR file with STARsolo matrix market files (barcodes.tsv, features.tsv, and matrix.mtx) | TAR |
-| library_metrics | `<input_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. |
+| library_metrics | `<input_id>_<nhash_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. |
 | cell_barcodes_csv | `<cell_csv>` | Optional output produced when `run_cellbender` is "true"; see CellBender [documentation](https://cellbender.readthedocs.io/en/latest/usage/index.html) and [GitHub repository](https://github.com/broadinstitute/CellBender/tree/master) for more information.|
 | checkpoint_file | `<ckpt_file>` | Optional output produced when `run_cellbender` is "true"; see CellBender [documentation](https://cellbender.readthedocs.io/en/latest/usage/index.html) and [GitHub repository](https://github.com/broadinstitute/CellBender/tree/master) for more information. |
 | h5_array | `<h5_array>` | Optional output produced when `run_cellbender` is "true"; see CellBender [documentation](https://cellbender.readthedocs.io/en/latest/usage/index.html) and [GitHub repository](https://github.com/broadinstitute/CellBender/tree/master) for more information. |

--- a/website/docs/Pipelines/Optimus_Pipeline/Library-metrics.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/Library-metrics.md
@@ -11,6 +11,7 @@ To produce the library-level metrics here, the [combined_mtx.py script](https://
 
 | Metric | Description |
 | ---| --- |
+| nhash_id | The first line of of the metrics CSV echos the NHash ID if specified in the workflow run |
 | number_of_reads | Total number of reads.|
 | sequencing_saturation | Proportion of unique molecular identifiers (UMIs) observed relative to the total number of possible UMIs. |
 | fraction_of_unique_reads_mapped_to_genome | Fraction of unique reads that map to the genome. |

--- a/website/docs/Pipelines/Optimus_Pipeline/Library-metrics.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/Library-metrics.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 5
+---
+
+# Optimus Library-level metrics
+
+The following table describes the library level metrics of the produced by the Optimus workflow. These are calcuated using custom python scripts available in the warp-tools repository. The Optimus workflow aligns files in shards to parallelize computationally intensive steps. This results in multiple matrix market files and shard-levl library metrics. 
+
+To produce the library-level metrics here, the [combined_mtx.py script](https://github.com/broadinstitute/warp-tools/blob/develop/3rd-party-tools/star-merge-npz/scripts/combined_mtx.py) combines all the shard-level matrix market files into one raw mtx file. Then, STARsolo is run to filter this matrix to only those barcodes that meet STARsolo's criteria of cells (using the Emptydrops_CR parameter). Lastly, the [combine_shard_metrics.py script](https://github.com/broadinstitute/warp-tools/blob/develop/3rd-party-tools/star-merge-npz/scripts/combine_shard_metrics.py) uses the filtered matrix and the all of the shard-level metrics files produced by STARsolo to calculate the metrics below. Each of the scripts are called from [MergeStarOutput task](https://github.com/broadinstitute/warp/blob/develop/tasks/skylab/StarAlign.wdl) of the Optimus workflow. 
+
+
+| Metric | Description |
+| ---| --- |
+| number_of_reads | Total number of reads.|
+| sequencing_saturation | Proportion of unique molecular identifiers (UMIs) observed relative to the total number of possible UMIs. |
+| fraction_of_unique_reads_mapped_to_genome | Fraction of unique reads that map to the genome. |
+| fraction_of_unique_and_multiple_reads_mapped_to_genome| Fraction of both unique and multiple reads that map to the genome. |
+| fraction_of_reads_with_Q30_bases_in_rna | Fraction of reads with base quality score ≥ Q30 in RNA sequences. |
+| fraction_of_reads_with_Q30_bases_in_cb_and_umi | Fraction of reads with base quality score ≥ Q30 in cell barcode (CB) and unique molecular identifier (UMI). |
+| fraction_of_reads_with_valid_barcodes | Fraction of reads with valid cell barcodes.                                                                   |
+| reads_mapped_antisense_to_gene | Number of reads mapped antisense to gene regions.  |
+| reads_mapped_confidently_exonic | Number of reads mapped confidently to exonic regions. |
+| reads_mapped_confidently_to_genome | Number of reads mapped confidently to the genome. |
+| reads_mapped_confidently_to_intronic_regions | Number of reads mapped confidently to intronic regions. |
+| reads_mapped_confidently_to_transcriptome | Number of reads mapped confidently to the transcriptome. |
+| estimated_cells | Estimated number of cells from STARsolo using the Emptydops_CR parameter. |
+| umis_in_cells | Total number of unique molecular identifiers (UMIs) in cells. |
+| mean_umi_per_cell | Average number of UMIs per cell. |
+| median_umi_per_cell | Median number of UMIs per cell. |
+| unique_reads_in_cells_mapped_to_gene | Number of unique reads in cells mapped to genes. |
+| fraction_of_unique_reads_in_cells  | Fraction of unique reads in cells. |
+| mean_reads_per_cell | Average number of reads per cell. |
+| median_reads_per_cell | Median number of reads per cell. |
+| mean_gene_per_cell | Average number of genes per cell. |
+| median_gene_per_cell  | Median number of genes per cell. |
+| total_genes_unique_detected | Total number of unique genes detected.  |
+| percent_target | Percentage of target cells. Calculated as: estimated_number_of_cells / barcoded_cell_sample_number_of_expected_cells |
+| percent_intronic_reads | Percentage of intronic reads. Calculated as: reads_mapped_confidently_to_intronic_regions / number_of_reads |
+| keeper_mean_reads_per_cell | Mean reads per cell for cells with >1500 genes or nuclei with >1000 genes. |
+| keeper_median_genes | Median genes per cell for cells with >1500 genes or nuclei with >1000 genes.  |
+| keeper_cells | Number of cells with >1500 genes or nuclei with >1000 genes.|
+| percent_keeper | Percentage of keeper cells. Calculated as: keeper_cells / estimated_cells |
+| percent_usable | Percentage of usable cells. Calculated as: keeper_cells / expected_cells |

--- a/website/docs/Pipelines/Optimus_Pipeline/Loom_schema.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/Loom_schema.md
@@ -32,6 +32,7 @@ The global attributes (unstuctured metadata) in the h5ad apply to the whole file
 | `input_id_metadata_field` | Optional string that describes, when applicable, the metadata field containing the `input_id`. |
 | `input_name_metadata_field` | Optional string that describes, when applicable, the metadata field containing the `input_name`. |
 | `pipeline_version` | String describing the version of the Optimus pipeline run on the data. |
+| `NHashID` | String that represents NHashID (an optional library aliquot identifier) if specified during the worfklow run. |
 
 ## Table 2. Cell metrics
 

--- a/website/docs/Pipelines/Optimus_Pipeline/README.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/README.md
@@ -89,6 +89,7 @@ The example configuration files also contain metadata for the reference files, d
 | read_struct | String describing the structure of reads; the workflow automatically selects the [10x Genomics](https://www.10xgenomics.com/) read structure that corresponds to the v2 or v3 chemistry based on the input `tenx_chemistry_version`. A custom read structure can also be provided if the input data was generated with a chemistry different from 10x Genomics v2 or v3. To use a custom read structure, set the input `force_no_check` to "true". | N/A |
 | tar_star_reference | TAR file containing a species-specific reference genome and GTF; it is generated using the [BuildIndices workflow](https://github.com/broadinstitute/warp/tree/master/pipelines/skylab/build_indices/BuildIndices.wdl). | N/A |
 | input_id | Unique identifier describing the biological sample or replicate that corresponds with the FASTQ files; can be a human-readable name or UUID. | N/A |
+| gex_nhash_id | Optional string to identify the library aliquot; will be echoed in the output h5ad file in the adata.uns and the library-level metrics CSV; default is null (`""`) | N/A |
 | input_name | Optional string that can be used to further identify the original biological sample. | N/A |
 | input_id_metadata_field | Optional string describing, when applicable, the metadata field containing the input_id. | N/A |
 | input_name_metadata_field | Optional string describing, when applicable, the metadata field containing the input_name. | N/A |
@@ -256,7 +257,7 @@ The following table lists the output files produced from the pipeline. For sampl
 | cell_metrics | `<input_id>.cell-metrics.csv.gz` | Matrix of metrics by cells. | Compressed CSV |
 | gene_metrics | `<input_id>.gene-metrics.csv.gz` |  Matrix of metrics by genes. | Compressed CSV |
 | aligner_metrics | `<input_id>.star_metrics.tar` | Tarred metrics files produced by the STARsolo aligner; contains align features, cell reads, summary, and UMI per cell metrics files. | TXT |
-| library_metrics | `<input_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. See the [Library-level metrics](./Library-metrics.md) for how metrics are calculated. | CSV |
+| library_metrics | `<input_id>_<gex_nash_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. See the [Library-level metrics](./Library-metrics.md) for how metrics are calculated. | CSV |
 | multimappers_EM_matrix | `UniqueAndMult-EM.mtx` | Optional output produced when `soloMultiMappers` is "EM"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |
 | multimappers_Uniform_matrix | `UniqueAndMult-Uniform.mtx` | Optional output produced when `soloMultiMappers` is "Uniform"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |
 | multimappers_Rescue_matrix | `UniqueAndMult-Rescue.mtx` | Optional output produced when `soloMultiMappers` is "Rescue"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |

--- a/website/docs/Pipelines/Optimus_Pipeline/README.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/README.md
@@ -102,6 +102,7 @@ The example configuration files also contain metadata for the reference files, d
 | ignore_r1_read_length | Boolean that overrides a check on the 10x chemistry. Default is set to false. If true, the workflow will not ensure that the 10x_chemistry_version input matches the chemistry in the read 1 FASTQ. | "true" or "false" (default) | 
 | emptydrops_lower | UMI threshold for emptyDrops detection; default is 100. | N/A |
 | count_exons | Boolean indicating if the workflow should calculate exon counts **when in single-nucleus (sn_rna) mode**. If true, this option will output an additional layer for the h5ad file. By default, it is set to "false". If the parameter is true and used with sc_rnamode, the workflow will return an error. | "true" or "false" (default) |
+| expected_cells | Optional integer input for the expected number of cells, which is used calculate library-level metrics. The default is set to 3,000 | 
 
 #### Pseudogene handling
 The example Optimus reference files are downloaded directly from GENCODE (see Quickstart table) and are not modified to remove pseudogenes. This is in contrast to the [references created for Cell Ranger](https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/release-notes/references#header) which remove pseudogenes and small RNAs.
@@ -255,7 +256,7 @@ The following table lists the output files produced from the pipeline. For sampl
 | cell_metrics | `<input_id>.cell-metrics.csv.gz` | Matrix of metrics by cells. | Compressed CSV |
 | gene_metrics | `<input_id>.gene-metrics.csv.gz` |  Matrix of metrics by genes. | Compressed CSV |
 | aligner_metrics | `<input_id>.star_metrics.tar` | Tarred metrics files produced by the STARsolo aligner; contains align features, cell reads, summary, and UMI per cell metrics files. | TXT |
-| library_metrics | `<input_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. | CSV |
+| library_metrics | `<input_id>_library_metrics.csv` | Optional CSV file containing all library-level metrics calculated with STARsolo for gene expression data. See the [Library-level metrics](./Library-metrics.md) for how metrics are calculated. | CSV |
 | multimappers_EM_matrix | `UniqueAndMult-EM.mtx` | Optional output produced when `soloMultiMappers` is "EM"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |
 | multimappers_Uniform_matrix | `UniqueAndMult-Uniform.mtx` | Optional output produced when `soloMultiMappers` is "Uniform"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |
 | multimappers_Rescue_matrix | `UniqueAndMult-Rescue.mtx` | Optional output produced when `soloMultiMappers` is "Rescue"; see STARsolo [documentation](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#multi-gene-reads) for more information. | MTX |


### PR DESCRIPTION
### Description
Adding NHash ID as input to BICAN workflows
----
This PR add optional nhash_id to Optimus, ATAC, Multiome, and Paired-tag workflows. It outputs the nhash_id to the h5ads in the adata.uns section and the gene expression library-level metrics (first line). It also names the library metrics CSV using the nhash_id.