### PR TITLE
Update snm3C.wdl to use 6M reads filtering

### DIFF
--- a/pipelines/skylab/snm3C/snm3C.wdl
+++ b/pipelines/skylab/snm3C/snm3C.wdl
@@ -44,7 +44,7 @@ workflow snm3C {
     }
 
     # version of the pipeline
-    String pipeline_version = "4.0.5"
+    String pipeline_version = "4.1.0"
 
     call Demultiplexing {
         input:
@@ -155,7 +155,7 @@ task Demultiplexing {
     String plate_id
     Int batch_number
     Int min_threshold = 100
-    Int max_threshold = 10000000
+    Int max_threshold = 6000000
     String docker
 
     Int disk_size = 1000


### PR DESCRIPTION
### Description
We decided to change filtering threshold from 10M to 6M in demux step to increase unformity of data in the alignment in inbalanced libraries.
