### PR TITLE
TSPS-269 Speed up CountVariantsInChunksBeagle by using bedtools

### DIFF
--- a/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
@@ -120,7 +120,7 @@ task CreateRefPanelBedFiles {
   input {
     File ref_panel_interval_list
 
-    Int disk_size_gb = ceil(2*size(ref_panel_interval_list, "GiB")) + 50 # not sure how big the disk size needs to be since we aren't downloading the entire VCF here
+    Int disk_size_gb = ceil(2*size(ref_panel_interval_list, "GiB")) + 50
     Int cpu = 1
     Int memory_mb = 8000
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"

--- a/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
@@ -11,6 +11,7 @@ workflow CreateImputationRefPanelBeagle {
 
     Boolean make_brefs = true
     Boolean make_interval_lists = true
+    Boolean make_bed_files = true
   }
 
   scatter (idx in range(length(ref_vcf))) {
@@ -38,7 +39,7 @@ workflow CreateImputationRefPanelBeagle {
     if (make_bed_files) {
       call CreateRefPanelBedFiles {
         input:
-          ref_panel_interval_list = CreateRefPanelIntervalLists.interval_list[idx]
+          ref_panel_interval_list = CreateRefPanelIntervalLists.interval_list
       }
     }
   }

--- a/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
@@ -34,10 +34,10 @@ workflow CreateImputationRefPanelBeagle {
           ref_panel_vcf_index = ref_vcf_index[idx],
           output_basename = custom_basename_with_chr
       }
-      File interval_list = select_first([CreateRefPanelIntervalLists.interval_list])
     }
 
     if (make_bed_files) {
+      File interval_list = select_first([CreateRefPanelIntervalLists.interval_list])
       call CreateRefPanelBedFiles {
         input:
           ref_panel_interval_list = interval_list

--- a/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
@@ -34,12 +34,13 @@ workflow CreateImputationRefPanelBeagle {
           ref_panel_vcf_index = ref_vcf_index[idx],
           output_basename = custom_basename_with_chr
       }
+      File interval_list = select_first([CreateRefPanelIntervalLists.interval_list])
     }
 
     if (make_bed_files) {
       call CreateRefPanelBedFiles {
         input:
-          ref_panel_interval_list = CreateRefPanelIntervalLists.interval_list
+          ref_panel_interval_list = interval_list
       }
     }
   }

--- a/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/CreateImputationRefPanelBeagle.wdl
@@ -26,19 +26,27 @@ workflow CreateImputationRefPanelBeagle {
         }
       }
         
-      if (make_interval_lists) {
-        call CreateRefPanelIntervalLists {
-          input:
-            ref_panel_vcf = ref_vcf[idx],
-            ref_panel_vcf_index = ref_vcf_index[idx],
-            output_basename = custom_basename_with_chr,
-        }
+    if (make_interval_lists || make_bed_files) {
+      call CreateRefPanelIntervalLists {
+        input:
+          ref_panel_vcf = ref_vcf[idx],
+          ref_panel_vcf_index = ref_vcf_index[idx],
+          output_basename = custom_basename_with_chr
       }
+    }
+
+    if (make_bed_files) {
+      call CreateRefPanelBedFiles {
+        input:
+          ref_panel_interval_list = CreateRefPanelIntervalLists.interval_list[idx]
+      }
+    }
   }
 
   output {
     Array[File?] bref3s = BuildBref3.out_bref3
     Array[File?] interval_lists = CreateRefPanelIntervalLists.interval_list
+    Array[File?] bed_files = CreateRefPanelBedFiles.bed_file
   }
 }
 
