### PR TITLE
Np abort jobs from previous commits

### DIFF
--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Install dependencies
+        run: |
+          cd scripts/firecloud_api/
+          pip install -r requirements.txt
+
       - name: Set Branch Name
         id: set_branch
         run: |
@@ -148,11 +153,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          cd scripts/firecloud_api/
-          pip install -r requirements.txt
 
       - name: Cancel Previous Terra Submissions
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -102,48 +102,28 @@ jobs:
         id: set_test_type
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            branch="${{ github.base_ref }}"
+            # For PRs, set based on target branch
+            if [ "${{ github.base_ref }}" == "master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType=Scientific"
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType=Plumbing"
+            fi
           else
-            branch="${GITHUB_REF##*/}"
+            # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+            fi
           fi
-
-          if [ -n "${{ github.event.inputs.testType }}" ]; then
-            testType="${{ github.event.inputs.testType }}"
-            echo "testType set to $testType from manual input"
-          else
-            testType=$([ "$branch" == "master" ] && echo "Scientific" || echo "Plumbing")
-            echo "testType set to $testType based on branch ($branch)"
-          fi
-
-          echo "testType=$testType" >> $GITHUB_ENV
-
-
-     #- name: Set Test Type
-     #  id: set_test_type
-     #  run: |
-     #    if [ "${{ github.event_name }}" == "pull_request" ]; then
-     #      # For PRs, set based on target branch
-     #      if [ "${{ github.base_ref }}" == "master" ]; then
-     #        echo "testType=Scientific" >> $GITHUB_ENV
-     #        echo "testType=Scientific"
-     #      else
-     #        echo "testType=Plumbing" >> $GITHUB_ENV
-     #        echo "testType=Plumbing"
-     #      fi
-     #    else
-     #      # For workflow_dispatch, check manual input first
-     #      if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-     #        echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-     #        echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-     #      # If no manual input, default based on target branch
-     #      elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-     #        echo "testType=Scientific" >> $GITHUB_ENV
-     #        echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-     #      else
-     #        echo "testType=Plumbing" >> $GITHUB_ENV
-     #        echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-     #      fi
-     #    fi
 
       - name: Create new method configuration
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Cancel Previous GHA Runs
         run: |
           # Get all running workflow runs for this workflow
-          RUNS=$(gh api repos/${{ github.repository }}/actions/workflows/${{ github.workflow }}/runs --jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: .inputs}')
+          RUNS=$(gh api repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: .inputs}')
           
           for run in $(echo "$RUNS" | jq -c '.'); do
             RUN_ID=$(echo $run | jq -r '.id')

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -147,12 +147,61 @@ jobs:
           USER: ${{ env.USER }}
 
       - name: Cancel Previous GHA Runs
+        run: |
+          # Get all running workflow runs for this workflow
+          RUNS=$(gh api repos/${{ github.repository }}/actions/workflows/${{ github.workflow }}/runs --jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: .inputs}')
+          
+          for run in $(echo "$RUNS" | jq -c '.'); do
+            RUN_ID=$(echo $run | jq -r '.id')
+          
+            # Skip the current run
+            if [ "$RUN_ID" = "${{ github.run_id }}" ]; then
+              continue
+            fi
+          
+            # Check if it's a Scientific test:
+            # 1. Check workflow_dispatch inputs if they exist
+            TEST_TYPE=$(echo $run | jq -r '.inputs.testType // empty')
+            if [ "$TEST_TYPE" = "Scientific" ]; then
+              echo "Skipping cancellation of Scientific run $RUN_ID (from inputs)"
+              continue
+            fi
+          
+            # 2. If no explicit test type, check if it's targeting master branch
+            BRANCH=$(echo $run | jq -r '.branch')
+            if [ "$BRANCH" = "master" ]; then
+              echo "Skipping cancellation of Scientific run $RUN_ID (master branch)"
+              continue
+            fi
+          
+            # 3. For PRs, check the target branch
+            if [ "$(echo $run | jq -r '.event')" = "pull_request" ]; then
+              TARGET_BRANCH=$(gh api repos/${{ github.repository }}/pulls --jq ".[] | select(.head.sha==\"$SHA\") | .base.ref")
+              if [ "$TARGET_BRANCH" = "master" ]; then
+                echo "Skipping cancellation of Scientific run $RUN_ID (PR to master)"
+                continue
+              fi
+            fi
+          
+            # If we get here, it's not a Scientific test, so cancel it
+            echo "Canceling run $RUN_ID"
+            gh api -X POST repos/${{ github.repository }}/actions/runs/$RUN_ID/cancel
+          done
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-          all_but_latest: true
-          ignore_sha: true
+        run: |
+          python3 scripts/firecloud_api/firecloud_api.py \
+            --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
+            --workspace-name "${{ env.TESTING_WORKSPACE }}" \
+            --pipeline_name "${{ env.PIPELINE_NAME }}" \
+            --branch_name "${{ env.BRANCH_NAME }}" \
+            --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
+            --user "${{ env.USER }}" \
+            --test_type "$testType" \
+            cancel_old_submissions
 
       - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      actions: write
 
     steps:
       # actions/checkout MUST come before auth action
@@ -75,7 +76,6 @@ jobs:
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
-          workflow_type: "all"       # This ensures it catches manually triggered workflows
           all_but_latest: true      # This ensures only the latest run continues
 
       - name: Set up python

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -151,65 +151,71 @@ jobs:
           echo "Fetching all running workflow runs..."
           
           # Get all running workflow runs for this workflow
-          RUNS=$(gh api repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: .inputs}')
+          RUNS=$(gh api repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: (.inputs // {})}')
           
           echo "Raw RUNS JSON: $RUNS"
-
+          
           for run in $(echo "$RUNS" | jq -c '.'); do
             RUN_ID=$(echo $run | jq -r '.id')
             echo "Processing run: $RUN_ID"
-
+          
             # Skip the current run
             if [ "$RUN_ID" = "${{ github.run_id }}" ]; then
               echo "Skipping current run: $RUN_ID"
               continue
             fi
-
+          
             # Debug: Show full JSON for the current run
             echo "Run JSON: $run"
-
-            # Check if it's a Scientific test:
-            # 1. Check workflow_dispatch inputs if they exist
-            TEST_TYPE=$(echo $run | jq -r '.inputs.testType // empty')
+          
+            # Ensure inputs exist before trying to extract testType
+            if [ "$(echo $run | jq -r '.inputs')" = "{}" ]; then
+              echo "No inputs found for run $RUN_ID"
+              TEST_TYPE=""
+            else
+              TEST_TYPE=$(echo $run | jq -r '.inputs.testType // empty')
+            fi
+          
             echo "Extracted TEST_TYPE: '$TEST_TYPE'"
-
+          
             if [ "$TEST_TYPE" = "Scientific" ]; then
               echo "Skipping cancellation of Scientific run $RUN_ID (from inputs)"
               continue
             fi
-
+          
             # 2. If no explicit test type, check if it's targeting master branch
             BRANCH=$(echo $run | jq -r '.branch')
             echo "Extracted BRANCH: '$BRANCH'"
-
+          
             if [ "$BRANCH" = "master" ]; then
               echo "Skipping cancellation of Scientific run $RUN_ID (master branch)"
               continue
             fi
-
+          
             # 3. For PRs, check the target branch
             EVENT=$(echo $run | jq -r '.event')
             echo "Extracted EVENT: '$EVENT'"
-
+          
             if [ "$EVENT" = "pull_request" ]; then
               SHA=$(echo $run | jq -r '.head_sha')
               echo "Fetching target branch for PR with SHA: $SHA"
-
+          
               TARGET_BRANCH=$(gh api repos/${{ github.repository }}/pulls --jq ".[] | select(.head.sha==\"$SHA\") | .base.ref")
               echo "Extracted TARGET_BRANCH: '$TARGET_BRANCH'"
-
+          
               if [ "$TARGET_BRANCH" = "master" ]; then
                 echo "Skipping cancellation of Scientific run $RUN_ID (PR to master)"
                 continue
               fi
             fi
-
+          
             # If we get here, it's not a Scientific test, so cancel it
             echo "Canceling run $RUN_ID"
             gh api -X POST repos/${{ github.repository }}/actions/runs/$RUN_ID/cancel
           done
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
 
       - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -75,6 +75,8 @@ jobs:
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
+          workflow_type: "all"       # This ensures it catches manually triggered workflows
+          all_but_latest: true      # This ensures only the latest run continues
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -158,12 +158,15 @@ jobs:
       - name: Cancel Previous Terra Submissions
         if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         run: |
+          #echo the test type
+          echo "Test Type: $testType"
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
             --workspace-name "${{ env.TESTING_WORKSPACE }}" \
             --pipeline_name "${{ env.PIPELINE_NAME }}" \
             --branch_name "${{ env.BRANCH_NAME }}" \
             --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
+            --test_type "$testType" \
             --user "${{ env.USER }}" \
             cancel_old_submissions
 

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -197,6 +197,7 @@ jobs:
             --workspace-name "$TESTING_WORKSPACE" \
             --pipeline_name "$PIPELINE_NAME" \
             --branch_name "$BRANCH_NAME" \
+            --test_type "$testType" \
             --sa-json-b64 "$SA_JSON_B64" \
             --user "$USER")
 
@@ -260,7 +261,7 @@ jobs:
             SUBMISSION_DATA_FILE="submission_data.json"
             printf '{
               "methodConfigurationNamespace": "%s",
-              "methodConfigurationName": "%s",
+              "methodConfigurationName": "%s_%s_%s",
               "useCallCache": %s,
               "deleteIntermediateOutputFiles": false,
               "useReferenceDisks": true,
@@ -268,7 +269,7 @@ jobs:
               "workflowFailureMode": "NoNewCalls",
               "userComment": "%s",
               "ignoreEmptyOutputs": false
-            }' "$WORKSPACE_NAMESPACE" "$METHOD_CONFIG_NAME" "$USE_CALL_CACHE_BOOL" "$input_file_filename" > "$SUBMISSION_DATA_FILE"
+            }' "$WORKSPACE_NAMESPACE" "$PIPELINE_NAME" "$TEST_TYPE" "$BRANCH_NAME" "$USE_CALL_CACHE_BOOL" "$input_file_filename" > "$SUBMISSION_DATA_FILE"
            
             echo "Created submission data file: $SUBMISSION_DATA_FILE"
             cat "$SUBMISSION_DATA_FILE"
