### PR TITLE
PD-2803: Fixing Optimus h5ad generation to handle gene_ids more flexibly

### DIFF
--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -91,7 +91,7 @@ workflow Optimus {
   String pytools_docker = "pytools:1.0.0-1661263730"
   String empty_drops_docker = "empty-drops:1.0.1-4.2"
   String star_docker = "star:1.0.1-2.7.11a-1692706072"
-  String warp_tools_docker_2_2_0 = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2803-fix-refseq-h5ad"
+  String warp_tools_docker_2_2_0 = "warp-tools:lk-PD-2803-fix-refseq-h5ad"
   String star_merge_docker = "star-merge-npz:1.3.0"
 
 

--- a/pipelines/skylab/optimus/Optimus.wdl
+++ b/pipelines/skylab/optimus/Optimus.wdl
@@ -91,7 +91,7 @@ workflow Optimus {
   String pytools_docker = "pytools:1.0.0-1661263730"
   String empty_drops_docker = "empty-drops:1.0.1-4.2"
   String star_docker = "star:1.0.1-2.7.11a-1692706072"
-  String warp_tools_docker_2_2_0 = "warp-tools:2.4.0"
+  String warp_tools_docker_2_2_0 = "us.gcr.io/broad-gotc-prod/warp-tools:lk-PD-2803-fix-refseq-h5ad"
   String star_merge_docker = "star-merge-npz:1.3.0"
 
 


### PR DESCRIPTION
This PR updates the warp-tools docker for Optimus; this docker contains updated scripts for building the h5ad file. The script adds a more flexible search gene_name and gene_id to enable processing with refseq GTFs like those used for BICAN macaque and marmoset data processing. This should produce an h5ad file that has the appropriate gene_ids in the anndata.var.index.