### PR TITLE
TSPS-462 - Change ImputationBeagle to pull dockers from GAR

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 Pipeline Name	Version	Date of Last Commit
-ArrayImputationQuotaConsumed	 1.0.1	2025-03-28 
-ImputationBeagle	 1.0.1	2025-03-28 
-Imputation	 1.1.17	2025-03-28 
+ArrayImputationQuotaConsumed	 1.0.1	2025-04-01
+ImputationBeagle	 1.0.1	2025-04-01
+Imputation	 1.1.17	2025-04-01
 WholeGenomeReprocessing	 3.3.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 
 CramToUnmappedBams	 1.1.3	2024-08-02 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 Pipeline Name	Version	Date of Last Commit
-ArrayImputationQuotaConsumed	 1.0.0	2025-02-24 
-ImputationBeagle	 1.0.1	2025-03-27 
-Imputation	 1.1.16	2025-02-24 
+ArrayImputationQuotaConsumed	 1.0.1	2025-03-28 
+ImputationBeagle	 1.0.1	2025-03-28 
+Imputation	 1.1.17	2025-03-28 
 WholeGenomeReprocessing	 3.3.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 
 CramToUnmappedBams	 1.1.3	2024-08-02 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,6 +1,6 @@
 Pipeline Name	Version	Date of Last Commit
 ArrayImputationQuotaConsumed	 1.0.0	2025-02-24 
-ImputationBeagle	 1.0.0	2025-02-26 
+ImputationBeagle	 1.0.1	2025-03-27 
 Imputation	 1.1.16	2025-02-24 
 WholeGenomeReprocessing	 3.3.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 Pipeline Name	Version	Date of Last Commit
-ArrayImputationQuotaConsumed	 1.0.1	2025-04-01
-ImputationBeagle	 1.0.1	2025-04-01
-Imputation	 1.1.17	2025-04-01
+ArrayImputationQuotaConsumed	 1.0.1	2025-04-01 
+ImputationBeagle	 1.0.1	2025-04-01 
+Imputation	 1.1.17	2025-04-01 
 WholeGenomeReprocessing	 3.3.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 
 CramToUnmappedBams	 1.1.3	2024-08-02 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.17
+2025-03-28 (Date of Last Commit)
+
+* Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.
+
 # 1.1.16
 2025-02-24 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,5 +1,5 @@
 # 1.1.17
