### PR TITLE
TSPS-462 Update Imputation Tasks to not request external IP addresses (use run…

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 Pipeline Name	Version	Date of Last Commit
-ArrayImputationQuotaConsumed	 1.0.1	2025-04-01 
-ImputationBeagle	 1.0.1	2025-04-01 
-Imputation	 1.1.17	2025-04-01 
+ArrayImputationQuotaConsumed	 1.0.2	2025-04-07 
+ImputationBeagle	 1.0.2	2025-04-07 
+Imputation	 1.1.18	2025-04-07 
 WholeGenomeReprocessing	 3.3.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 
 CramToUnmappedBams	 1.1.3	2024-08-02 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.1.18
+2025-04-07 (Date of Last Commit)
+
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+
 # 1.1.17
 2025-04-01 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,7 +1,7 @@
 # 1.1.18
 2025-04-07 (Date of Last Commit)
 
-* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true').
 
 # 1.1.17
 2025-04-01 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Imputation {
 
-  String pipeline_version = "1.1.17"
+  String pipeline_version = "1.1.18"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.2
 2025-04-07 (Date of Last Commit)
 
-* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true').
 
 # 1.0.1
 2025-04-01 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2025-04-07 (Date of Last Commit)
+
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+
 # 1.0.1
 2025-04-01 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "../../../../tasks/broad/ImputationTasks.wdl" as tasks
 
 workflow QuotaConsumed {
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
         Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.2
 2025-04-07 (Date of Last Commit)
 
-* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true').
 
 # 1.0.1
 2025-04-01 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2025-04-07 (Date of Last Commit)
+
+* Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')
+
 # 1.0.1
 2025-04-01 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/ImputationBeagleTasks.wdl" as beagleTasks
 
 workflow ImputationBeagle {
 
-  String pipeline_version = "1.0.1"
+  String pipeline_version = "1.0.2"
 
   input {
     Int chunkLength = 25000000

--- a/tasks/broad/ImputationBeagleTasks.wdl
+++ b/tasks/broad/ImputationBeagleTasks.wdl
@@ -34,6 +34,7 @@ task CountVariantsInChunks {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -64,6 +65,7 @@ task CheckChunks {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -111,6 +113,7 @@ task Phase {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -156,6 +159,7 @@ task Impute {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -176,6 +180,7 @@ task ErrorWithMessageIfErrorCountNotZero {
   runtime {
     docker: "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
     preemptible: 3
+    noAddress: true
   }
   output {
     Boolean done = true
@@ -209,6 +214,7 @@ task CreateVcfIndex {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File vcf = "~{vcf_basename}"

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -22,6 +22,7 @@ task CalculateChromosomeLength {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     Int chrom_length = read_int(stdout())
@@ -52,6 +53,7 @@ task GetMissingContigList {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 
   output {
@@ -94,6 +96,7 @@ task GenerateChunk {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
   parameter_meta {
     vcf: {
@@ -141,6 +144,7 @@ task CountVariantsInChunks {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 }
 
@@ -180,6 +184,7 @@ task CheckChunks {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 }
 
@@ -218,6 +223,7 @@ task PhaseVariantsEagle {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 }
 
@@ -264,6 +270,7 @@ task Minimac4 {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 }
 
@@ -297,6 +304,7 @@ task GatherVcfs {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
   output {
     File output_vcf = "~{output_vcf_basename}.vcf.gz"
@@ -331,6 +339,7 @@ task ReplaceHeader {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 
   output {
@@ -370,6 +379,7 @@ task UpdateHeader {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File output_vcf = "~{basename}.vcf.gz"
@@ -405,6 +415,7 @@ task RemoveSymbolicAlleles {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -435,6 +446,7 @@ task SeparateMultiallelics {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -469,6 +481,7 @@ task OptionalQCSites {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
   output {
     File output_vcf = "~{output_vcf_basename}.vcf.gz"
@@ -511,6 +524,7 @@ task MergeSingleSampleVcfs {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
   output {
     File output_vcf = "~{output_vcf_basename}.vcf.gz"
@@ -539,6 +553,7 @@ task CountSamples {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     Int nSamples = read_int(stdout())
@@ -583,6 +598,7 @@ task AggregateImputationQCMetrics {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File aggregated_metrics = "~{basename}_aggregated_imputation_metrics.tsv"
@@ -623,6 +639,7 @@ task StoreChunksInfo {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File chunks_info = "~{basename}_chunk_info.tsv"
@@ -661,6 +678,7 @@ task MergeImputationQCMetrics {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File aggregated_metrics = "~{basename}_aggregated_imputation_metrics.tsv"
@@ -700,6 +718,7 @@ task SubsetVcfToRegion {
     disks: "local-disk ${disk_size_gb} HDD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
 
   parameter_meta {
@@ -741,6 +760,7 @@ task SetIDs {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File output_vcf = "~{output_basename}.vcf.gz"
@@ -770,6 +790,7 @@ task ExtractIDs {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
 }
 
@@ -811,6 +832,7 @@ task SelectVariantsByIds {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File output_vcf = "~{basename}.vcf.gz"
@@ -840,6 +862,7 @@ task RemoveAnnotations {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File output_vcf = "~{basename}.vcf.gz"
@@ -872,6 +895,7 @@ task InterleaveVariants {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File output_vcf = "~{basename}.vcf.gz"
@@ -900,6 +924,7 @@ task FindSitesUniqueToFileTwoOnly {
     memory: "${memory_mb} MiB"
     cpu: cpu
     preemptible: 3
+    noAddress: true
   }
   output {
     File missing_sites = "missing_sites.ids"
@@ -932,6 +957,7 @@ task SplitMultiSampleVcf {
     disks: "local-disk ${disk_size_gb} SSD"
     memory: "${memory_mb} MiB"
     cpu: cpu
+    noAddress: true
   }
   output {
     Array[File] single_sample_vcfs = glob("out_dir/*.vcf.gz")


### PR DESCRIPTION
TSPS-462 Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')

### Description

TSPS-462 Update Imputation Tasks to not request external IP addresses (use runtime attribute 'noAddress: true')


----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