@@ -419,9 +420,10 @@ jobs:
             --workspace-name "$TESTING_WORKSPACE" \
             --pipeline_name "$PIPELINE_NAME" \
             --branch_name "$BRANCH_NAME" \
+            --test_type "$testType" \
             --sa-json-b64 "$SA_JSON_B64" \
             --user "$USER" \
-            --method_config_name "$METHOD_CONFIG_NAME")
+            --method_config_name "${PIPELINE_NAME}_${testType}_${BRANCH_NAME}")
             echo "Delete response: $DELETE_RESPONSE"
           if [ "$DELETE_RESPONSE" == "True" ]; then
             echo "Method configuration deleted successfully."

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,6 +76,13 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Cancel Previous GHA Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+          all_but_latest: true
+          ignore_sha: true
+
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v4
@@ -98,75 +105,14 @@ jobs:
             echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
           fi
 
-      - name: Set Test Type
-        id: set_test_type
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, set based on target branch
-            if [ "${{ github.base_ref }}" == "master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType=Scientific"
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType=Plumbing"
-            fi
-          else
-            # For workflow_dispatch, check manual input first
-            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-            # If no manual input, default based on target branch
-            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-            fi
-          fi
-
-      - name: Create new method configuration
-        run: |
-          echo "Creating new method configuration for branch: $BRANCH_NAME"
-
-          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
-            create_new_method_config \
-            --workspace-namespace $WORKSPACE_NAMESPACE \
-            --workspace-name "$TESTING_WORKSPACE" \
-            --pipeline_name "$PIPELINE_NAME" \
-            --branch_name "$BRANCH_NAME" \
-            --test_type "$testType" \
-            --sa-json-b64 "$SA_JSON_B64" \
-            --user "$USER")
-
-            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
-        env:
-          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
-          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
-          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
-          USER: ${{ env.USER }}
-
-      - name: Cancel Previous GHA Runs
-        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-          all_but_latest: true
-          ignore_sha:
-            true
-
       - name: Cancel Previous Terra Submissions
-        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         run: |
-          #echo the test type
-          echo "Test Type: $testType"
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
             --workspace-name "${{ env.TESTING_WORKSPACE }}" \
             --pipeline_name "${{ env.PIPELINE_NAME }}" \
             --branch_name "${{ env.BRANCH_NAME }}" \
             --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
-            --test_type "$testType" \
             --user "${{ env.USER }}" \
             cancel_old_submissions
 
@@ -221,6 +167,54 @@ jobs:
           DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
           GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
 
+      - name: Set Test Type
+        id: set_test_type
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PRs, set based on target branch
+            if [ "${{ github.base_ref }}" == "master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType=Scientific"
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType=Plumbing"
+            fi
+          else
+            # # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+            fi
+          fi
+
+      - name: Create new method configuration
+        run: |
+          echo "Creating new method configuration for branch: $BRANCH_NAME"
+
+          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
+            create_new_method_config \
+            --workspace-namespace $WORKSPACE_NAMESPACE \
+            --workspace-name "$TESTING_WORKSPACE" \
+            --pipeline_name "$PIPELINE_NAME" \
+            --branch_name "$BRANCH_NAME" \
+            --test_type "$testType" \
+            --sa-json-b64 "$SA_JSON_B64" \
+            --user "$USER")
+
+            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
+        env:
+          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
+          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
+          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
+          USER: ${{ env.USER }}
+
       - name: Update test inputs, Upload to Terra, Submit, Monitor and Retrieve Outputs
         run: |
           UPDATE_TRUTH="${{ github.event.inputs.updateTruth || 'false' }}"
@@ -259,7 +253,7 @@ jobs:
           RESULTS_PATH="gs://broad-gotc-test-storage/$DOCKSTORE_PIPELINE_NAME/results/$CURRENT_TIME"
           
           
