### PR TITLE
Lk fix aou rnaseq removeids

### DIFF
--- a/all_of_us/rna_seq/rnaseq_aou.changelog.md
+++ b/all_of_us/rna_seq/rnaseq_aou.changelog.md
@@ -1,3 +1,8 @@
+# aou-9.0.1
+2025-06-06 (Date of Last Commit)
+
+* Removed the remove_IDs task from rnaseq_aou WDL; it does not change the input BAM from STAR and this change does not impact the results
+
 # aou-9.0.0
 2025-05-20 (Date of Last Commit)
 

--- a/all_of_us/rna_seq/rnaseq_aou.wdl
+++ b/all_of_us/rna_seq/rnaseq_aou.wdl
@@ -16,6 +16,7 @@ import "./rnaseqc2.wdl" as rnaseqc_wdl
 workflow rnaseq_pipeline_bam_workflow {
 
     String prefix
+    String pipeline_version = "aou_9.0.1"
 
     call samtofastq_wdl.samtofastq {
         input: prefix=prefix

--- a/all_of_us/rna_seq/rnaseq_aou.wdl
+++ b/all_of_us/rna_seq/rnaseq_aou.wdl
@@ -11,7 +11,6 @@ import "./star.wdl" as star_align_wdl
 import "./markduplicates.wdl" as markduplicates_wdl
 import "./rsem.wdl" as rsem_wdl
 import "./rnaseqc2.wdl" as rnaseqc_wdl
-import "./remove_IDS_reads.wdl" as prersem_wdl
 
 
 workflow rnaseq_pipeline_bam_workflow {
@@ -26,17 +25,9 @@ workflow rnaseq_pipeline_bam_workflow {
         input: fastq1=samtofastq.fastq1, fastq2=samtofastq.fastq2, prefix=prefix
     }
 
-    call prersem_wdl.remove_IDS_reads {
+    call rsem_wdl.rsem {
         input: transcriptome_bam=star.transcriptome_bam, prefix=prefix
     }
-
-    call rsem_wdl.rsem {
-        input: transcriptome_bam=remove_IDS_reads.transcriptome_noIDS_bam, prefix=prefix
-    }
-
-#    call bamsync_wdl.bamsync {
-#        input: target_bam=star.bam_file, target_bam_index=star.bam_index, prefix=prefix
-#    }
 
     call markduplicates_wdl.markduplicates {
         #input: input_bam=bamsync.patched_bam_file, prefix=prefix


### PR DESCRIPTION
This PR adds the version number to the rnaseq_aou pipeline and updates it to remove the task remove_ids because it is unnecessary. This does not impact the results of the pipeline. 