@@ -96,6 +104,41 @@ task CreateRefPanelIntervalLists {
 
   output {
     File interval_list = "~{basename}.interval_list"
+  }
+
+  runtime {
+    docker: gatk_docker
+    disks: "local-disk ${disk_size_gb} HDD"
+    memory: "${memory_mb} MiB"
+    cpu: cpu
+  }
+}
+
+task CreateRefPanelBedFiles {
+  input {
+    File ref_panel_interval_list
+
+    Int disk_size_gb = ceil(2*size(ref_panel_interval_list, "GiB")) + 50 # not sure how big the disk size needs to be since we aren't downloading the entire VCF here
+    Int cpu = 1
+    Int memory_mb = 8000
+    String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+  }
+
+  Int command_mem = memory_mb - 1000
+  Int max_heap = memory_mb - 500
+
+  String basename = basename(ref_panel_interval_list, ".interval_list")
+
+
+  command {
+    gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
+    IntervalListToBed \
+    -I ~{ref_panel_interval_list} \
+    -O ~{basename}.bed
+  }
+
+  output {
+    File bed_file = "~{basename}.bed"
   }
 
   runtime {

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl
@@ -20,7 +20,7 @@ workflow ImputationBeagle {
         String output_basename # the basename for intermediate and output files
 
         # file extensions used to find reference panel files
-        String interval_list_suffix = ".interval_list"
+        String bed_suffix = ".bed"
         String bref3_suffix = ".bref3"
 
         String gatk_docker = "terrapublic.azurecr.io/gatk:4.5-squashed" # "broadinstitute/gatk-nightly:2024-06-06-4.5.0.0-36-g2a420e483-NIGHTLY-SNAPSHOT"
@@ -46,7 +46,7 @@ workflow ImputationBeagle {
         String genetic_map_filename = genetic_maps_path + "plink." + contigs[contig_index] + ".GRCh38.withchr.map"
 
         ReferencePanelContig referencePanelContig = {
-                                                        "interval_list": reference_basename + interval_list_suffix,
+                                                        "bed": reference_basename + bed_suffix,
                                                         "bref3": reference_basename  + bref3_suffix,
                                                         "contig": contigs[contig_index],
                                                         "genetic_map": genetic_map_filename
@@ -79,7 +79,7 @@ workflow ImputationBeagle {
                 input:
                     vcf = PreChunkVcf.generate_chunk_vcfs[i],
                     vcf_index = PreChunkVcf.generate_chunk_vcf_indices[i],
-                    panel_interval_list = referencePanelContig.interval_list,
+                    panel_bed_file = referencePanelContig.bed,
                     gatk_docker = gatk_docker
             }
 
@@ -241,7 +241,7 @@ workflow ImputationBeagle {
 }
 
 struct ReferencePanelContig {
-    File interval_list
+    File bed
     File bref3
     String contig
     File genetic_map

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -319,7 +319,7 @@ task CountVariantsInChunksBeagle {
     ln -sf ~{vcf_index} input.vcf.gz.tbi
 
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V input.vcf.gz | tail -n 1 > var_in_original
-    bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_in_reference
+    bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_also_in_reference
   >>>
 
   output {

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -306,7 +306,7 @@ task CountVariantsInChunksBeagle {
 
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
     Int cpu = 1
-    Int memory_mb = 4000
+    Int memory_mb = 8000
     Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_bed_file], "GiB")) + 20
   }
   Int command_mem = memory_mb - 1000
@@ -315,7 +315,10 @@ task CountVariantsInChunksBeagle {
   command <<<
     set -e -o pipefail
 
-    echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf}  | sed 's/Tool returned://') > var_in_original
+    ln -sf ~{vcf} input.vcf.gz
+    ln -sf ~{vcf_index} input.vcf.gz.tbi
+
+    gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V input.vcf.gz | tail -n 1 > var_in_original
     bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_in_reference
   >>>
 

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -146,12 +146,13 @@ task CountVariantsInChunks {
   input {
     File vcf
     File vcf_index
-    File panel_bed_file
+    File panel_vcf
+    File panel_vcf_index
 
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
     Int cpu = 1
     Int memory_mb = 4000
-    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_bed_file], "GiB")) + 20
+    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_vcf, panel_vcf_index], "GiB")) + 20
   }
   Int command_mem = memory_mb - 1000
   Int max_heap = memory_mb - 500