-
+          
           # 1. Submit all jobs first and store their submission IDs
           for input_file in "$INPUTS_DIR"/*.json; do
             test_input_file=$(python3 scripts/firecloud_api/UpdateTestInputs.py --truth_path "$TRUTH_PATH" \
@@ -283,7 +277,7 @@ jobs:
               "userComment": "%s",
               "ignoreEmptyOutputs": false
             }' "$WORKSPACE_NAMESPACE" "$PIPELINE_NAME" "$TEST_TYPE" "$BRANCH_NAME" "$USE_CALL_CACHE_BOOL" "$input_file_filename" > "$SUBMISSION_DATA_FILE"
-           
+          
             echo "Created submission data file: $SUBMISSION_DATA_FILE"
             cat "$SUBMISSION_DATA_FILE"
 
@@ -330,7 +324,7 @@ jobs:
           echo "All jobs have been submitted. Starting to poll for statuses..."
 
           # Continue with polling and output retrieval...
-                
+          
           # 2. After all submissions are done, start polling for statuses of all jobs
           for SUBMISSION_ID in "${SUBMISSION_IDS[@]}"; do
             attempt=1
@@ -342,7 +336,7 @@ jobs:
                   --user "$USER" \
                   --workspace-namespace "$WORKSPACE_NAMESPACE" \
                   --workspace-name "$TESTING_WORKSPACE")
-              
+          
               if [ -z "$RESPONSE" ]; then
                   echo "Failed to retrieve Workflow IDs for submission: $SUBMISSION_ID"
                   OVERALL_SUCCESS=false
@@ -354,7 +348,7 @@ jobs:
                   sleep $RETRY_DELAY
                   continue
               fi
-      
+          
               WORKFLOW_STATUSES_FOR_SUBMISSION=$(echo "$RESPONSE" | jq -r 'to_entries | map(.key + " | " + .value) | .[]')
               WORKFLOW_STATUSES["$SUBMISSION_ID"]="$WORKFLOW_STATUSES_FOR_SUBMISSION"
           

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -87,6 +87,13 @@ jobs:
           cd scripts/firecloud_api/
           pip install -r requirements.txt
 
+      - name: Check inputs
+        run: |
+          echo "Use call cache: ${{ github.event.inputs.useCallCache }}"
+          echo "Update truth: ${{ github.event.inputs.updateTruth }}"
+          echo "Test type: ${{ github.event.inputs.testType }}"
+          echo "Truth branch: ${{ github.event.inputs.truthBranch }}"
+
       - name: Set Branch Name
         id: set_branch
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Cancel Previous Runs
+      - name: Cancel Previous GHA Runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
@@ -100,7 +100,7 @@ jobs:
             echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
           fi
 
-      - name: Cancel Previous Runs
+      - name: Cancel Previous Terra Runs
         run: |
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -291,6 +291,7 @@ jobs:
                 --test_input_file "$test_input_file" \
                 --branch_name "$BRANCH_NAME" \
                 --sa-json-b64 "$SA_JSON_B64" \
+                --test_type "$testType" \
                 --user "$USER"
 
             attempt=1

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,7 +76,8 @@ jobs:
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
-          all_but_latest: true      # This ensures only the latest run continues
+          all_but_latest: true
+          ignore_sha: true
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -100,7 +100,7 @@ jobs:
             echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
           fi
 
-      - name: Cancel Previous Terra Runs
+      - name: Cancel Previous Terra Submissions
         run: |
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,13 +76,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Cancel Previous GHA Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-          all_but_latest: true
-          ignore_sha: true
-
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v4
@@ -105,7 +98,65 @@ jobs:
             echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
           fi
 
+      - name: Set Test Type
+        id: set_test_type
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PRs, set based on target branch
+            if [ "${{ github.base_ref }}" == "master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType=Scientific"
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType=Plumbing"
+            fi
+          else
+            # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+            fi
+          fi
+
+      - name: Create new method configuration
+        run: |
+          echo "Creating new method configuration for branch: $BRANCH_NAME"
+
+          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
+            create_new_method_config \
+            --workspace-namespace $WORKSPACE_NAMESPACE \
+            --workspace-name "$TESTING_WORKSPACE" \
+            --pipeline_name "$PIPELINE_NAME" \
+            --branch_name "$BRANCH_NAME" \
+            --test_type "$testType" \
+            --sa-json-b64 "$SA_JSON_B64" \
+            --user "$USER")
+
+            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
+        env:
+          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
+          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
+          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
+          USER: ${{ env.USER }}
+
+      - name: Cancel Previous GHA Runs
+        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+          all_but_latest: true
+          ignore_sha:
+            true
+
       - name: Cancel Previous Terra Submissions
+        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         run: |
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
@@ -145,7 +196,6 @@ jobs:
           echo "Dockstore Commit Hash: $DOCKSTORE_COMMIT_HASH_FROM_FETCH"
 
         env:
-          ## TODO NEED TO ADD DOCKSTORE_TOKEN FOR SERVICE ACCOUNT ##
           DOCKSTORE_TOKEN: ${{ secrets.DOCKSTORE_TOKEN }}
           DOCKSTORE_PIPELINE_NAME: ${{ env.DOCKSTORE_PIPELINE_NAME }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
@@ -167,54 +217,6 @@ jobs:
         env:
           DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
           GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
-
-      - name: Set Test Type
-        id: set_test_type
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, set based on target branch
-            if [ "${{ github.base_ref }}" == "master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType=Scientific"
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType=Plumbing"
-            fi
-          else
-            # # For workflow_dispatch, check manual input first
-            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-            # If no manual input, default based on target branch
-            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-            fi
-          fi
-
-      - name: Create new method configuration
-        run: |
-          echo "Creating new method configuration for branch: $BRANCH_NAME"
-
-          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
-            create_new_method_config \
-            --workspace-namespace $WORKSPACE_NAMESPACE \
-            --workspace-name "$TESTING_WORKSPACE" \
-            --pipeline_name "$PIPELINE_NAME" \
-            --branch_name "$BRANCH_NAME" \
-            --test_type "$testType" \
-            --sa-json-b64 "$SA_JSON_B64" \
-            --user "$USER")
-
-            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
-        env:
-          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
-          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
-          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
-          USER: ${{ env.USER }}
 
       - name: Update test inputs, Upload to Terra, Submit, Monitor and Retrieve Outputs
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,6 +76,12 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: |
           cd scripts/firecloud_api/
@@ -147,12 +153,6 @@ jobs:
           access_token: ${{ github.token }}
           all_but_latest: true
           ignore_sha: true
-
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
 
       - name: Cancel Previous Terra Submissions
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -102,28 +102,47 @@ jobs:
         id: set_test_type
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, set based on target branch
-            if [ "${{ github.base_ref }}" == "master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType=Scientific"
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType=Plumbing"
-            fi
+            branch="${{ github.base_ref }}"
           else
-            # For workflow_dispatch, check manual input first
-            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-            # If no manual input, default based on target branch
-            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-            fi
+            branch="${{ github.ref#refs/heads/ }}"
           fi
+
+          if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+            testType="${{ github.event.inputs.testType }}"
+            echo "testType set to $testType from manual input"
+          else
+            testType=$([ "$branch" == "master" ] && echo "Scientific" || echo "Plumbing")
+            echo "testType set to $testType based on branch ($branch)"
+          fi
+
+          echo "testType=$testType" >> $GITHUB_ENV
+
+     #- name: Set Test Type
+     #  id: set_test_type
+     #  run: |
+     #    if [ "${{ github.event_name }}" == "pull_request" ]; then
+     #      # For PRs, set based on target branch
+     #      if [ "${{ github.base_ref }}" == "master" ]; then
+     #        echo "testType=Scientific" >> $GITHUB_ENV
+     #        echo "testType=Scientific"
+     #      else
+     #        echo "testType=Plumbing" >> $GITHUB_ENV
+     #        echo "testType=Plumbing"
+     #      fi
+     #    else
+     #      # For workflow_dispatch, check manual input first
+     #      if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+     #        echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+     #        echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+     #      # If no manual input, default based on target branch
+     #      elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+     #        echo "testType=Scientific" >> $GITHUB_ENV
+     #        echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+     #      else
+     #        echo "testType=Plumbing" >> $GITHUB_ENV
+     #        echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+     #      fi
+     #    fi
 
       - name: Create new method configuration
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -76,7 +76,67 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Set Branch Name
+        id: set_branch
+        run: |
+          if [ -z "${{ github.head_ref }}" ]; then
+            echo "Branch name is missing, using ${GITHUB_REF##*/}"
+            echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          else
+            echo "Branch name from PR: ${{ github.head_ref }}"
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set Test Type
+        id: set_test_type
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PRs, set based on target branch
+            if [ "${{ github.base_ref }}" == "master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType=Scientific"
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType=Plumbing"
+            fi
+          else
+            # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+            fi
+          fi
+
+      - name: Create new method configuration
+        run: |
+          echo "Creating new method configuration for branch: $BRANCH_NAME"
+
+          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
+            create_new_method_config \
+            --workspace-namespace $WORKSPACE_NAMESPACE \
+            --workspace-name "$TESTING_WORKSPACE" \
+            --pipeline_name "$PIPELINE_NAME" \
+            --branch_name "$BRANCH_NAME" \
+            --test_type "$testType" \
+            --sa-json-b64 "$SA_JSON_B64" \
+            --user "$USER")
+
+            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
+        env:
+          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
+          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
+          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
+          USER: ${{ env.USER }}
+
       - name: Cancel Previous GHA Runs
