### PR TITLE
Lk ancestry v8

### DIFF
--- a/all_of_us/ancestry/determine_hq_sites_intersection.changelog.md
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.changelog.md
@@ -2,6 +2,8 @@
 2025-04-16 (Date of Last Commit)
 
 * Workflow version used for All Of Us Echo V4 R2 (V8 releaes)
+* Added a pipeline_version string
+* Updated the SelectVariants function and runtime parameters
 
 # beta release
 2025-04-15 (Date of Last Commit)

--- a/all_of_us/ancestry/determine_hq_sites_intersection.changelog.md
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.changelog.md
@@ -1,4 +1,9 @@
+# aou-8.0.0
+2025-04-16 (Date of Last Commit)
+
+* Workflow version used for All Of Us Echo V4 R2 (V8 releaes)
+
 # beta release
 2025-04-15 (Date of Last Commit)
 
-First iteration of the pipeline through Dockstore. 
+* First iteration of the pipeline through Dockstore. 

--- a/all_of_us/ancestry/determine_hq_sites_intersection.wdl
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.wdl
@@ -1,6 +1,6 @@
 version 1.0
 # Determine the high-quality sites as an intersection of the training high quality sites (from determine hq_sites.wdl) and
-#  the input data (ordered_vcf_shards).  As a reminder, HQ sites can only be biallelic SNPs.
+#  the input data (ordered_vcf_shards).
 workflow determine_hq_sites_intersection {
     input {
 
@@ -34,6 +34,7 @@ workflow determine_hq_sites_intersection {
 
     Array[File] ordered_vcf_shards = if (defined(ordered_vcf_shards_list)) then read_lines(select_first([ordered_vcf_shards_list, ""])) else ordered_vcf_shards_in
     Array[File] ordered_vcf_shards_idx = if (defined(ordered_vcf_shards_idx_list)) then read_lines(select_first([ordered_vcf_shards_idx_list, ""])) else ordered_vcf_shards_idx_in
+    String pipeline_version = "aou-8.0.0"
 
     # Get the high quality sites that are called in the test data (intersection file).
     #  Return as a full VCF of the training data ("hq full").  And return the count as well.
@@ -242,10 +243,10 @@ task merge_vcf_bgzs {
 
     runtime {
         docker: "mgibio/bcftools-cwl:1.12"
-        memory: "31 GB"
-        cpu: "4"
-        disks: "local-disk 700 HDD"
-        bootDiskSizeGb: 750
+        memory: "100 GB"
+        cpu: "16"
+        disks: "local-disk 1500 HDD"
+        bootDiskSizeGb: 1500
     }
 
     output {
@@ -289,7 +290,7 @@ task filter_by_sites_only {
         gsutil cp ~{vcf_idx} .
         fi
 
-        gatk SelectVariants -V ~{updated_input_vcf} -L ~{sites_only_vcf}  --select-type-to-include SNP  -O ~{output_filename}
+        gatk SelectVariants -V ~{updated_input_vcf} -L ~{sites_only_vcf}  -O ~{output_filename}
         gatk IndexFeatureFile -I ~{output_filename}
     >>>
 

--- a/all_of_us/ancestry/run_ancestry.changelog.md
+++ b/all_of_us/ancestry/run_ancestry.changelog.md
@@ -1,3 +1,9 @@
+# aou-8.0.0
+2025-04-16 (Date of Last Commit)
+
+* Updated pipeline version to the one used for Echo V4 R2
+* Added pipeline_version string
+
 # beta release
 2025-04-15 (Date of Last Commit)
 

--- a/all_of_us/ancestry/run_ancestry.wdl
+++ b/all_of_us/ancestry/run_ancestry.wdl
@@ -36,6 +36,7 @@ workflow run_ancestry {
 
     File hgdp_metadata_file = select_first([hgdp_metadata_file_in, "gs://gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.sample_meta.tsv.gz"])
     Float other_cutoff = select_first([other_cutoff_in, 0.75])
+    String pipeline_version = "aou_8.0.0"
 
     # Train the model on the intersection sites (full version that includes the samples)
     call create_hw_pca_training {


### PR DESCRIPTION
This PR updates the ancestry preprocessing and ancestry processing pipelines to be the same version used for the V8 release (Echo) and to have new pipeline_version strings.