### PR TITLE
Lk atac percent target

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -30,11 +30,11 @@ ExomeReprocessing	 3.3.3	2024-11-04
 BuildIndices	 3.0.0	2023-12-06 
 scATAC	 1.3.2	2023-08-03 
 snm3C	 4.0.4	2024-08-06 
-Multiome	 5.9.0	2024-10-21 
-PairedTag	 1.8.1	2024-11-04 
+Multiome	 5.9.1	2024-11-12 
+PairedTag	 1.8.2	2024-11-12 
 MultiSampleSmartSeq2	 2.2.22	2024-09-11 
 MultiSampleSmartSeq2SingleNucleus	 2.0.3	2024-11-04 
 Optimus	 7.8.1	2024-11-04 
-atac	 2.5.0	2024-10-23 
+atac	 2.5.1	2024-11-12 
 SmartSeq2SingleSample	 5.1.21	2024-09-11 
 SlideSeq	 3.4.4	2024-11-04 

--- a/pipelines/skylab/atac/atac.changelog.md
+++ b/pipelines/skylab/atac/atac.changelog.md
@@ -1,7 +1,13 @@
+# 2.5.1
+2024-11-12 (Date of Last Commit)
+
+* Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
+
 # 2.5.0
 2024-10-23 (Date of Last Commit)
 
 * Updated the tabix flag in CreateFragmentFile task to use CSI instead of TBI indexing, which supports chromosomes larger than 512 Mbp
+* Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
 
 # 2.4.0
 2024-10-23 (Date of Last Commit)

--- a/pipelines/skylab/atac/atac.wdl
+++ b/pipelines/skylab/atac/atac.wdl
@@ -49,7 +49,7 @@ workflow ATAC {
     String adapter_seq_read3 = "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"
   }
 
-  String pipeline_version = "2.5.0"
+  String pipeline_version = "2.5.1"
 
   # Determine docker prefix based on cloud provider
   String gcr_docker_prefix = "us.gcr.io/broad-gotc-prod/"

