### PR TITLE
remove 15 min timeout from poll_job_status

### DIFF
--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -391,6 +391,7 @@ class FirecloudAPI:
                 # Check if the submission is complete
                 submission_status = status_data.get("status", "")
                 if submission_status == "Done":
+                    logging.info("Submission is done.")
                     break
 
                 # Wait for 20 seconds before polling again
@@ -404,6 +405,7 @@ class FirecloudAPI:
                 retry_delay = min(retry_delay * 1.5, max_retry_delay)
 
         return workflow_status_map
+
     def quote_values(self, inputs_json):
         """
         Format JSON values with proper handling of nested structures

--- a/scripts/firecloud_api/firecloud_api.py
+++ b/scripts/firecloud_api/firecloud_api.py
@@ -338,19 +338,12 @@ class FirecloudAPI:
         workflow_status_map = {}
 
         # Set up retry parameters
-        max_retry_duration = 15 * 60  # 15 minutes in seconds
         start_time = time.time()
         retry_delay = 5  # Start with a 5-second delay between retries
         max_retry_delay = 30  # Maximum retry delay in seconds
 
         # Continuously poll the status of the submission until completion
         while True:
-            # Check if we've exceeded the maximum retry duration
-            current_time = time.time()
-            if current_time - start_time > max_retry_duration:
-                logging.error(f"Exceeded maximum retry duration of {max_retry_duration/60} minutes.")
-                return workflow_status_map
-
             try:
                 # Get the token and headers
                 token = self.get_user_token(self.delegated_creds)


### PR DESCRIPTION
### Description

The poll_job_status() function had a 15 minute timeout that was causing tests to pass after 15 minutes no matter whether the actual workflow [succeeded](https://github.com/broadinstitute/warp/actions/runs/13554917068/job/37886991465?pr=1333) or [failed](https://github.com/broadinstitute/warp/actions/runs/13554917055/job/37886990984?pr=1333) in Terra. 

Here we remove this 15 minute timeout in the poll_job_status() function to allow workflows to proceed indefinitely until they complete.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