+        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
@@ -93,44 +153,6 @@ jobs:
         run: |
           cd scripts/firecloud_api/
           pip install -r requirements.txt
-
-      - name: Set Test Type
-        id: set_test_type
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, set based on target branch
-            if [ "${{ github.base_ref }}" == "master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType=Scientific"
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType=Plumbing"
-            fi
-          else
-            # # For workflow_dispatch, check manual input first
-            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-            # If no manual input, default based on target branch
-            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-            fi
-          fi
-
-      - name: Set Branch Name
-        id: set_branch
-        run: |
-          if [ -z "${{ github.head_ref }}" ]; then
-            echo "Branch name is missing, using ${GITHUB_REF##*/}"
-            echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-          else
-            echo "Branch name from PR: ${{ github.head_ref }}"
-            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
-          fi
 
       - name: Cancel Previous Terra Submissions
         run: |
@@ -194,28 +216,6 @@ jobs:
       #  env:
       #    DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
       #    GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
-
-
-      - name: Create new method configuration
-        run: |
-          echo "Creating new method configuration for branch: $BRANCH_NAME"
-
-          METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
-            create_new_method_config \
-            --workspace-namespace $WORKSPACE_NAMESPACE \
-            --workspace-name "$TESTING_WORKSPACE" \
-            --pipeline_name "$PIPELINE_NAME" \
-            --branch_name "$BRANCH_NAME" \
-            --test_type "$testType" \
-            --sa-json-b64 "$SA_JSON_B64" \
-            --user "$USER")
-
-            echo "METHOD_CONFIG_NAME=$METHOD_CONFIG_NAME" >> $GITHUB_ENV
-        env:
-          PIPELINE_NAME: ${{ env.PIPELINE_NAME }}
-          TESTING_WORKSPACE: ${{ env.TESTING_WORKSPACE }}
-          WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
-          USER: ${{ env.USER }}
 
       - name: Update test inputs, Upload to Terra, Submit, Monitor and Retrieve Outputs
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -94,6 +94,33 @@ jobs:
           cd scripts/firecloud_api/
           pip install -r requirements.txt
 
