### PR TITLE
moving the sleep in gha framework

### DIFF
--- a/.github/workflows/warp_test_workflow.yml
+++ b/.github/workflows/warp_test_workflow.yml
@@ -116,6 +116,10 @@ jobs:
       # Purpose: Sets up the testing configuration in Terra workspace
       - name: Create new method configuration
         run: |
+          # Wait 5.5 minutes for Dockstore to update
+          echo "Waiting for Dockstore to update..."
+          sleep 330
+          
           echo "Creating new method configuration for branch: $BRANCH_NAME"
 
           METHOD_CONFIG_NAME=$(python3 scripts/firecloud_api/firecloud_api.py \
@@ -177,8 +181,6 @@ jobs:
       - name: Compare Dockstore and Github Commit Hashes with Retry
         id: compare_hashes
         run: |
-          # Wait 5.5 minutes for Dockstore to update
-          sleep 330
 
           MAX_WAIT_TIME=$((15 * 60)) # 15 minutes in seconds
           WAIT_INTERVAL=60          # 1 minute in seconds


### PR DESCRIPTION
### Description

We need to move the 'delay' portion of the code higher up in the workflow to account for the time it takes for Dockstore to recognize a newly pushed branch. Right now, the delay isn't happening early enough, which causes issues with branch detection. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