-2025-03-28 (Date of Last Commit)
+2025-04-01 (Date of Last Commit)
 
 * Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.
 

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Imputation {
 
-  String pipeline_version = "1.1.16"
+  String pipeline_version = "1.1.17"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1
+2025-03-28 (Date of Last Commit)
+
+* Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.
+
 # 1.0.0
 2025-02-24 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.1
-2025-03-28 (Date of Last Commit)
+2025-04-01 (Date of Last Commit)
 
 * Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "../../../../tasks/broad/ImputationTasks.wdl" as tasks
 
 workflow QuotaConsumed {
-    String pipeline_version = "1.0.0"
+    String pipeline_version = "1.0.1"
 
     input {
         Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.1
-2025-03-28 (Date of Last Commit)
+2025-04-01 (Date of Last Commit)
 
 * Have ImputationBeagle use gatk docker in GAR rather than pull it from dockerhub
 * Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,3 +1,9 @@
+# 1.0.1
+2025-03-28 (Date of Last Commit)
+
+* Have ImputationBeagle use gatk docker in GAR rather than pull it from dockerhub
+* Update Imputation Tasks to use dockers (ubuntu and tidyverse) that have been moved to GAR.
+
 # 1.0.0
 2025-02-26 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/ImputationBeagleTasks.wdl" as beagleTasks
 
 workflow ImputationBeagle {
 
-  String pipeline_version = "1.0.0"
+  String pipeline_version = "1.0.1"
 
   input {
     Int chunkLength = 25000000
@@ -24,8 +24,8 @@ workflow ImputationBeagle {
     String bed_suffix = ".bed"
     String bref3_suffix = ".bref3"
 
-    String gatk_docker = "broadinstitute/gatk:4.6.0.0"
-    String ubuntu_docker = "ubuntu:20.04"
+    String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
+    String ubuntu_docker = "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
 
     Int? error_count_override
   }

--- a/tasks/broad/ImputationBeagleTasks.wdl
+++ b/tasks/broad/ImputationBeagleTasks.wdl
@@ -174,7 +174,7 @@ task ErrorWithMessageIfErrorCountNotZero {
   >>>
 
   runtime {
-    docker: "ubuntu:20.04"
+    docker: "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
     preemptible: 3
   }
   output {

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -5,7 +5,7 @@ task CalculateChromosomeLength {
     File ref_dict
     String chrom
 
-    String ubuntu_docker = "ubuntu:20.04"
+    String ubuntu_docker = "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
     Int memory_mb = 2000
     Int cpu = 1
     Int disk_size_gb = ceil(2*size(ref_dict, "GiB")) + 5
@@ -33,7 +33,7 @@ task GetMissingContigList {
     File ref_dict
     File included_contigs
 
-    String ubuntu_docker = "ubuntu:20.04"
+    String ubuntu_docker = "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
     Int memory_mb = 2000
     Int cpu = 1
     Int disk_size_gb = ceil(2*size(ref_dict, "GiB")) + 5
@@ -550,7 +550,7 @@ task AggregateImputationQCMetrics {
     Int nSamples
     String basename
 
-    String rtidyverse_docker = "rocker/tidyverse:4.1.0"
+    String rtidyverse_docker = "us.gcr.io/broad-dsde-methods/rocker/tidyverse:4.1.0"
     Int cpu = 1
     Int memory_mb = 2000
     Int disk_size_gb = ceil(size(infoFile, "GiB")) + 10
@@ -598,7 +598,7 @@ task StoreChunksInfo {
     Array[Boolean] valids
     String basename
 
-    String rtidyverse_docker = "rocker/tidyverse:4.1.0"
+    String rtidyverse_docker = "us.gcr.io/broad-dsde-methods/rocker/tidyverse:4.1.0"
     Int cpu = 1
     Int memory_mb = 2000
     Int disk_size_gb = 10
@@ -635,7 +635,7 @@ task MergeImputationQCMetrics {
     Array[File] metrics
     String basename
 
-    String rtidyverse_docker = "rocker/tidyverse:4.1.0"
+    String rtidyverse_docker = "us.gcr.io/broad-dsde-methods/rocker/tidyverse:4.1.0"
     Int cpu = 1
     Int memory_mb = 2000
     Int disk_size_gb = ceil(size(metrics, "GiB")) + 10
@@ -883,7 +883,7 @@ task FindSitesUniqueToFileTwoOnly {
     File file1
     File file2
 
-    String ubuntu_docker = "ubuntu:20.04"
+    String ubuntu_docker = "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
     Int cpu = 1
     Int memory_mb = 4000
     Int disk_size_gb = ceil(size(file1, "GiB") + 2*size(file2, "GiB")) + 10

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -43,6 +43,7 @@ task GetMissingContigList {
     set -e -o pipefail
 
     grep "@SQ" ~{ref_dict} | sed 's/.*SN://' | sed 's/\t.*//' > contigs.txt
+
     awk 'NR==FNR{arr[$0];next} !($0 in arr)' ~{included_contigs} contigs.txt > missing_contigs.txt
   >>>
 


### PR DESCRIPTION
### Description

TSPS-462.
Update ImputationBeagle to pull dockers from GAR

Previously ImputationBeagle was pulling the gatk docker and other dockers from DockerHub. We ran into several cases where it failed to pull from DockerHub (with being outside of allowed number of retries).

This PR updates the code to pull gatk, ubuntu and one other docker from GAR

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