+      - name: Set Test Type
+        id: set_test_type
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PRs, set based on target branch
+            if [ "${{ github.base_ref }}" == "master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType=Scientific"
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType=Plumbing"
+            fi
+          else
+            # # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
+              echo "testType=Scientific" >> $GITHUB_ENV
+              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
+            else
+              echo "testType=Plumbing" >> $GITHUB_ENV
+              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
+            fi
+          fi
+
       - name: Set Branch Name
         id: set_branch
         run: |
@@ -114,6 +141,7 @@ jobs:
             --branch_name "${{ env.BRANCH_NAME }}" \
             --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
             --user "${{ env.USER }}" \
+            --test_type $testType \
             cancel_old_submissions
 
       - name: Determine Github Commit Hash
@@ -167,32 +195,6 @@ jobs:
       #    DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
       #    GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
 
-      - name: Set Test Type
-        id: set_test_type
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, set based on target branch
-            if [ "${{ github.base_ref }}" == "master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType=Scientific"
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType=Plumbing"
-            fi
-          else
-            # # For workflow_dispatch, check manual input first
-            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
-              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
-              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
-            # If no manual input, default based on target branch
-            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
-              echo "testType=Scientific" >> $GITHUB_ENV
-              echo "testType is set to Scientific as the branch is ${{ github.ref }} "
-            else
-              echo "testType=Plumbing" >> $GITHUB_ENV
-              echo "testType is set to Plumbing as the branch is ${{ github.ref }}"
-            fi
-          fi
 
       - name: Create new method configuration
         run: |
@@ -290,7 +292,7 @@ jobs:
                 --test_input_file "$test_input_file" \
                 --branch_name "$BRANCH_NAME" \
                 --sa-json-b64 "$SA_JSON_B64" \
-                --test_type "$testType" \
+                --test_type "$TEST_TYPE \
                 --user "$USER"
 
             attempt=1

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -154,75 +154,12 @@ jobs:
           USER: ${{ env.USER }}
 
       - name: Cancel Previous GHA Runs
-        run: |
-          echo "Fetching all running workflow runs..."
-          
-          # Get all running workflow runs for this workflow
-          RUNS=$(gh api repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: (.inputs // {})}')
-          
-          echo "Raw RUNS JSON: $RUNS"
-          
-          for run in $(echo "$RUNS" | jq -c '.'); do
-            RUN_ID=$(echo $run | jq -r '.id')
-            echo "Processing run: $RUN_ID"
-          
-            # Skip the current run
-            if [ "$RUN_ID" = "${{ github.run_id }}" ]; then
-              echo "Skipping current run: $RUN_ID"
-              continue
-            fi
-          
-            # Debug: Show full JSON for the current run
-            echo "Run JSON: $run"
-          
-            # Ensure inputs exist before trying to extract testType
-            if [ "$(echo $run | jq -r '.inputs')" = "{}" ]; then
-              echo "No inputs found for run $RUN_ID"
-              TEST_TYPE=""
-            else
-              TEST_TYPE=$(echo $run | jq -r '.inputs.testType // empty')
-            fi
-          
-            echo "Extracted TEST_TYPE: '$TEST_TYPE'"
-          
-            if [ "$TEST_TYPE" = "Scientific" ]; then
-              echo "Skipping cancellation of Scientific run $RUN_ID (from inputs)"
-              continue
-            fi
-          
-            # 2. If no explicit test type, check if it's targeting master branch
-            BRANCH=$(echo $run | jq -r '.branch')
-            echo "Extracted BRANCH: '$BRANCH'"
-          
-            if [ "$BRANCH" = "master" ]; then
-              echo "Skipping cancellation of Scientific run $RUN_ID (master branch)"
-              continue
-            fi
-          
-            # 3. For PRs, check the target branch
-            EVENT=$(echo $run | jq -r '.event')
-            echo "Extracted EVENT: '$EVENT'"
-          
-            if [ "$EVENT" = "pull_request" ]; then
-              SHA=$(echo $run | jq -r '.head_sha')
-              echo "Fetching target branch for PR with SHA: $SHA"
-          
-              TARGET_BRANCH=$(gh api repos/${{ github.repository }}/pulls --jq ".[] | select(.head.sha==\"$SHA\") | .base.ref")
-              echo "Extracted TARGET_BRANCH: '$TARGET_BRANCH'"
-          
-              if [ "$TARGET_BRANCH" = "master" ]; then
-                echo "Skipping cancellation of Scientific run $RUN_ID (PR to master)"
-                continue
-              fi
-            fi
-          
-            # If we get here, it's not a Scientific test, so cancel it
-            echo "Canceling run $RUN_ID"
-            gh api -X POST repos/${{ github.repository }}/actions/runs/$RUN_ID/cancel
-          done
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
+        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+          all_but_latest: true
+          ignore_sha: true
 
       - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -104,10 +104,10 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             branch="${{ github.base_ref }}"
           else
-            branch="${{ github.ref#refs/heads/ }}"
+            branch="${GITHUB_REF##*/}"
           fi
 
-          if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+          if [ -n "${{ github.event.inputs.testType }}" ]; then
             testType="${{ github.event.inputs.testType }}"
             echo "testType set to $testType from manual input"
           else
@@ -116,6 +116,7 @@ jobs:
           fi
 
           echo "testType=$testType" >> $GITHUB_ENV
+
 
      #- name: Set Test Type
      #  id: set_test_type

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -93,6 +93,17 @@ jobs:
             echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
           fi
 
+      - name: Cancel Previous Runs
+        run: |
+          python3 scripts/firecloud_api/firecloud_api.py \
+            --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
+            --workspace-name "${{ env.TESTING_WORKSPACE }}" \
+            --pipeline_name "${{ env.PIPELINE_NAME }}" \
+            --branch_name "${{ env.BRANCH_NAME }}" \
+            --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
+            --user "${{ env.USER }}" \
+            cancel_old_submissions
+
       - name: Determine Github Commit Hash
         id: determine_github_commit_hash
         run: |

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Fetch Dockstore Workflow Commit Hash
         run: |
           # Wait 5.5 minutes for Dockstore to update
-          sleep 330
+          sleep 3
           
           DOCKSTORE_COMMIT_HASH_FROM_FETCH=$(python scripts/dockstore_api/fetch_dockstore_commit.py \
             $DOCKSTORE_TOKEN \
@@ -149,23 +149,23 @@ jobs:
           DOCKSTORE_PIPELINE_NAME: ${{ env.DOCKSTORE_PIPELINE_NAME }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
 
-      - name: Compare Dockstore and Commit Hashes
-        id: compare_hashes
-        run: |
-          echo "Comparing hashes..."
-          echo "Dockstore Commit Hash: $DOCKSTORE_COMMIT_HASH"
-          echo "GitHub Commit Hash: $GITHUB_COMMIT_HASH"
-
-          if [ "$DOCKSTORE_COMMIT_HASH" != "$GITHUB_COMMIT_HASH" ]; then
-            echo "Error: The Dockstore Commit Hash does not match the GitHub Commit Hash!"
-            echo "Mismatch found: $DOCKSTORE_COMMIT_HASH != $GITHUB_COMMIT_HASH"
-            exit 1
-          else
-            echo "Success: The Dockstore Commit Hash matches the GitHub Commit Hash."
-          fi
-        env:
-          DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
-          GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
+      #- name: Compare Dockstore and Commit Hashes
+      #  id: compare_hashes
+      #  run: |
+      #    echo "Comparing hashes..."
+      #    echo "Dockstore Commit Hash: $DOCKSTORE_COMMIT_HASH"
+      #    echo "GitHub Commit Hash: $GITHUB_COMMIT_HASH"
+#
+      #    if [ "$DOCKSTORE_COMMIT_HASH" != "$GITHUB_COMMIT_HASH" ]; then
+      #      echo "Error: The Dockstore Commit Hash does not match the GitHub Commit Hash!"
+      #      echo "Mismatch found: $DOCKSTORE_COMMIT_HASH != $GITHUB_COMMIT_HASH"
+      #      exit 1
+      #    else
+      #      echo "Success: The Dockstore Commit Hash matches the GitHub Commit Hash."
+      #    fi
+      #  env:
+      #    DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
+      #    GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
 
       - name: Set Test Type
         id: set_test_type

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -147,7 +147,7 @@ jobs:
           USER: ${{ env.USER }}
 
       - name: Cancel Previous GHA Runs
-        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
+        if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
@@ -155,7 +155,7 @@ jobs:
           ignore_sha: true
 
       - name: Cancel Previous Terra Submissions
-        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
+        if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}
         run: |
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -155,6 +155,7 @@ jobs:
           ignore_sha: true
 
       - name: Cancel Previous Terra Submissions
+        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         run: |
           python3 scripts/firecloud_api/firecloud_api.py \
             --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -33,6 +33,10 @@ on:
       testType:
         description: 'Specify the type of test (Plumbing or Scientific)'
         required: false
+        type: choice
+        options:
+          - Plumbing
+          - Scientific
       truthBranch:
         description: 'Specify the branch for truth files (default: master)'
         required: false
@@ -177,8 +181,12 @@ jobs:
               echo "testType=Plumbing"
             fi
           else
-            # For workflow_dispatch, default based on target branch
-            if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            # # For workflow_dispatch, check manual input first
+            if [ ! -z "${{ github.event.inputs.testType }}" ]; then
+              echo "testType=${{ github.event.inputs.testType }}" >> $GITHUB_ENV
+              echo "testType is set to ${{ github.event.inputs.testType }} from manual input"
+            # If no manual input, default based on target branch
+            elif [ "${{ github.ref }}" == "refs/heads/master" ]; then
               echo "testType=Scientific" >> $GITHUB_ENV
               echo "testType is set to Scientific as the branch is ${{ github.ref }} "
             else

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -141,7 +141,7 @@ jobs:
             --branch_name "${{ env.BRANCH_NAME }}" \
             --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
             --user "${{ env.USER }}" \
-            --test_type $testType \
+            --test_type "$testType" \
             cancel_old_submissions
 
       - name: Determine Github Commit Hash
@@ -292,7 +292,7 @@ jobs:
                 --test_input_file "$test_input_file" \
                 --branch_name "$BRANCH_NAME" \
                 --sa-json-b64 "$SA_JSON_B64" \
-                --test_type "$TEST_TYPE \
+                --test_type "$TEST_TYPE" \
                 --user "$USER"
 
             attempt=1

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -148,60 +148,68 @@ jobs:
 
       - name: Cancel Previous GHA Runs
         run: |
+          echo "Fetching all running workflow runs..."
+          
           # Get all running workflow runs for this workflow
           RUNS=$(gh api repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[] | select(.status=="in_progress" or .status=="queued") | {id: .id, event: .event, branch: .head_branch, inputs: .inputs}')
           
+          echo "Raw RUNS JSON: $RUNS"
+
           for run in $(echo "$RUNS" | jq -c '.'); do
             RUN_ID=$(echo $run | jq -r '.id')
-          
+            echo "Processing run: $RUN_ID"
+
             # Skip the current run
             if [ "$RUN_ID" = "${{ github.run_id }}" ]; then
+              echo "Skipping current run: $RUN_ID"
               continue
             fi
-          
+
+            # Debug: Show full JSON for the current run
+            echo "Run JSON: $run"
+
             # Check if it's a Scientific test:
             # 1. Check workflow_dispatch inputs if they exist
             TEST_TYPE=$(echo $run | jq -r '.inputs.testType // empty')
+            echo "Extracted TEST_TYPE: '$TEST_TYPE'"
+
             if [ "$TEST_TYPE" = "Scientific" ]; then
               echo "Skipping cancellation of Scientific run $RUN_ID (from inputs)"
               continue
             fi
-          
+
             # 2. If no explicit test type, check if it's targeting master branch
             BRANCH=$(echo $run | jq -r '.branch')
+            echo "Extracted BRANCH: '$BRANCH'"
+
             if [ "$BRANCH" = "master" ]; then
               echo "Skipping cancellation of Scientific run $RUN_ID (master branch)"
               continue
             fi
-          
+
             # 3. For PRs, check the target branch
-            if [ "$(echo $run | jq -r '.event')" = "pull_request" ]; then
+            EVENT=$(echo $run | jq -r '.event')
+            echo "Extracted EVENT: '$EVENT'"
+
+            if [ "$EVENT" = "pull_request" ]; then
+              SHA=$(echo $run | jq -r '.head_sha')
+              echo "Fetching target branch for PR with SHA: $SHA"
+
               TARGET_BRANCH=$(gh api repos/${{ github.repository }}/pulls --jq ".[] | select(.head.sha==\"$SHA\") | .base.ref")
+              echo "Extracted TARGET_BRANCH: '$TARGET_BRANCH'"
+
               if [ "$TARGET_BRANCH" = "master" ]; then
                 echo "Skipping cancellation of Scientific run $RUN_ID (PR to master)"
                 continue
               fi
             fi
-          
+
             # If we get here, it's not a Scientific test, so cancel it
             echo "Canceling run $RUN_ID"
             gh api -X POST repos/${{ github.repository }}/actions/runs/$RUN_ID/cancel
           done
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Cancel Previous Terra Submissions
-        if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}
-        run: |
-          python3 scripts/firecloud_api/firecloud_api.py \
-            --workspace-namespace "${{ env.WORKSPACE_NAMESPACE }}" \
-            --workspace-name "${{ env.TESTING_WORKSPACE }}" \
-            --pipeline_name "${{ env.PIPELINE_NAME }}" \
-            --branch_name "${{ env.BRANCH_NAME }}" \
-            --sa-json-b64 "${{ secrets.PDT_TESTER_SA_B64 }}" \
-            --user "${{ env.USER }}" \
-            --test_type "$testType" \
-            cancel_old_submissions
 
       - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}

--- a/.github/workflows/test_illumina_genotyping_array.yml
+++ b/.github/workflows/test_illumina_genotyping_array.yml
@@ -87,13 +87,6 @@ jobs:
           cd scripts/firecloud_api/
           pip install -r requirements.txt
 
-      - name: Check inputs
-        run: |
-          echo "Use call cache: ${{ github.event.inputs.useCallCache }}"
-          echo "Update truth: ${{ github.event.inputs.updateTruth }}"
-          echo "Test type: ${{ github.event.inputs.testType }}"
-          echo "Truth branch: ${{ github.event.inputs.truthBranch }}"
-
       - name: Set Branch Name
         id: set_branch
         run: |
@@ -153,14 +146,17 @@ jobs:
           WORKSPACE_NAMESPACE: ${{ env.WORKSPACE_NAMESPACE }}
           USER: ${{ env.USER }}
 
+      # Cancel previous GHA workflows from the same branch (regardless of plumbing or scientific test type)
+      # to avoid running multiple tests at the same time
       - name: Cancel Previous GHA Runs
-        if: contains(env.METHOD_CONFIG_NAME, 'Plumbing')
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
           all_but_latest: true
           ignore_sha: true
 
+      # Abort previous Terra submissions from the same branch to avoid running multiple tests at the same time
+      # Will not abort a Terra submission if it is a scientific test
       - name: Cancel Previous Terra Submissions
         if: ${{ !contains(env.METHOD_CONFIG_NAME, '_Scientific_') }}
         run: |
@@ -191,7 +187,7 @@ jobs:
       - name: Fetch Dockstore Workflow Commit Hash
         run: |
           # Wait 5.5 minutes for Dockstore to update
-          sleep 3
+          sleep 330
           
           DOCKSTORE_COMMIT_HASH_FROM_FETCH=$(python scripts/dockstore_api/fetch_dockstore_commit.py \
             $DOCKSTORE_TOKEN \
@@ -207,23 +203,23 @@ jobs:
           DOCKSTORE_PIPELINE_NAME: ${{ env.DOCKSTORE_PIPELINE_NAME }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
 
-      #- name: Compare Dockstore and Commit Hashes
-      #  id: compare_hashes
-      #  run: |
-      #    echo "Comparing hashes..."
-      #    echo "Dockstore Commit Hash: $DOCKSTORE_COMMIT_HASH"
-      #    echo "GitHub Commit Hash: $GITHUB_COMMIT_HASH"
-#
-      #    if [ "$DOCKSTORE_COMMIT_HASH" != "$GITHUB_COMMIT_HASH" ]; then
-      #      echo "Error: The Dockstore Commit Hash does not match the GitHub Commit Hash!"
-      #      echo "Mismatch found: $DOCKSTORE_COMMIT_HASH != $GITHUB_COMMIT_HASH"
-      #      exit 1
-      #    else
-      #      echo "Success: The Dockstore Commit Hash matches the GitHub Commit Hash."
-      #    fi
-      #  env:
-      #    DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
-      #    GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
+      - name: Compare Dockstore and Commit Hashes
+        id: compare_hashes
+        run: |
+          echo "Comparing hashes..."
+          echo "Dockstore Commit Hash: $DOCKSTORE_COMMIT_HASH"
+          echo "GitHub Commit Hash: $GITHUB_COMMIT_HASH"
+
+          if [ "$DOCKSTORE_COMMIT_HASH" != "$GITHUB_COMMIT_HASH" ]; then
+            echo "Error: The Dockstore Commit Hash does not match the GitHub Commit Hash!"
+            echo "Mismatch found: $DOCKSTORE_COMMIT_HASH != $GITHUB_COMMIT_HASH"
+            exit 1
+          else
+            echo "Success: The Dockstore Commit Hash matches the GitHub Commit Hash."
+          fi
+        env:
+          DOCKSTORE_COMMIT_HASH: ${{ env.DOCKSTORE_COMMIT_HASH }}
+          GITHUB_COMMIT_HASH: ${{ env.GITHUB_COMMIT_HASH }}
 
       - name: Update test inputs, Upload to Terra, Submit, Monitor and Retrieve Outputs
         run: |

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -375,7 +375,6 @@ class FirecloudAPI:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
                 config_name = submission.get('methodConfigurationName', '')
-                logging.info(f"config_name: {config_name}")
                 if config_name.startswith(method_config_name):
                     active_submissions.append(submission)
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -370,8 +370,9 @@ class FirecloudAPI:
                 else:
                     active_submissions.append(submission)
 
-        #print the active submissions
-        print(f"Active submissions: {json.dumps(active_submissions, indent=2)}
+        logging.info(f"Found {len(active_submissions)} active submissions")
+        logging.info(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
+
         return active_submissions
 
     def cancel_submission(self, submission_id):

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -171,7 +171,6 @@ class FirecloudAPI:
         """
 
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
-        print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 
         token = self.get_user_token(self.delegated_creds)

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -374,6 +374,8 @@ class FirecloudAPI:
         submissions = response.json()
         active_submissions = []
 
+        logging.info(f"Method config name: {method_config_name}")
+
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
@@ -383,6 +385,11 @@ class FirecloudAPI:
                 else:
                     active_submissions.append(submission)
 
+        # logging info for active submissions
+        if active_submissions:
+            logging.info(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
+        else:
+            logging.info("No active submissions found.")
         return active_submissions
 
     def cancel_submission(self, submission_id):

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -371,6 +371,8 @@ class FirecloudAPI:
         submissions = response.json()
         active_submissions = []
 
+        #logigng info method_config_name
+        logging.info(f"method_config_name: {method_config_name}")
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -370,6 +370,8 @@ class FirecloudAPI:
                 else:
                     active_submissions.append(submission)
 
+        #print the active submissions
+        print(f"Active submissions: {json.dumps(active_submissions, indent=2)}
         return active_submissions
 
     def cancel_submission(self, submission_id):

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -369,6 +369,11 @@ class FirecloudAPI:
             return []
 
         submissions = response.json()
+        #list out all the methodConfigurationName from submissions
+        method_config_names = [submission.get('methodConfigurationName') for submission in submissions]
+        logging.info(f" the method_config_names from submissions: {method_config_names}")
+
+
         active_submissions = []
 
         #logigng info method_config_name

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -360,6 +360,7 @@ class FirecloudAPI:
 
         submissions = response.json()
         active_submissions = []
+        logging.info(f"Full API Response: {json.dumps(submissions, indent=2)}")
 
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -369,15 +369,8 @@ class FirecloudAPI:
             return []
 
         submissions = response.json()
-        #list out all the methodConfigurationName from submissions
-        method_config_names = [submission.get('methodConfigurationName') for submission in submissions]
-        logging.info(f" the method_config_names from submissions: {method_config_names}")
-
-
         active_submissions = []
 
-        #logigng info method_config_name
-        logging.info(f"method_config_name: {method_config_name}")
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -542,11 +542,6 @@ if __name__ == "__main__":
         if not all([args.pipeline_name, args.branch_name]):
             parser.error("Arguments --pipeline_name and --branch_name are required for 'cancel_old_submissions'")
 
-        # Get the current commit hash from the environment or as an argument
-        current_commit = os.environ.get('GITHUB_SHA')
-        if not current_commit:
-            parser.error("GITHUB_SHA environment variable is required for 'cancel_old_submissions'")
-
         # Cancel old submissions
         cancelled_count = api.cancel_old_submissions(
             args.pipeline_name,

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -115,7 +115,6 @@ class FirecloudAPI:
 
         :param branch_name: The branch name
         :param pipeline_name: The name of the pipeline
-        :param test_type: The type of test (Scientific or Plumbing)
         :return: The name of the created method configuration or None if failed
         """
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -171,6 +171,8 @@ class FirecloudAPI:
         """
 
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
+        print(f" the Test type: {test_type}")
+        print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 
         token = self.get_user_token(self.delegated_creds)
@@ -317,6 +319,18 @@ class FirecloudAPI:
         else:
             logging.error(f"Failed to retrieve workflow outputs. Status code: {response.status_code}")
             return None, None
+
+    #def gsutil_copy(self, source, destination):
+    #    #client = storage.Client()  # Uses GOOGLE_APPLICATION_CREDENTIALS implicitly
+    #    source_bucket_name, source_blob_name = source.replace("gs://", "").split("/", 1)
+    #    destination_bucket_name, destination_blob_name = destination.replace("gs://", "").split("/", 1)
+
+    #    source_bucket = self.storage_client.bucket(source_bucket_name)
+    #    source_blob = source_bucket.blob(source_blob_name)
+    #    destination_bucket = self.storage_client.bucket(destination_bucket_name)
+
+    #    source_bucket.copy_blob(source_blob, destination_bucket, destination_blob_name)
+
     def delete_method_config(self, method_config_name):
         """
         Deletes a method configuration from the workspace.
@@ -359,7 +373,6 @@ class FirecloudAPI:
 
         submissions = response.json()
         active_submissions = []
-        logging.info(f"Full API Response: {json.dumps(submissions, indent=2)}")
 
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
@@ -369,9 +382,6 @@ class FirecloudAPI:
                         active_submissions.append(submission)
                 else:
                     active_submissions.append(submission)
-
-        logging.info(f"Found {len(active_submissions)} active submissions")
-        logging.info(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
 
         return active_submissions
 
@@ -399,12 +409,7 @@ class FirecloudAPI:
         Returns the number of cancelled submissions.
         """
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, args.test_type)
-        #print the method config name
-        print(f"The Method config name: {method_config_name}")
         active_submissions = self.get_active_submissions(method_config_name)
-        #print the active submissions
-        print(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
-
         cancelled_count = 0
 
         for submission in active_submissions:
@@ -576,7 +581,6 @@ if __name__ == "__main__":
             args.branch_name
         )
         print(f"Cancelled {cancelled_count} old submissions")
-
 
 
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -380,9 +380,7 @@ class FirecloudAPI:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
                 #if method_config_name:
-                #    if submission.get('methodConfigurationName') == method_config_name:
-                active_submissions.append(submission)
-            else:
+                #   if submission.get('methodConfigurationName') == method_config_name:
                 active_submissions.append(submission)
 
         # logging info for active submissions

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -9,7 +9,6 @@ from google.auth import credentials
 import argparse
 import logging
 import time
-import os
 
 # Configure logging to display INFO level and above messages
 logging.basicConfig(

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -318,18 +318,6 @@ class FirecloudAPI:
         else:
             logging.error(f"Failed to retrieve workflow outputs. Status code: {response.status_code}")
             return None, None
-
-    #def gsutil_copy(self, source, destination):
-    #    #client = storage.Client()  # Uses GOOGLE_APPLICATION_CREDENTIALS implicitly
-    #    source_bucket_name, source_blob_name = source.replace("gs://", "").split("/", 1)
-    #    destination_bucket_name, destination_blob_name = destination.replace("gs://", "").split("/", 1)
-
-    #    source_bucket = self.storage_client.bucket(source_bucket_name)
-    #    source_blob = source_bucket.blob(source_blob_name)
-    #    destination_bucket = self.storage_client.bucket(destination_bucket_name)
-
-    #    source_bucket.copy_blob(source_blob, destination_bucket, destination_blob_name)
-
     def delete_method_config(self, method_config_name):
         """
         Deletes a method configuration from the workspace.
@@ -408,7 +396,12 @@ class FirecloudAPI:
         Returns the number of cancelled submissions.
         """
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, args.test_type)
+        #print the method config name
+        print(f"The Method config name: {method_config_name}")
         active_submissions = self.get_active_submissions(method_config_name)
+        #print the active submissions
+        print(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
+
         cancelled_count = 0
 
         for submission in active_submissions:

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -381,9 +381,10 @@ class FirecloudAPI:
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
-                #if method_config_name:
-                #   if submission.get('methodConfigurationName') == method_config_name:
-                active_submissions.append(submission)
+                config_name = submission.get('methodConfigurationName', '')
+                logging.info(f"config_name: {config_name}")
+                if config_name.startswith(method_config_name):
+                    active_submissions.append(submission)
 
         return active_submissions
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -171,6 +171,7 @@ class FirecloudAPI:
         """
 
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
+        print(f" the Test type: {test_type}")
         print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -170,8 +170,6 @@ class FirecloudAPI:
         """
 
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
-        print(f" the Test type: {test_type}")
-        print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 
         token = self.get_user_token(self.delegated_creds)
@@ -373,20 +371,13 @@ class FirecloudAPI:
         submissions = response.json()
         active_submissions = []
 
-        logging.info(f"Method config name: {method_config_name}")
-
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
-                #if method_config_name:
-                #   if submission.get('methodConfigurationName') == method_config_name:
-                active_submissions.append(submission)
+                if method_config_name:
+                   if submission.get('methodConfigurationName') == method_config_name:
+                       active_submissions.append(submission)
 
-        # logging info for active submissions
-        if active_submissions:
-            logging.info(f"Active submissions: {json.dumps(active_submissions, indent=2)}")
-        else:
-            logging.info("No active submissions found.")
         return active_submissions
 
     def cancel_submission(self, submission_id):

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -171,7 +171,6 @@ class FirecloudAPI:
         """
 
         method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
-        print(f" the Test type: {test_type}")
         print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -364,7 +364,6 @@ class FirecloudAPI:
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
-                # If method_config_name is specified, filter by it
                 if method_config_name:
                     if submission.get('methodConfigurationName') == method_config_name:
                         active_submissions.append(submission)

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -376,9 +376,9 @@ class FirecloudAPI:
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
-                if method_config_name:
-                   if submission.get('methodConfigurationName') == method_config_name:
-                       active_submissions.append(submission)
+                #if method_config_name:
+                #   if submission.get('methodConfigurationName') == method_config_name:
+                active_submissions.append(submission)
 
         return active_submissions
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -379,11 +379,11 @@ class FirecloudAPI:
         for submission in submissions:
             # Check if submission is active (not Done, Aborted, or Failed)
             if submission['status'] in ['Submitted', 'Running', 'Queued']:
-                if method_config_name:
-                    if submission.get('methodConfigurationName') == method_config_name:
-                        active_submissions.append(submission)
-                else:
-                    active_submissions.append(submission)
+                #if method_config_name:
+                #    if submission.get('methodConfigurationName') == method_config_name:
+                active_submissions.append(submission)
+            else:
+                active_submissions.append(submission)
 
         # logging info for active submissions
         if active_submissions:

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -9,7 +9,7 @@ from google.auth import credentials
 import argparse
 import logging
 import time
-
+import os
 
 # Configure logging to display INFO level and above messages
 logging.basicConfig(
@@ -342,6 +342,70 @@ class FirecloudAPI:
             logging.error(f"Response body: {response.text}")
             return False
 
+    def get_active_submissions(self, method_config_name=None):
+        """
+        Get all active workflow submissions for the workspace.
+        Optionally filter by method configuration name.
+        """
+        url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/submissions"
+        token = self.get_user_token(self.delegated_creds)
+        headers = self.build_auth_headers(token)
+
+        response = requests.get(url, headers=headers)
+
+        if response.status_code != 200:
+            logging.error(f"Failed to get submissions. Status code: {response.status_code}")
+            logging.error(f"Response body: {response.text}")
+            return []
+
+        submissions = response.json()
+        active_submissions = []
+
+        for submission in submissions:
+            # Check if submission is active (not Done, Aborted, or Failed)
+            if submission['status'] in ['Submitted', 'Running', 'Queued']:
+                # If method_config_name is specified, filter by it
+                if method_config_name:
+                    if submission.get('methodConfigurationName') == method_config_name:
+                        active_submissions.append(submission)
+                else:
+                    active_submissions.append(submission)
+
+        return active_submissions
+
+    def cancel_submission(self, submission_id):
+        """
+        Cancel a specific workflow submission.
+        """
+        url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/submissions/{submission_id}"
+        token = self.get_user_token(self.delegated_creds)
+        headers = self.build_auth_headers(token)
+
+        response = requests.delete(url, headers=headers)
+
+        if response.status_code not in [204]:
+            logging.error(f"Failed to cancel submission {submission_id}. Status code: {response.status_code}")
+            logging.error(f"Response body: {response.text}")
+            return False
+
+        logging.info(f"Successfully cancelled submission {submission_id}")
+        return True
+
+    def cancel_old_submissions(self, pipeline_name, branch_name):
+        """
+        Cancel all active submissions for a pipeline's method configuration.
+        Returns the number of cancelled submissions.
+        """
+        method_config_name = f"{pipeline_name}_{branch_name}"
+        active_submissions = self.get_active_submissions(method_config_name)
+        cancelled_count = 0
+
+        for submission in active_submissions:
+            if self.cancel_submission(submission['submissionId']):
+                cancelled_count += 1
+                logging.info(f"Cancelled submission {submission['submissionId']}")
+
+        return cancelled_count
 
 
     def main(self):
@@ -406,7 +470,7 @@ if __name__ == "__main__":
     parser.add_argument("--source", help="Source GCS path for gsutil copy")
     parser.add_argument("--destination", help="Destination GCS path for gsutil copy")
     parser.add_argument("--method_config_name", help="Name of the method configuration to delete")
-    parser.add_argument("action", choices=["submit_job", "upload_test_inputs", "poll_job_status", "get_workflow_outputs", "create_new_method_config", "delete_method_config"],
+    parser.add_argument("action", choices=["submit_job", "upload_test_inputs", "poll_job_status", "get_workflow_outputs", "create_new_method_config", "delete_method_config", "cancel_old_submissions"],
                         help="Action to perform: 'submit_job', 'upload_test_inputs', 'poll_job_status', 'get_workflow_outputs',  'create_new_method_config', or 'delete_method_config'")
 
     args = parser.parse_args()
@@ -475,7 +539,21 @@ if __name__ == "__main__":
                 logging.info("Method configuration deleted successfully.")
             else:
                 logging.error("Failed to delete method configuration.")
+    elif args.action == "cancel_old_submissions":
+        if not all([args.pipeline_name, args.branch_name]):
+            parser.error("Arguments --pipeline_name and --branch_name are required for 'cancel_old_submissions'")
 
+        # Get the current commit hash from the environment or as an argument
+        current_commit = os.environ.get('GITHUB_SHA')
+        if not current_commit:
+            parser.error("GITHUB_SHA environment variable is required for 'cancel_old_submissions'")
+
+        # Cancel old submissions
+        cancelled_count = api.cancel_old_submissions(
+            args.pipeline_name,
+            args.branch_name
+        )
+        print(f"Cancelled {cancelled_count} old submissions")
 
 
 

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -159,15 +159,18 @@ class FirecloudAPI:
             return None
 
 
-    def upload_test_inputs(self, pipeline_name, test_inputs, branch_name):
+    def upload_test_inputs(self, pipeline_name, test_inputs, branch_name, test_type):
         """
         Uploads test inputs to the workspace via Firecloud API.
 
         :param test_inputs: JSON data containing test inputs
+        :param pipeline_name: The name of the pipeline
+        :param branch_name: The name of the branch
+        :param test_type: The type of test (Scientific or Plumbing)
         :return: True if successful, False otherwise
         """
 
-        method_config_name = self.get_method_config_name(pipeline_name, branch_name, args.test_type)
+        method_config_name = self.get_method_config_name(pipeline_name, branch_name, test_type)
         print(f"Method config name: {method_config_name}")
         url = f"{self.base_url}/workspaces/{self.namespace}/{quote(self.workspace_name)}/method_configs/{self.namespace}/{method_config_name}"
 
@@ -441,7 +444,7 @@ class FirecloudAPI:
             result = self.delete_method_config(method_config_name)
             print(str(result).lower())
         elif self.action == "upload_test_inputs":
-            success = self.upload_test_inputs(self.pipeline_name, self.test_input_file, self.branch_name)
+            success = self.upload_test_inputs(self.pipeline_name, self.test_input_file, self.branch_name, self.test_type)
             if success:
                 logging.info("Test inputs uploaded successfully.")
             else:
@@ -520,7 +523,7 @@ if __name__ == "__main__":
         if not args.pipeline_name or not args.test_input_file or not args.branch_name:
             parser.error("Arguments --pipeline_name, --test_input_file, and --branch_name are required for 'upload_test_inputs'")
         # Call the function to upload test inputs
-        api.upload_test_inputs(args.pipeline_name, args.test_input_file, args.branch_name)
+        api.upload_test_inputs(args.pipeline_name, args.test_input_file, args.branch_name, args.test_type)
 
     elif args.action == "submit_job":
         # Check for required argument for submit_job action


### PR DESCRIPTION
### Description


- Modified method configuration naming to include test type: `${PIPELINE_NAME}_${testType}_${BRANCH_NAME}`
- ` Cancel Previous GHA Runs `aborts running GHA workflows from the same branch (regardless of scientific or plumbing test type)
- `Cancel Previous Terra Submission`s aborts queued or running Terra submissions from the same branch. **Only** plumbing tests will be automatically aborted. Scientific tests will not be aborted. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
