### PR TITLE
simplify import ../../tasks/broad down to nothing in tasks/broad

### DIFF
--- a/tasks/broad/AggregatedBamQC.wdl
+++ b/tasks/broad/AggregatedBamQC.wdl
@@ -15,7 +15,7 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/broad/Qc.wdl" as QC
+import "Qc.wdl" as QC
 import "../../structs/dna_seq/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION

--- a/tasks/broad/BamToCram.wdl
+++ b/tasks/broad/BamToCram.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../../tasks/broad/Utilities.wdl" as Utils
-import "../../tasks/broad/Qc.wdl" as QC
+import "Utilities.wdl" as Utils
+import "Qc.wdl" as QC
 
 workflow BamToCram {
 

--- a/tasks/broad/SplitLargeReadGroup.wdl
+++ b/tasks/broad/SplitLargeReadGroup.wdl
@@ -15,10 +15,10 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/broad/Alignment.wdl" as Alignment
-import "../../tasks/broad/DragmapAlignment.wdl" as DragmapAlignment
-import "../../tasks/broad/BamProcessing.wdl" as Processing
-import "../../tasks/broad/Utilities.wdl" as Utils
+import "Alignment.wdl" as Alignment
+import "DragmapAlignment.wdl" as DragmapAlignment
+import "BamProcessing.wdl" as Processing
+import "Utilities.wdl" as Utils
 import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
 
 workflow SplitLargeReadGroup {

--- a/tasks/broad/UMIAwareDuplicateMarking.wdl
+++ b/tasks/broad/UMIAwareDuplicateMarking.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../../tasks/broad/RNAWithUMIsTasks.wdl" as tasks
+import "RNAWithUMIsTasks.wdl" as tasks
 
 ## Copyright Broad Institute, 2021
 ##

--- a/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl
+++ b/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../../tasks/broad/JointGenotypingTasks.wdl" as Tasks
+import "JointGenotypingTasks.wdl" as Tasks
 
 # Given a joint callset with a "score_key" INFO level annotation, this pipeline chooses a threshold that maximizes
 # the F1 score on a single sample in the callset using known truth data for that one sample.

--- a/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl
+++ b/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../../tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl" as Tasks
-import "../../tasks/broad/Alignment.wdl" as AlignmentTasks
+import "UltimaGenomicsWholeGenomeGermlineTasks.wdl" as Tasks
+import "Alignment.wdl" as AlignmentTasks
 import "../../structs/dna_seq/UltimaGenomicsWholeGenomeGermlineStructs.wdl" as Structs
 
 workflow AlignmentAndMarkDuplicates {

--- a/tasks/broad/UltimaGenomicsWholeGenomeGermlineQC.wdl
+++ b/tasks/broad/UltimaGenomicsWholeGenomeGermlineQC.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../../tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl" as Tasks
-import "../../tasks/broad/Qc.wdl" as QC
+import "UltimaGenomicsWholeGenomeGermlineTasks.wdl" as Tasks
+import "Qc.wdl" as QC
 
 workflow UltimaGenomicsWholeGenomeGermlineQC {
   input {

--- a/tasks/broad/UnmappedBamToAlignedBam.wdl
+++ b/tasks/broad/UnmappedBamToAlignedBam.wdl
@@ -16,12 +16,12 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../../tasks/broad/Alignment.wdl" as Alignment
-import "../../tasks/broad/DragmapAlignment.wdl" as DragmapAlignment
-import "../../tasks/broad/SplitLargeReadGroup.wdl" as SplitRG
-import "../../tasks/broad/Qc.wdl" as QC
-import "../../tasks/broad/BamProcessing.wdl" as Processing
-import "../../tasks/broad/Utilities.wdl" as Utils
+import "Alignment.wdl" as Alignment
+import "DragmapAlignment.wdl" as DragmapAlignment
+import "SplitLargeReadGroup.wdl" as SplitRG
+import "Qc.wdl" as QC
+import "BamProcessing.wdl" as Processing
+import "Utilities.wdl" as Utils
 import "../../structs/dna_seq/DNASeqStructs.wdl" as Structs
 
 # WORKFLOW DEFINITION


### PR DESCRIPTION
### Description

Barring a quirk I'm not aware of, these import paths are needlessly clunky, presumably after some large scale directory structure reshuffling.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [x] Did you modify, delete or move: file paths, file names, input names, output names, or task names?