### PR TITLE
Make ReblockGVCFs more robust to large inputs

### DIFF
--- a/pipelines/broad/arrays/single_sample/Arrays.changelog.md
+++ b/pipelines/broad/arrays/single_sample/Arrays.changelog.md
@@ -1,3 +1,8 @@
+# 2.6.26
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 2.6.25
 2024-07-09
 * Updated tasks GermlineVariantDiscovery.wdl and QC.wdl to allow multi-cloud dockers; this does not affect this pipeline.

--- a/pipelines/broad/arrays/single_sample/Arrays.wdl
+++ b/pipelines/broad/arrays/single_sample/Arrays.wdl
@@ -23,7 +23,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Arrays {
 
-  String pipeline_version = "2.6.25"
+  String pipeline_version = "2.6.26"
 
   input {
     String chip_well_barcode

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.changelog.md
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs
+
 # 2.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl
+++ b/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl
@@ -6,7 +6,7 @@ import "../../../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow ReblockGVCF {
 
-  String pipeline_version = "2.2.0"
+  String pipeline_version = "2.2.1"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 3.1.22
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 3.1.21
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl
@@ -45,7 +45,7 @@ import "../../../../../../tasks/broad/Utilities.wdl" as utils
 # WORKFLOW DEFINITION
 workflow ExomeGermlineSingleSample {
 
-  String pipeline_version = "3.1.21"
+  String pipeline_version = "3.1.22"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.19
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.0.18
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl
@@ -50,7 +50,7 @@ workflow UltimaGenomicsWholeGenomeGermline {
     filtering_model_no_gt_name: "String describing the optional filtering model; default set to rf_model_ignore_gt_incl_hpol_runs"
   }
 
-  String pipeline_version = "1.0.18"
+  String pipeline_version = "1.0.19"
 
 
   References references = alignment_references.references

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.changelog.md
@@ -1,3 +1,8 @@
+# 3.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 3.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl
@@ -40,7 +40,7 @@ import "../../../../../../structs/dna_seq/DNASeqStructs.wdl"
 workflow WholeGenomeGermlineSingleSample {
 
 
-  String pipeline_version = "3.2.0"
+  String pipeline_version = "3.2.1"
 
 
   input {

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs
+
 # 2.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
+++ b/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl
@@ -9,7 +9,7 @@ import "../../../../../tasks/broad/DragenTasks.wdl" as DragenTasks
 workflow VariantCalling {
 
 
-  String pipeline_version = "2.2.0"
+  String pipeline_version = "2.2.1"
 
 
   input {
@@ -43,7 +43,7 @@ workflow VariantCalling {
   String gatk_docker_gcp = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
   String gatk_docker_azure = "dsppipelinedev.azurecr.io/gatk_reduced_layers:1.0.0"
   String gatk_docker = if cloud_provider == "gcp" then gatk_docker_gcp else gatk_docker_azure
-  
+
   String gatk_1_3_docker_gcp = "us.gcr.io/broad-gotc-prod/gatk:1.3.0-4.2.6.1-1649964384"
   String gatk_1_3_docker_azure = "us.gcr.io/broad-gotc-prod/gatk:1.3.0-4.2.6.1-1649964384"
   String gatk_1_3_docker = if cloud_provider == "gcp" then gatk_1_3_docker_gcp else gatk_1_3_docker_azure
@@ -55,7 +55,7 @@ workflow VariantCalling {
   String picard_cloud_docker_gcp = "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
   String picard_cloud_docker_azure = "dsppipelinedev.azurecr.io/picard-cloud:2.26.10"
   String picard_cloud_docker = if cloud_provider == "gcp" then picard_cloud_docker_gcp else picard_cloud_docker_azure
-  
+
 
   # make sure either gcp or azr is supplied as cloud_provider input
   if ((cloud_provider != "gcp") && (cloud_provider != "azure")) {

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.changelog.md
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.19
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.0.18
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
+++ b/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl
@@ -43,7 +43,7 @@ workflow UltimaGenomicsWholeGenomeCramOnly {
     save_bam_file: "If true, then save intermeidate ouputs used by germline pipeline (such as the output BAM) otherwise they won't be kept as outputs."
   }
 
-  String pipeline_version = "1.0.18"
+  String pipeline_version = "1.0.19"
 
   References references = alignment_references.references
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.changelog.md
@@ -1,3 +1,8 @@
+# 1.12.20
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.12.19
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
+++ b/pipelines/broad/genotyping/illumina/IlluminaGenotypingArray.wdl
@@ -21,7 +21,7 @@ import "../../../../tasks/broad/Qc.wdl" as Qc
 
 workflow IlluminaGenotypingArray {
 
-  String pipeline_version = "1.12.19"
+  String pipeline_version = "1.12.20"
 
   input {
     String sample_alias

--- a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.changelog.md
+++ b/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.10
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.1.9
 2024-07-09
 

--- a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl
+++ b/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl
@@ -9,7 +9,7 @@ workflow BroadInternalArrays {
         description: "Push outputs of Arrays.wdl to TDR dataset table ArraysOutputsTable."
     }
 
-    String pipeline_version = "1.1.9"
+    String pipeline_version = "1.1.10"
 
     input {
         # inputs to wrapper task

--- a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.changelog.md
+++ b/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.20
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.0.19
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
+++ b/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
@@ -6,7 +6,7 @@ import "../../../../../../../pipelines/broad/qc/CheckFingerprint.wdl" as FP
 
 workflow BroadInternalUltimaGenomics {
 
-  String pipeline_version = "1.0.19"
+  String pipeline_version = "1.0.20"
 
   input {
   

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.32
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.0.31
 2024-07-09
 * Updated tasks GermlineVariantDiscovery.wdl and QC.wdl to allow multi-cloud dockers; this does not affect this pipeline

--- a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -7,7 +7,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow BroadInternalRNAWithUMIs {
 
-  String pipeline_version = "1.0.31"
+  String pipeline_version = "1.0.32"
 
   input {
     # input needs to be either "hg19" or "hg38"

--- a/pipelines/broad/qc/CheckFingerprint.changelog.md
+++ b/pipelines/broad/qc/CheckFingerprint.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.19
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 1.0.18
 2024-07-00 (Date of Last Commit)
 

--- a/pipelines/broad/qc/CheckFingerprint.wdl
+++ b/pipelines/broad/qc/CheckFingerprint.wdl
@@ -24,7 +24,7 @@ import "../../../tasks/broad/Qc.wdl" as Qc
 
 workflow CheckFingerprint {
 
-  String pipeline_version = "1.0.18"
+  String pipeline_version = "1.0.19"
 
   input {
     File? input_vcf

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 3.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl
@@ -7,7 +7,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 workflow ExomeReprocessing {
 
 
-  String pipeline_version = "3.2.0"
+  String pipeline_version = "3.2.1"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 3.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl
@@ -5,7 +5,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalExomeReprocessing {
 
-  String pipeline_version = "3.2.0"
+  String pipeline_version = "3.2.1"
 
 
   input {

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 2.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../../tasks/broad/CopyFilesFromCloudToCloud.wdl" as Copy
 workflow ExternalWholeGenomeReprocessing {
 
 
-  String pipeline_version = "2.2.0"
+  String pipeline_version = "2.2.1"
 
   input {
     File? input_cram

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.changelog.md
@@ -1,3 +1,8 @@
+# 3.2.1
+2024-06-12 (Date of Last Commit)
+
+* ValidateVcfs is more robust to larger inputs; this does not affect this pipeline
+
 # 3.2.0
 2024-07-09 (Date of Last Commit)
 

--- a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
+++ b/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl
@@ -6,7 +6,7 @@ import "../../../../structs/dna_seq/DNASeqStructs.wdl"
 
 workflow WholeGenomeReprocessing {
 
-  String pipeline_version = "3.2.0"
+  String pipeline_version = "3.2.1"
 
   input {
     File? input_cram

--- a/tasks/broad/Qc.wdl
+++ b/tasks/broad/Qc.wdl
@@ -641,7 +641,8 @@ task ValidateVCF {
       # We can't always assume the index was located with the vcf, so make a link so that the paths look the same
       ln -s ~{calling_interval_list} ~{calling_interval_list_basename}
       ln -s ~{calling_interval_list_index} ~{calling_interval_list_index_basename}
-      gatk VcfToIntervalList -I ~{calling_interval_list_basename} -O intervals_from_gvcf.interval_list
+      gatk --java-options "-Xms~{command_mem_mb}m -Xmx~{command_mem_mb}m" \
+        VcfToIntervalList -I ~{calling_interval_list_basename} -O intervals_from_gvcf.interval_list
       INTERVALS="intervals_from_gvcf.interval_list"
     else
       INTERVALS="~{calling_interval_list}"

--- a/tasks/broad/Qc.wdl
+++ b/tasks/broad/Qc.wdl
@@ -632,7 +632,7 @@ task ValidateVCF {
 
   Int command_mem_mb = machine_mem_mb - 2000
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
-  Int disk_size = ceil(size(input_vcf, "GiB") + size(dbsnp_vcf, "GiB") + ref_size) + 20
+  Int disk_size = ceil(size(input_vcf, "GiB") + size(calling_interval_list, "GiB") + size(dbsnp_vcf, "GiB") + ref_size) + 20
 
   command {
     set -e


### PR DESCRIPTION
When running ReblockGVCFs with large input occasionally the VM was running out of disk space in the process of converting the input GVCF into an interval list for validation. This fixes that by including the interval list in the disk_size calculation.

Additionally a separate very large sample was running out of memory on the interval list generation step in the validation task. This allows the user to increase the memory of the machine and actually use it both in Validating and converting the GVCF to interval list.

In the next point release of GATK there will be a fix that's already been merged into htsjdk that will fix the requirement for a large amount of memory for the conversion, but for now giving the command more memory will do the trick.