@@ -160,7 +161,7 @@ task CountVariantsInChunks {
     set -e -o pipefail
 
     echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf}  | sed 's/Tool returned://') > var_in_original
-    bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_in_reference
+    echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf} -L ~{panel_vcf} | sed 's/Tool returned://') > var_in_reference
   >>>
   output {
     Int var_in_original = read_int("var_in_original")
@@ -301,12 +302,12 @@ task CountVariantsInChunksBeagle {
   input {
     File vcf
     File vcf_index
-    File panel_interval_list
+    File panel_bed_file
 
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
     Int cpu = 1
-    Int memory_mb = 8000
-    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_interval_list], "GiB")) + 20
+    Int memory_mb = 4000
+    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_bed_file], "GiB")) + 20
   }
   Int command_mem = memory_mb - 1000
   Int max_heap = memory_mb - 500
@@ -314,12 +315,10 @@ task CountVariantsInChunksBeagle {
   command <<<
     set -e -o pipefail
 
-    ln -sf ~{vcf} input.vcf.gz
-    ln -sf ~{vcf_index} input.vcf.gz.tbi
-
-    gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V input.vcf.gz | tail -n 1 > var_in_original
-    gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V input.vcf.gz -L ~{panel_interval_list} | tail -n 1 > var_also_in_reference
+    echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf}  | sed 's/Tool returned://') > var_in_original
+    bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_in_reference
   >>>
+
   output {
     Int var_in_original = read_int("var_in_original")
     Int var_also_in_reference = read_int("var_also_in_reference")

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -146,13 +146,12 @@ task CountVariantsInChunks {
   input {
     File vcf
     File vcf_index
-    File panel_vcf
-    File panel_vcf_index
+    File panel_bed_file
 
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
     Int cpu = 1
     Int memory_mb = 4000
-    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_vcf, panel_vcf_index], "GiB")) + 20
+    Int disk_size_gb = 2 * ceil(size([vcf, vcf_index, panel_bed_file], "GiB")) + 20
   }
   Int command_mem = memory_mb - 1000
   Int max_heap = memory_mb - 500
@@ -161,7 +160,7 @@ task CountVariantsInChunks {
     set -e -o pipefail
 
     echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf}  | sed 's/Tool returned://') > var_in_original
-    echo $(gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" CountVariants -V ~{vcf} -L ~{panel_vcf}  | sed 's/Tool returned://') > var_in_reference
+    bedtools intersect -a ~{vcf} -b ~{panel_bed_file} | wc -l > var_in_reference
   >>>
   output {
     Int var_in_original = read_int("var_in_original")


### PR DESCRIPTION
### Description

Stats for this task before and after the change:

1000 sample input, 1000G ref panel:
- before - using interval lists: 
  - chr1, shard 0 var_in_original=6917, var_also_in_reference=6447
  - avg task duration 1:04:14 (n=126)
  - 48 of 74 total retries (65%)
- after - using bed files:
  - chr1, shard 0 var_in_original=6917, var_also_in_reference=6447 (identical as expected)
  - avg task duration 0:06:36 (n=126) - likely lower than 42 sample input because this input has 66% fewer sites
  - 6 of 31 total retries (19%)

This PR also includes an update to the Ref Panel generation wdl to include creating the ref panel bed files used in the new task.


Also tested that the QC check for overlapping sites between input and reference still works: https://app.terra.bio/#workspaces/morgan-fieldeng/Imputation_pipeline_testing/job_history/d116884a-d918-44d1-900e-b91691a2b3b1

old branch: 500 sample input, 1000G ref panel. shard 0 / ... / CountVariantsInChunksBeagle / shard 0
var_in_original: 7574
var_also_in_reference: 7076

this branch: 500 sample input, sim 10k ref panel. shard 0 / .../ CountVariantsInChunksBeagle / shard 0
var_in_original: 7574
var_also_in_reference: 426

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