--- a/pipelines/skylab/atac/atac.wdl
+++ b/pipelines/skylab/atac/atac.wdl
@@ -575,7 +575,7 @@ task CreateFragmentFile {
     print("Print number of cells", number_of_cells)
     atac_percent_target = number_of_cells / expected_cells*100
     print("Setting percent target in nested dictionary")
-    data['Cells']['percent_target'] = atac_percent_target
+    data['Cells']['atac_percent_target'] = atac_percent_target
     
     
     # Flatten the dictionary

--- a/pipelines/skylab/multiome/Multiome.changelog.md
+++ b/pipelines/skylab/multiome/Multiome.changelog.md
@@ -1,7 +1,15 @@
+# 5.9.1
+2024-11-12 (Date of Last Commit)
+
+* Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
+
 # 5.9.0
 2024-10-21 (Date of Last Commit)
+
 * Updated the tabix flag in JoinMultiomeBarcodes task in H5adUtils.wdl to use CSI instead of TBI indexing, which supports chromosomes larger than 512 Mbp; this task changes the format for the ATAC fragment file index 
 * Renamed the fragment file index from atac_fragment_tsv_tbi to atac_fragment_tsv_index
+
+
 # 5.8.0
 2024-10-23 (Date of Last Commit)
 

--- a/pipelines/skylab/multiome/Multiome.wdl
+++ b/pipelines/skylab/multiome/Multiome.wdl
@@ -9,7 +9,7 @@ import "../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Multiome {
 
-    String pipeline_version = "5.9.0"
+    String pipeline_version = "5.9.1"
 
     input {
         String cloud_provider

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,7 +1,7 @@
 # 1.8.2
 2024-11-12 (Date of Last Commit)
 
-* * Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
+* Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
 
 # 1.8.1
 2024-11-04 (Date of Last Commit)

--- a/pipelines/skylab/paired_tag/PairedTag.changelog.md
+++ b/pipelines/skylab/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 1.8.2
+2024-11-12 (Date of Last Commit)
+
+* * Renamed the ATAC workflow library metric percent_target to atac_percent_target for compatibility with downstream tools
+
 # 1.8.1
 2024-11-04 (Date of Last Commit)
 

--- a/pipelines/skylab/paired_tag/PairedTag.wdl
+++ b/pipelines/skylab/paired_tag/PairedTag.wdl
@@ -8,7 +8,7 @@ import "../../../tasks/broad/Utilities.wdl" as utils
 
 workflow PairedTag {
 
-    String pipeline_version = "1.8.1"
+    String pipeline_version = "1.8.2"
 
 
     input {

--- a/website/docs/Pipelines/ATAC/README.md
+++ b/website/docs/Pipelines/ATAC/README.md
@@ -8,7 +8,7 @@ slug: /Pipelines/ATAC/README
 
 | Pipeline Version | Date Updated | Documentation Author | Questions or Feedback |
 | :----: | :---: | :----: | :--------------: |
-| [2.4.0](https://github.com/broadinstitute/warp/releases) | October, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues). |
+| [2.5.1](https://github.com/broadinstitute/warp/releases) | November, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues). |
 
 
 ## Introduction to the ATAC workflow

--- a/website/docs/Pipelines/ATAC/library-metrics.md
+++ b/website/docs/Pipelines/ATAC/library-metrics.md
@@ -31,6 +31,6 @@ The [ATAC pipeline](README.md) uses [SnapATAC2](https://github.com/kaizhang/Snap
 | Number_of_peaks | The total number of peaks, or regions of accessible chromatin, identified in the dataset, representing potential regulatory elements. |
 | fraction_of_genome_in_peaks | The fraction of the genome that is covered by identified peaks, indicating the extent of chromatin accessibility across the genome. |
 | fraction_of_high-quality_fragments_overlapping_peaks | The fraction of high-quality fragments that overlap with identified peaks, providing an indication of the efficiency of the assay in capturing accessible regions. |
-| percent_target | Percent of cells recovered; value is calculated as estimated_cells/expected_cells. |
+| atac_percent_target | Percent of cells recovered; value is calculated as estimated_cells/expected_cells. |
 
 

--- a/website/docs/Pipelines/Multiome_Pipeline/README.md
+++ b/website/docs/Pipelines/Multiome_Pipeline/README.md
@@ -7,7 +7,7 @@ slug: /Pipelines/Multiome_Pipeline/README
 
 | Pipeline Version | Date Updated | Documentation Author | Questions or Feedback |
 | :----: | :---: | :----: | :--------------: |
-| [Multiome v5.8.0](https://github.com/broadinstitute/warp/releases) | October, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues).  |
+| [Multiome v5.9.1](https://github.com/broadinstitute/warp/releases) | November, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues).  |
 
 ![Multiome_diagram](./multiome_diagram.png)
 
@@ -108,9 +108,9 @@ The Multiome workflow calls two WARP subworkflows, one external subworkflow (opt
 | multiome_pipeline_version_out | N.A. | String describing the version of the Multiome pipeline used. |
 | bam_aligned_output_atac | `<input_id>_atac.bam` | BAM file containing aligned reads from ATAC workflow. |
 | fragment_file_atac | `<input_id>_atac.fragments.sorted.tsv.gz` | Sorted and bgzipped TSV file containing fragment start and stop coordinates per barcode. The columns are "Chromosome", "Start", "Stop", "ATAC Barcode", "Number of reads", and "GEX Barcode". | 
-| fragment_file_index |  `<input_id>_atac.fragments.sorted.tsv.gz.tbi` | tabix index file for the fragment file. |
+| fragment_file_index |  `<input_id>_atac.fragments.sorted.tsv.gz.csi` | Tabix CSI index file for the fragment file. |
 | snap_metrics_atac | `<input_id>_atac.metrics.h5ad` | h5ad (Anndata) file containing per-barcode metrics from SnapATAC2. Also contains the equivalent gene expression barcode for each ATAC barcode in the `gex_barcodes` column of the `h5ad.obs` property. See the [ATAC Count Matrix Overview](../ATAC/count-matrix-overview.md) for more details. |
-| atac_library_metrics | `<input_id>_atac_<nhash_id>.metrics.csv` | CSV with library-level metrics produced by SnapATAC2. See the ATAC [Library Level Metrics Overview](../ATAC/library-metrics.md) for more details. |
+| atac_library_metrics | `<input_id>_atac_<nhash_id>_library_metrics.csv` | CSV with library-level metrics produced by SnapATAC2. See the ATAC [Library Level Metrics Overview](../ATAC/library-metrics.md) for more details. |
 | genomic_reference_version_gex | `<reference_version>.txt` | File containing the Genome build, source and GTF annotation version. |
 | bam_gex | `<input_id>_gex.bam` | BAM file containing aligned reads from Optimus workflow. |
 | matrix_gex | `<input_id>_gex_sparse_counts.npz` | NPZ file containing raw gene by cell counts. |

--- a/website/docs/Pipelines/PairedTag_Pipeline/README.md
+++ b/website/docs/Pipelines/PairedTag_Pipeline/README.md
@@ -7,7 +7,7 @@ slug: /Pipelines/PairedTag_Pipeline/README
 
 |                          Pipeline Version                           | Date Updated | Documentation Author | Questions or Feedback |
 |:---:| :---: | :---: | :---: |
-| [PairedTag_v1.8.0](https://github.com/broadinstitute/warp/releases) | October, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues). |
+| [PairedTag_v1.8.2](https://github.com/broadinstitute/warp/releases) | November, 2024 | WARP Pipelines | Please [file an issue in WARP](https://github.com/broadinstitute/warp/issues). |
 
 
 ## Introduction to the Paired-Tag workflow


### PR DESCRIPTION
This PR renames that ATAC workflow's library CSV metric percent_target to be atac_percent_target for downstream compatibility with NIMP. 