### PR TITLE
Allow reblocking TDR/DRS VCFs

### DIFF
--- a/tasks/broad/GermlineVariantDiscovery.wdl
+++ b/tasks/broad/GermlineVariantDiscovery.wdl
@@ -217,20 +217,19 @@ task Reblock {
   }
 
   Int disk_size = ceil((size(gvcf, "GiB")) * 4) + additional_disk
-  String gvcf_basename = basename(gvcf)
-  String gvcf_index_basename = basename(gvcf_index)
 
   command {
     set -e 
 
     # We can't always assume the index was located with the gvcf, so make a link so that the paths look the same
-    ln -s ~{gvcf} ~{gvcf_basename}
-    ln -s ~{gvcf_index} ~{gvcf_index_basename}
+    # Use bash basename instead of WDL to support DRS: https://support.terra.bio/hc/en-us/community/posts/4405396480027
+    ln -s ~{gvcf} $(basename ~{gvcf})
+    ln -s ~{gvcf_index} $(basename ~{gvcf_index})
 
     gatk --java-options "-Xms3000m -Xmx3000m" \
       ReblockGVCF \
       -R ~{ref_fasta} \
-      -V ~{gvcf_basename} \
+      -V $(basename ~{gvcf}) \
       -do-qual-approx \
       --floor-blocks -GQB 20 -GQB 30 -GQB 40 \
       ~{annotations_to_keep_command} \


### PR DESCRIPTION
### Description

When a DRS URI is used with the ReblockGVCF WDL, the workflow fails because Cromwell's basename function does not support DRS. Recently, instead of receiving GCS URIs for our samples from the Broad's Genomics Platform, our group received DRS URIs for our files stored in TDR. When run with the existing ReblockGVCF workflow in [642e3f2](https://github.com/broadinstitute/warp/commit/642e3f2094d4d7307e1936b7c2e122445780bdf7), the WDL basename calls on DRS URIs produce errors as discussed in this Terra Support post: https://support.terra.bio/hc/en-us/community/posts/4405396480027

This PR changes the workflow to use bash's basename instead of WDL's basename during ReblockGVCF.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
