### PR TITLE
TSPS-293: Fix up streaming imputation beagle

### DIFF
--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -74,7 +74,7 @@ workflow ImputationBeagle {
       # generate the chunked vcf file that will be used for imputation, including overlaps
       call tasks.GenerateChunk {
         input:
-          vcf = CreateVcfIndex.vcf,
+          vcf = multi_sample_vcf,
           vcf_index = CreateVcfIndex.vcf_index,
           start = startWithOverlaps,
           end = endWithOverlaps,
@@ -100,7 +100,7 @@ workflow ImputationBeagle {
       # create chunk without overlaps to get sites to impute
       call tasks.SubsetVcfToRegion {
         input:
-          vcf = CreateVcfIndex.vcf,
+          vcf = multi_sample_vcf,
           vcf_index = CreateVcfIndex.vcf_index,
           output_basename = "input_samples_subset_to_chunk",
           contig = referencePanelContig.contig,

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -36,7 +36,7 @@ workflow ImputationBeagle {
 
   call tasks.CreateVcfIndex {
     input:
-      vcf = multi_sample_vcf,
+      vcf_input = multi_sample_vcf,
       gatk_docker = gatk_docker
   }
 

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -74,7 +74,7 @@ workflow ImputationBeagle {
       # generate the chunked vcf file that will be used for imputation, including overlaps
       call tasks.GenerateChunk {
         input:
-          vcf = multi_sample_vcf,
+          vcf = CreateVcfIndex.vcf,
           vcf_index = CreateVcfIndex.vcf_index,
           start = startWithOverlaps,
           end = endWithOverlaps,
@@ -100,7 +100,7 @@ workflow ImputationBeagle {
       # create chunk without overlaps to get sites to impute
       call tasks.SubsetVcfToRegion {
         input:
-          vcf = multi_sample_vcf,
+          vcf = CreateVcfIndex.vcf,
           vcf_index = CreateVcfIndex.vcf_index,
           output_basename = "input_samples_subset_to_chunk",
           contig = referencePanelContig.contig,

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -14,22 +14,20 @@ workflow ImputationBeagle {
     File multi_sample_vcf
     File multi_sample_vcf_index
 
-    Boolean perform_extra_qc_steps = false # these are optional additional extra QC steps from Amit's group that should only be
-    # run for large sample sets, especially a diverse set of samples (it's further limiting called at sites to 95% and by HWE)
-    Float optional_qc_max_missing = 0.05
-    Float optional_qc_hwe = 0.000001
     File ref_dict # for reheadering / adding contig lengths in the header of the ouptut VCF, and calculating contig lengths
     Array[String] contigs
-    String reference_panel_path # path to the bucket where the reference panel files are stored for all contigs
+    String reference_panel_path_prefix # path + file prefix to the bucket where the reference panel files are stored for all contigs
     String genetic_maps_path # path to the bucket where genetic maps are stored for all contigs
-    String output_callset_name # the output callset name
-    Boolean split_output_to_single_sample = false
-    
-    Int chunks_fail_threshold = 1 # require fewer than this many chunks to fail in order to pass
+    String output_basename # the basename for intermediate and output files
 
     # file extensions used to find reference panel files
-    String interval_list_suffix = ".interval_list"
+    String bed_suffix = ".bed"
     String bref3_suffix = ".bref3"
+
+    String gatk_docker = "broadinstitute/gatk-nightly:2024-06-06-4.5.0.0-36-g2a420e483-NIGHTLY-SNAPSHOT"
+    String ubuntu_docker = "ubuntu:20.04"
+
+    Int? error_count_override
   }
 
   call tasks.CountSamples {
@@ -41,32 +39,34 @@ workflow ImputationBeagle {
 
   scatter (contig in contigs) {
     # these are specific to hg38 - contig is format 'chr1'
-    String reference_filename = reference_panel_path + "hgdp.tgp.gwaspy.merged." + contig + ".merged.AN_added.bcf.ac2"
+    String reference_basename = reference_panel_path_prefix + "." + contig
     String genetic_map_filename = genetic_maps_path + "plink." + contig + ".GRCh38.withchr.map"
 
     ReferencePanelContig referencePanelContig = {
-      "interval_list": reference_filename + interval_list_suffix,
-      "bref3": reference_filename + bref3_suffix,
-      "contig": contig,
-      "genetic_map": genetic_map_filename
-    }
+                                                  "bed": reference_basename + bed_suffix,
+                                                  "bref3": reference_basename  + bref3_suffix,
+                                                  "contig": contig,
+                                                  "genetic_map": genetic_map_filename
+                                                }
+
 
     call tasks.CalculateChromosomeLength {
       input:
         ref_dict = ref_dict,
-        chrom = referencePanelContig.contig
+        chrom = referencePanelContig.contig,
+        ubuntu_docker = ubuntu_docker
     }
 
     Int num_chunks = ceil(CalculateChromosomeLength.chrom_length / chunkLengthFloat)
 
     scatter (i in range(num_chunks)) {
-      String chunk_contig = referencePanelContig.contig
       Int start = (i * chunkLength) + 1
       Int startWithOverlaps = if (start - chunkOverlaps < 1) then 1 else start - chunkOverlaps
       Int end = if (CalculateChromosomeLength.chrom_length < ((i + 1) * chunkLength)) then CalculateChromosomeLength.chrom_length else ((i + 1) * chunkLength)
       Int endWithOverlaps = if (CalculateChromosomeLength.chrom_length < end + chunkOverlaps) then CalculateChromosomeLength.chrom_length else end + chunkOverlaps
       String chunk_basename = referencePanelContig.contig + "_chunk_" + i
 
+      # generate the chunked vcf file that will be used for imputation, including overlaps
       call tasks.GenerateChunk {
         input:
           vcf = multi_sample_vcf,
@@ -74,25 +74,16 @@ workflow ImputationBeagle {
           start = startWithOverlaps,
           end = endWithOverlaps,
           chrom = referencePanelContig.contig,
-          basename = chunk_basename
-      }
-
-      if (perform_extra_qc_steps) {
-        call tasks.OptionalQCSites {
-          input:
-            input_vcf = GenerateChunk.output_vcf,
-            input_vcf_index = GenerateChunk.output_vcf_index,
-            output_vcf_basename = chunk_basename,
-            optional_qc_max_missing = optional_qc_max_missing,
-            optional_qc_hwe = optional_qc_hwe
-        }
+          basename = chunk_basename,
+          gatk_docker = gatk_docker
       }
 
       call tasks.CountVariantsInChunksBeagle {
         input:
-          vcf = select_first([OptionalQCSites.output_vcf,  GenerateChunk.output_vcf]),
-          vcf_index = select_first([OptionalQCSites.output_vcf_index, GenerateChunk.output_vcf_index]),
-          panel_interval_list = referencePanelContig.interval_list
+          vcf = GenerateChunk.output_vcf,
+          vcf_index = GenerateChunk.output_vcf_index,
+          panel_bed_file = referencePanelContig.bed,
+          gatk_docker = gatk_docker
       }
 
       call tasks.CheckChunksBeagle {
@@ -101,6 +92,7 @@ workflow ImputationBeagle {
           var_also_in_reference = CountVariantsInChunksBeagle.var_also_in_reference
       }
 
+      # create chunk without overlaps to get sites to impute
       call tasks.SubsetVcfToRegion {
         input:
           vcf = multi_sample_vcf,
@@ -108,7 +100,8 @@ workflow ImputationBeagle {
           output_basename = "input_samples_subset_to_chunk",
           contig = referencePanelContig.contig,
           start = start,
-          end = end
+          end = end,
+          gatk_docker = gatk_docker
       }
 
       call tasks.SetIDs as SetIdsVcfToImpute {
@@ -116,71 +109,107 @@ workflow ImputationBeagle {
           vcf = SubsetVcfToRegion.output_vcf,
           output_basename = "input_samples_with_variant_ids"
       }
+    }
+
+    call tasks.StoreChunksInfo as StoreContigLevelChunksInfo {
+      input:
+        chroms = contigs,
+        starts = start,
+        ends = end,
+        vars_in_array = CountVariantsInChunksBeagle.var_in_original,
+        vars_in_panel = CountVariantsInChunksBeagle.var_also_in_reference,
+        valids = CheckChunksBeagle.valid,
+        basename = output_basename
+    }
+
+    # if any chunk for any chromosome fail CheckChunks, then we will not impute run any task in the next scatter,
+    # namely phasing and imputing which would be the most costly to throw away
+    Int n_failed_chunks_int = select_first([error_count_override, read_int(StoreContigLevelChunksInfo.n_failed_chunks)])
+    call tasks.ErrorWithMessageIfErrorCountNotZero as FailQCNChunks {
+      input:
+        errorCount = n_failed_chunks_int,
+        message = "contig " + referencePanelContig.contig + " had " + n_failed_chunks_int + " failing chunks"
+    }
+
+    Array[File] chunkedVcfsWithOverlapsForImputation = GenerateChunk.output_vcf
+    Array[File] chunkedVcfsWithoutOverlapsForSiteIds = SetIdsVcfToImpute.output_vcf
+    Array[File] chunkedVcfIndexesWithoutOverlapsForSiteIds = SetIdsVcfToImpute.output_vcf_index
+
+    scatter (i in range(num_chunks)) {
+      String chunk_basename_imputed = referencePanelContig.contig + "_chunk_" + i + "_imputed"
+      
+      # these are copies from the first scatter, but need to have a different variable name
+      Int start2 = (i * chunkLength) + 1
+      Int end2 = if (CalculateChromosomeLength.chrom_length < ((i + 1) * chunkLength)) then CalculateChromosomeLength.chrom_length else ((i + 1) * chunkLength)
 
       call tasks.ExtractIDs as ExtractIdsVcfToImpute {
         input:
-          vcf = SetIdsVcfToImpute.output_vcf,
+          vcf = chunkedVcfsWithoutOverlapsForSiteIds[i],
+          output_basename = "imputed_sites",
+          for_dependency = FailQCNChunks.done # these shenanigans can be replaced with `after` in wdl 1.1
+      }
+
+      call tasks.PhaseAndImputeBeagle {
+        input:
+          dataset_vcf = chunkedVcfsWithOverlapsForImputation[i],
+          ref_panel_bref3 = referencePanelContig.bref3,
+          chrom = referencePanelContig.contig,
+          basename = chunk_basename_imputed,
+          genetic_map_file = referencePanelContig.genetic_map,
+          start = start2,
+          end = end2
+      }
+
+      call tasks.UpdateHeader {
+        input:
+          vcf = PhaseAndImputeBeagle.vcf,
+          vcf_index = PhaseAndImputeBeagle.vcf_index,
+          ref_dict = ref_dict,
+          basename = chunk_basename_imputed,
+          gatk_docker = gatk_docker
+      }
+
+      call tasks.SeparateMultiallelics {
+        input:
+          original_vcf = UpdateHeader.output_vcf,
+          original_vcf_index = UpdateHeader.output_vcf_index,
+          output_basename = chunk_basename_imputed
+      }
+
+      call tasks.RemoveSymbolicAlleles {
+        input:
+          original_vcf = SeparateMultiallelics.output_vcf,
+          original_vcf_index = SeparateMultiallelics.output_vcf_index,
+          output_basename = chunk_basename_imputed,
+          gatk_docker = gatk_docker
+      }
+
+      call tasks.SetIDs {
+        input:
+          vcf = RemoveSymbolicAlleles.output_vcf,
+          output_basename = chunk_basename_imputed
+      }
+
+      call tasks.ExtractIDs {
+        input:
+          vcf = SetIDs.output_vcf,
           output_basename = "imputed_sites"
       }
-
-      if (CheckChunksBeagle.valid) {
-        call tasks.PhaseAndImputeBeagle {
-          input:
-            dataset_vcf = select_first([OptionalQCSites.output_vcf,  GenerateChunk.output_vcf]),
-            ref_panel_bref3 = referencePanelContig.bref3,
-            chrom = referencePanelContig.contig,
-            basename = chunk_basename,
-            genetic_map_file = referencePanelContig.genetic_map,
-            start = start,
-            end = end
-        }
-
-        call tasks.UpdateHeader {
-          input:
-            vcf = PhaseAndImputeBeagle.vcf,
-            vcf_index = PhaseAndImputeBeagle.vcf_index,
-            ref_dict = ref_dict,
-            basename = chunk_basename + "_imputed"
-        }
-
-        call tasks.SeparateMultiallelics {
-          input:
-            original_vcf = UpdateHeader.output_vcf,
-            original_vcf_index = UpdateHeader.output_vcf_index,
-            output_basename = chunk_basename + "_imputed"
-        }
-
-        call tasks.RemoveSymbolicAlleles {
-          input:
-            original_vcf = SeparateMultiallelics.output_vcf,
-            original_vcf_index = SeparateMultiallelics.output_vcf_index,
-            output_basename = chunk_basename + "_imputed"
-        }
-
-        call tasks.SetIDs {
-          input:
-            vcf = RemoveSymbolicAlleles.output_vcf,
-            output_basename = chunk_basename + "_imputed"
-        }
-
-        call tasks.ExtractIDs {
-          input:
-            vcf = SetIDs.output_vcf,
-            output_basename = "imputed_sites"
-        }
-      }
+      
       call tasks.FindSitesUniqueToFileTwoOnly {
         input:
           file1 = select_first([ExtractIDs.ids, write_lines([])]),
-          file2 = ExtractIdsVcfToImpute.ids
+          file2 = ExtractIdsVcfToImpute.ids,
+          ubuntu_docker = ubuntu_docker
       }
 
       call tasks.SelectVariantsByIds {
         input:
-          vcf = SetIdsVcfToImpute.output_vcf,
-          vcf_index = SetIdsVcfToImpute.output_vcf_index,
+          vcf = chunkedVcfsWithoutOverlapsForSiteIds[i],
+          vcf_index = chunkedVcfIndexesWithoutOverlapsForSiteIds[i],
           ids = FindSitesUniqueToFileTwoOnly.missing_sites,
-          basename = "imputed_sites_to_recover"
+          basename = "imputed_sites_to_recover",
+          gatk_docker = gatk_docker
       }
 
       call tasks.RemoveAnnotations {
@@ -192,7 +221,8 @@ workflow ImputationBeagle {
       call tasks.InterleaveVariants {
         input:
           vcfs = select_all([RemoveAnnotations.output_vcf, SetIDs.output_vcf]),
-          basename = output_callset_name
+          basename = output_basename,
+          gatk_docker = gatk_docker
       }
     }
 
@@ -202,45 +232,25 @@ workflow ImputationBeagle {
   call tasks.GatherVcfs {
     input:
       input_vcfs = flatten(chromosome_vcfs),
-      output_vcf_basename = output_callset_name + ".imputed"
+      output_vcf_basename = output_basename + ".imputed",
+      gatk_docker = gatk_docker
   }
 
   call tasks.StoreChunksInfo {
     input:
-      chroms = flatten(chunk_contig),
+      chroms = contigs,
       starts = flatten(start),
       ends = flatten(end),
       vars_in_array = flatten(CountVariantsInChunksBeagle.var_in_original),
       vars_in_panel = flatten(CountVariantsInChunksBeagle.var_also_in_reference),
       valids = flatten(CheckChunksBeagle.valid),
-      basename = output_callset_name
+      basename = output_basename
   }
   
-  Int n_failed_chunks_int = read_int(StoreChunksInfo.n_failed_chunks)
-
-  if (n_failed_chunks_int >= chunks_fail_threshold) {
-    call utils.ErrorWithMessage as FailQCNChunks {
-      input:
-        message = n_failed_chunks_int + " chunks failed imputation, QC threshold was set to " + chunks_fail_threshold
-    }
-  }
-
-  if (split_output_to_single_sample) {
-    call tasks.SplitMultiSampleVcf {
-      input:
-        multiSampleVcf = GatherVcfs.output_vcf,
-        nSamples = CountSamples.nSamples
-    }
-  }
-
   output {
-    Array[File]? imputed_single_sample_vcfs = SplitMultiSampleVcf.single_sample_vcfs
-    Array[File]? imputed_single_sample_vcf_indices = SplitMultiSampleVcf.single_sample_vcf_indices
     File imputed_multi_sample_vcf = GatherVcfs.output_vcf
-    File imputed_multi_sample_vcf_index = GatherVcfs.output_vcf_index
-    File chunks_info = StoreChunksInfo.chunks_info
-    File failed_chunks = StoreChunksInfo.failed_chunks
-    File n_failed_chunks = StoreChunksInfo.n_failed_chunks
+        File imputed_multi_sample_vcf_index = GatherVcfs.output_vcf_index
+        File chunks_info = StoreChunksInfo.chunks_info
   }
 
   meta {
@@ -250,7 +260,7 @@ workflow ImputationBeagle {
 }
 
 struct ReferencePanelContig {
-  File interval_list
+  File bed
   File bref3
   String contig
   File genetic_map

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -23,7 +23,7 @@ workflow ImputationBeagle {
     String bed_suffix = ".bed"
     String bref3_suffix = ".bref3"
 
-    String gatk_docker = "broadinstitute/gatk-nightly:2024-06-06-4.5.0.0-36-g2a420e483-NIGHTLY-SNAPSHOT"
+    String gatk_docker = "broadinstitute/gatk:4.6.0.0"
     String ubuntu_docker = "ubuntu:20.04"
 
     Int? error_count_override

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -67,10 +67,14 @@ workflow ImputationBeagle {
     scatter (i in range(num_chunks)) {
       String chunk_contig = referencePanelContig.contig
 
-      Int start = (i * chunkLength) + 1
-      Int startWithOverlaps = if (start - chunkOverlaps < 1) then 1 else start - chunkOverlaps
-      Int end = if (CalculateChromosomeLength.chrom_length < ((i + 1) * chunkLength)) then CalculateChromosomeLength.chrom_length else ((i + 1) * chunkLength)
-      Int endWithOverlaps = if (CalculateChromosomeLength.chrom_length < end + chunkOverlaps) then CalculateChromosomeLength.chrom_length else end + chunkOverlaps
+      call defineStartAndEnd {
+        input:
+          i = i,
+          chunk_length = chunkLength,
+          chrom_length = CalculateChromosomeLength.chrom_length
+      }
+      Int startWithOverlaps = if (defineStartAndEnd.start - chunkOverlaps < 1) then 1 else defineStartAndEnd.start - chunkOverlaps
+      Int endWithOverlaps = if (CalculateChromosomeLength.chrom_length < defineStartAndEnd.end + chunkOverlaps) then CalculateChromosomeLength.chrom_length else defineStartAndEnd.end + chunkOverlaps
       String chunk_basename = referencePanelContig.contig + "_chunk_" + i
 
       # generate the chunked vcf file that will be used for imputation, including overlaps
@@ -106,8 +110,8 @@ workflow ImputationBeagle {
           vcf_index = CreateVcfIndex.vcf_index,
           output_basename = "input_samples_subset_to_chunk",
           contig = referencePanelContig.contig,
-          start = start,
-          end = end,
+          start = defineStartAndEnd.start,
+          end = defineStartAndEnd.end,
           gatk_docker = gatk_docker
       }
 
@@ -118,6 +122,9 @@ workflow ImputationBeagle {
       }
     }
 
+    Array[Int] starts = defineStartAndEnd.start
+    Array[Int] ends = defineStartAndEnd.end
+
     Array[File] chunkedVcfsWithOverlapsForImputation = GenerateChunk.output_vcf
     Array[File] chunkedVcfsWithoutOverlapsForSiteIds = SetIdsVcfToImpute.output_vcf
     Array[File] chunkedVcfIndexesWithoutOverlapsForSiteIds = SetIdsVcfToImpute.output_vcf_index
@@ -125,8 +132,8 @@ workflow ImputationBeagle {
     call tasks.StoreChunksInfo as StoreContigLevelChunksInfo {
       input:
         chroms = chunk_contig,
-        starts = start,
-        ends = end,
+        starts = starts,
+        ends = ends,
         vars_in_array = CountVariantsInChunksBeagle.var_in_original,
         vars_in_panel = CountVariantsInChunksBeagle.var_also_in_reference,
         valids = CheckChunksBeagle.valid,
@@ -159,8 +166,8 @@ workflow ImputationBeagle {
           chrom = referencePanelContig.contig,
           basename = chunk_basename_imputed,
           genetic_map_file = referencePanelContig.genetic_map,
-          start = start[i],
-          end = end[i]
+          start = starts[i],
+          end = ends[i]
       }
 
       call tasks.UpdateHeader {
@@ -242,8 +249,8 @@ workflow ImputationBeagle {
   call tasks.StoreChunksInfo {
     input:
       chroms = flatten(chunk_contig),
-      starts = flatten(start),
-      ends = flatten(end),
+      starts = flatten(defineStartAndEnd.start),
+      ends = flatten(defineStartAndEnd.end),
       vars_in_array = flatten(CountVariantsInChunksBeagle.var_in_original),
       vars_in_panel = flatten(CountVariantsInChunksBeagle.var_also_in_reference),
       valids = flatten(CheckChunksBeagle.valid),
@@ -267,4 +274,22 @@ struct ReferencePanelContig {
   File bref3
   String contig
   File genetic_map
+}
+
+task defineStartAndEnd {
+  input {
+    Int i
+    Int chunk_length
+    Int chrom_length
+  }
+
+  # Int start = (i * chunk_length) + 1
+  # Int end = if (chrom_length < ((i + 1) * chunk_length)) then chrom_length else ((i + 1) * chunk_length)
+
+  command <<<>>>
+
+  output {
+    Int start = (i * chunk_length) + 1
+    Int end = if (chrom_length < ((i + 1) * chunk_length)) then chrom_length else ((i + 1) * chunk_length)
+  }
 }

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -65,6 +65,8 @@ workflow ImputationBeagle {
     Int num_chunks = ceil(CalculateChromosomeLength.chrom_length / chunkLengthFloat)
 
     scatter (i in range(num_chunks)) {
+      String chunk_contig = referencePanelContig.contig
+
       Int start = (i * chunkLength) + 1
       Int startWithOverlaps = if (start - chunkOverlaps < 1) then 1 else start - chunkOverlaps
       Int end = if (CalculateChromosomeLength.chrom_length < ((i + 1) * chunkLength)) then CalculateChromosomeLength.chrom_length else ((i + 1) * chunkLength)
@@ -118,7 +120,7 @@ workflow ImputationBeagle {
 
     call tasks.StoreChunksInfo as StoreContigLevelChunksInfo {
       input:
-        chroms = contigs,
+        chroms = chunk_contig,
         starts = start,
         ends = end,
         vars_in_array = CountVariantsInChunksBeagle.var_in_original,
@@ -243,7 +245,7 @@ workflow ImputationBeagle {
 
   call tasks.StoreChunksInfo {
     input:
-      chroms = contigs,
+      chroms = flatten(chunk_contig),
       starts = flatten(start),
       ends = flatten(end),
       vars_in_array = flatten(CountVariantsInChunksBeagle.var_in_original),

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl
@@ -5,7 +5,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow ImputationBeagle {
 
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.1"
 
     input {
         Int chunkLength = 25000000

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1103,11 +1103,13 @@ task CreateVcfIndex {
   Int command_mem = memory_mb - 1000
   Int max_heap = memory_mb - 500
 
+  String basename = basename(vcf_input)
+
   command {
     set -e -o pipefail
 
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
-    IndexFeatureFile -I ~{vcf_input}
+    IndexFeatureFile -F ~{vcf_input} -O "~{basename}.tbi"
   }
   runtime {
     docker: gatk_docker
@@ -1118,8 +1120,7 @@ task CreateVcfIndex {
     preemptible: 3
   }
   output {
-    File vcf = "~{vcf_input}" # delocalize the vcf to have it in the same directory as the index
-    File vcf_index = "~{vcf_input}.tbi"
+    File vcf_index = "~{basename}.tbi"
   }
 }
 

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1103,13 +1103,17 @@ task CreateVcfIndex {
   Int command_mem = memory_mb - 1000
   Int max_heap = memory_mb - 500
 
-  String basename = basename(vcf_input)
+  String vcf_basename = basename(vcf_input)
 
   command {
     set -e -o pipefail
 
+    mv ~{vcf_input} ~{vcf_basename}
+
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
-    IndexFeatureFile -I ~{vcf_input} -O "~{basename}.tbi"
+    IndexFeatureFile -I ~{vcf_basename}
+
+    
   }
   runtime {
     docker: gatk_docker
@@ -1120,7 +1124,8 @@ task CreateVcfIndex {
     preemptible: 3
   }
   output {
-    File vcf_index = "~{basename}.tbi"
+    File vcf = "~{vcf_basename}"
+    File vcf_index = "~{vcf_basename}.tbi"
   }
 }
 

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1093,9 +1093,9 @@ task SplitMultiSampleVcf {
 
 task CreateVcfIndex {
   input {
-    File vcf
+    File vcf_input
 
-    Int disk_size_gb = ceil(3*size(vcf, "GiB")) + 50
+    Int disk_size_gb = ceil(3*size(vcf_input, "GiB")) + 50
     Int cpu = 1
     Int memory_mb = 8000
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
@@ -1107,7 +1107,7 @@ task CreateVcfIndex {
     set -e -o pipefail
 
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
-    IndexFeatureFile -I ~{vcf}
+    IndexFeatureFile -I ~{vcf_input}
   }
   runtime {
     docker: gatk_docker
@@ -1118,8 +1118,8 @@ task CreateVcfIndex {
     preemptible: 3
   }
   output {
-    File vcf = "~{vcf}" # delocalize the vcf to have it in the same directory as the index
-    File vcf_index = "~{vcf}.tbi"
+    File vcf = "~{vcf_input}" # delocalize the vcf to have it in the same directory as the index
+    File vcf_index = "~{vcf_input}.tbi"
   }
 }
 

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1118,6 +1118,7 @@ task CreateVcfIndex {
     preemptible: 3
   }
   output {
+    File vcf = "~{vcf}" # delocalize the vcf to have it in the same directory as the index
     File vcf_index = "~{vcf}.tbi"
   }
 }

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1109,7 +1109,7 @@ task CreateVcfIndex {
     set -e -o pipefail
 
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
-    IndexFeatureFile -F ~{vcf_input} -O "~{basename}.tbi"
+    IndexFeatureFile -I ~{vcf_input} -O "~{basename}.tbi"
   }
   runtime {
     docker: gatk_docker

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -1108,7 +1108,7 @@ task CreateVcfIndex {
   command {
     set -e -o pipefail
 
-    mv ~{vcf_input} ~{vcf_basename}
+    ln -sf ~{vcf_input} ~{vcf_basename}
 
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
     IndexFeatureFile -I ~{vcf_basename}


### PR DESCRIPTION
### Description

Add back streaming to the Imputation Beagle wdl for use on GCP.

Test run: https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/a06c05dc-6c9d-4160-b7d5-b5fabdf4ce08
Verified output (CompareVcfs): https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/2b675471-62f2-43b8-8615-1226edcafcdb

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP documentation team by tagging either @ekiernan or @kayleemathews in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
