### PR TITLE
TSPS-343 reduce imputation beagle chunkOverlaps to 2MB from 5MB

### DIFF
--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -8,7 +8,7 @@ workflow ImputationBeagle {
 
   input {
     Int chunkLength = 25000000
-    Int chunkOverlaps = 5000000 # this is the padding that will be added to the beginning and end of each chunk to reduce edge effects
+    Int chunkOverlaps = 2000000 # this is the padding that will be added to the beginning and end of each chunk to reduce edge effects
 
     File multi_sample_vcf
 


### PR DESCRIPTION
### Description
In order to reduce computation in the workflow, we want to lower the amount of overlap between the different chunks from 5MB to 2MB.  This did not cause outputs to change

run with 2MB overlap - https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/ca884e62-d25a-47e6-be02-a8760930f12e

comparison of output against 5MB overlap - https://bvdp-saturn-dev.appspot.com/#workspaces/teaspoons-imputation-dev/teaspoons_imputation_dev_control_workspace_20240726/job_history/90342454-2886-4d9e-9669-333df0c022d4


Jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-343
----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
