### PR TITLE
TSPS-477 Imputation Beagle - add ability to write pipeline info to output vcf header

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,12 +1,12 @@
-ArrayImputationQC	 1.0.1	2025-08-26 
-ArrayImputationQuotaConsumed	 1.0.4	2025-08-26 
+ArrayImputationQC	 1.0.2	2025-09-03 
+ArrayImputationQuotaConsumed	 1.0.5	2025-09-03 
 BuildIndices	 4.1.0	2025-08-20 
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.4	2025-02-21 
 ExomeReprocessing	 3.3.4	2025-02-21 
 IlluminaGenotypingArray	 1.12.24	2024-11-04 
-Imputation	 1.1.20	2025-08-26 
-ImputationBeagle	 2.0.1	2025-08-26 
+Imputation	 1.1.21	2025-09-03 
+ImputationBeagle	 2.0.2	2025-09-03 
 JointGenotyping	 1.7.2	2024-11-04 
 MultiSampleSmartSeq2SingleNucleus	 2.2.2	 2025-06-20 
 Multiome	 6.1.3	2025-08-15 

--- a/pipelines/broad/arrays/imputation/Imputation.changelog.md
+++ b/pipelines/broad/arrays/imputation/Imputation.changelog.md
@@ -1,3 +1,9 @@
+# 1.1.21
+2025-09-03 (Date of Last Commit)
+
+* Update UpdateHeader task to add an optional pipeline_header_line input that when supplied, will add a header line containing 
+this value to the header of the output vcf.  Currently not used by this pipeline
+
 # 1.1.20
 2025-08-26 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation/Imputation.wdl
+++ b/pipelines/broad/arrays/imputation/Imputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/Utilities.wdl" as utils
 
 workflow Imputation {
 
-  String pipeline_version = "1.1.20"
+  String pipeline_version = "1.1.21"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2025-09-03 (Date of Last Commit)
+
+* Add optional pipeline_header_line input to match beagle imputation pipeline inputs
+
 # 1.0.1
 2025-08-26 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "../../../../tasks/broad/ImputationBeagleQcTasks.wdl" as tasks
 
 workflow InputQC {
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
         Int chunkLength = 25000000
@@ -16,6 +16,8 @@ workflow InputQC {
         String reference_panel_path_prefix
         String genetic_maps_path
         String output_basename
+
+        String? pipeline_header_line
     }
 
     call tasks.QcChecks {

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.5
+2025-09-03 (Date of Last Commit)
+
+* Add optional pipeline_header_line input to match beagle imputation pipeline inputs
+
 # 1.0.4
 2025-08-26 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQuotaConsumed.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "../../../../tasks/broad/ImputationTasks.wdl" as tasks
 
 workflow QuotaConsumed {
-    String pipeline_version = "1.0.4"
+    String pipeline_version = "1.0.5"
 
     input {
         Int chunkLength = 25000000
@@ -16,6 +16,8 @@ workflow QuotaConsumed {
         String reference_panel_path_prefix
         String genetic_maps_path
         String output_basename
+
+        String? pipeline_header_line
     }
 
     call tasks.CountSamples {

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,3 +1,9 @@
+# 2.0.2
+2025-09-03 (Date of Last Commit)
+
+* Add optional pipeline_header_line input that when supplied, will add a header line containing this value to the 
+header of the output vcf
+
 # 2.0.1
 2025-08-26 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,8 +1,7 @@
 # 2.0.2
 2025-09-03 (Date of Last Commit)
 
-* Add optional pipeline_header_line input that when supplied, will add a header line containing this value to the 
-header of the output vcf
+* Add optional pipeline_header_line input that when supplied, will add a header line containing this value to the header of the output vcf
 
 # 2.0.1
 2025-08-26 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -148,6 +148,7 @@ workflow ImputationBeagle {
     Int num_chunks_2 = num_chunks[contig_index]
     scatter (i in range(num_chunks_2)) {
       String impute_scatter_position_chunk_basename = referencePanelContig_2.contig + "_chunk_" + i
+      String? impute_scatter_pipeline_header_line = pipeline_header_line
 
       scatter (j in range(num_sample_chunks)) {
         # sample FORMAT fields in vcfs start after the 8 mandatory fields plus FORMAT (FORMAT isnt mandatory
@@ -264,7 +265,7 @@ workflow ImputationBeagle {
           ref_dict = ref_dict,
           basename = impute_scatter_position_chunk_basename + ".imputed.no_overlaps.update_header",
           disable_sequence_dictionary_validation = false,
-          pipeline_header_line = pipeline_header_line,
+          pipeline_header_line = impute_scatter_pipeline_header_line,
           gatk_docker = gatk_docker
       }
     }

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -21,6 +21,8 @@ workflow ImputationBeagle {
     String genetic_maps_path # path to the bucket where genetic maps are stored for all contigs
     String output_basename # the basename for intermediate and output files
 
+    String? pipeline_header_line # optional additional header lines to add to the output VCF
+
     # file extensions used to find reference panel files
     String bed_suffix = ".bed"
     String bref3_suffix = ".bref3"
@@ -262,6 +264,7 @@ workflow ImputationBeagle {
           ref_dict = ref_dict,
           basename = impute_scatter_position_chunk_basename + ".imputed.no_overlaps.update_header",
           disable_sequence_dictionary_validation = false,
+          pipeline_header_line = pipeline_header_line,
           gatk_docker = gatk_docker
       }
     }

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -146,9 +146,9 @@ workflow ImputationBeagle {
                                                   "genetic_map": genetic_map_filename_2
                                                 }
     Int num_chunks_2 = num_chunks[contig_index]
+    String? impute_scatter_pipeline_header_line = pipeline_header_line
     scatter (i in range(num_chunks_2)) {
       String impute_scatter_position_chunk_basename = referencePanelContig_2.contig + "_chunk_" + i
-      String? impute_scatter_pipeline_header_line = pipeline_header_line
 
       scatter (j in range(num_sample_chunks)) {
         # sample FORMAT fields in vcfs start after the 8 mandatory fields plus FORMAT (FORMAT isnt mandatory
@@ -265,7 +265,7 @@ workflow ImputationBeagle {
           ref_dict = ref_dict,
           basename = impute_scatter_position_chunk_basename + ".imputed.no_overlaps.update_header",
           disable_sequence_dictionary_validation = false,
-          pipeline_header_line = impute_scatter_pipeline_header_line,
+          task_pipeline_header_line = impute_scatter_pipeline_header_line,
           gatk_docker = gatk_docker
       }
     }

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/broad/ImputationBeagleTasks.wdl" as beagleTasks
 
 workflow ImputationBeagle {
 
-  String pipeline_version = "2.0.1"
+  String pipeline_version = "2.0.2"
 
   input {
     Int chunkLength = 25000000

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -36,6 +36,7 @@ workflow ImputationBeagle {
     Int beagle_phase_memory_in_gb = 40
     Int beagle_impute_memory_in_gb = 45
   }
+  String defined_pipeline_header_line = if defined(pipeline_header_line) then select_first([pipeline_header_line]) else ""
 
   call tasks.CountSamples {
     input:
@@ -146,7 +147,6 @@ workflow ImputationBeagle {
                                                   "genetic_map": genetic_map_filename_2
                                                 }
     Int num_chunks_2 = num_chunks[contig_index]
-    String? impute_scatter_pipeline_header_line = pipeline_header_line
     scatter (i in range(num_chunks_2)) {
       String impute_scatter_position_chunk_basename = referencePanelContig_2.contig + "_chunk_" + i
 
@@ -265,7 +265,7 @@ workflow ImputationBeagle {
           ref_dict = ref_dict,
           basename = impute_scatter_position_chunk_basename + ".imputed.no_overlaps.update_header",
           disable_sequence_dictionary_validation = false,
-          task_pipeline_header_line = impute_scatter_pipeline_header_line,
+          pipeline_header_line = defined_pipeline_header_line,
           gatk_docker = gatk_docker
       }
     }

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -388,7 +388,8 @@ task UpdateHeader {
 
       bcftools view -h --no-version temp.vcf.gz > header.txt
       TOTAL_LINES=$(wc -l < "header.txt")
-      sed -i "${TOTAL_LINES}i\##~{pipeline_header_line}" header.txt
+      REMOVED_COMMENT_CHARACTER_HEADER_LINE=$(echo "~{pipeline_header_line}" | sed 's/^#*//')
+      sed -i "${TOTAL_LINES}i\##${REMOVED_COMMENT_CHARACTER_HEADER_LINE}" header.txt
 
       bcftools reheader -h header.txt -o ~{basename}.vcf.gz temp.vcf.gz
       bcftools index -t ~{basename}.vcf.gz

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -359,7 +359,7 @@ task UpdateHeader {
     File ref_dict
     String basename
     Boolean disable_sequence_dictionary_validation = true
-    String? pipeline_header_line
+    String? task_pipeline_header_line
 
     Int disk_size_gb = ceil(4*(size(vcf, "GiB") + size(vcf_index, "GiB"))) + 20
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
@@ -382,13 +382,13 @@ task UpdateHeader {
     ~{disable_sequence_dict_validation_flag}
 
     ## update header with pipeline_header_line if provided
-    if [ -n "~{default="" pipeline_header_line}" ]; then
+    if [ -n "~{default="" task_pipeline_header_line}" ]; then
       mv ~{basename}.vcf.gz temp.vcf.gz
       mv ~{basename}.vcf.gz.tbi temp.vcf.gz.tbi
 
       bcftools view -h --no-version temp.vcf.gz > header.txt
       TOTAL_LINES=$(wc -l < "header.txt")
-      sed -i "${TOTAL_LINES}i\##~{pipeline_header_line}" header.txt
+      sed -i "${TOTAL_LINES}i\##~{task_pipeline_header_line}" header.txt
 
       bcftools reheader -h header.txt -o ~{basename}.vcf.gz temp.vcf.gz
       bcftools index -t ~{basename}.vcf.gz

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -381,8 +381,8 @@ task UpdateHeader {
     --replace -V ~{vcf} \
     ~{disable_sequence_dict_validation_flag}
 
-    ## update header with pipeline name and version if provided
-    if [ -n ~{default="" pipeline_header_line} ]; then
+    ## update header with pipeline_header_line if provided
+    if [ -n "~{default="" pipeline_header_line}" ]; then
       mv ~{basename}.vcf.gz temp.vcf.gz
       mv ~{basename}.vcf.gz.tbi temp.vcf.gz.tbi
 
@@ -390,7 +390,7 @@ task UpdateHeader {
       TOTAL_LINES=$(wc -l < "header.txt")
       sed -i "${TOTAL_LINES}i\##~{pipeline_header_line}" header.txt
 
-      bcftools reheader -h header.txt -Oz -o ~{basename}.vcf.gz temp.vcf.gz
+      bcftools reheader -h header.txt -o ~{basename}.vcf.gz temp.vcf.gz
       bcftools index -t ~{basename}.vcf.gz
     fi
   >>>

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -359,6 +359,7 @@ task UpdateHeader {
     File ref_dict
     String basename
     Boolean disable_sequence_dictionary_validation = true
+    String? pipeline_header_line
 
     Int disk_size_gb = ceil(4*(size(vcf, "GiB") + size(vcf_index, "GiB"))) + 20
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
@@ -370,13 +371,28 @@ task UpdateHeader {
   String disable_sequence_dict_validation_flag = if disable_sequence_dictionary_validation then "--disable-sequence-dictionary-validation" else ""
 
   command <<<
-    ## update the header of the merged vcf
+    set -e -o pipefail
+
+    ## update the header of the merged vcf with the reference dictionary
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
     UpdateVCFSequenceDictionary \
     --source-dictionary ~{ref_dict} \
     --output ~{basename}.vcf.gz \
     --replace -V ~{vcf} \
     ~{disable_sequence_dict_validation_flag}
+
+    ## update header with pipeline name and version if provided
+    if [ -n ~{default="" pipeline_header_line} ]; then
+      mv ~{basename}.vcf.gz temp.vcf.gz
+      mv ~{basename}.vcf.gz.tbi temp.vcf.gz.tbi
+
+      bcftools view -h --no-version temp.vcf.gz > header.txt
+      TOTAL_LINES=$(wc -l < "header.txt")
+      sed -i "${TOTAL_LINES}i\##~{pipeline_header_line}" header.txt
+
+      bcftools reheader -h header.txt -Oz -o ~{basename}.vcf.gz temp.vcf.gz
+      bcftools index -t ~{basename}.vcf.gz
+    fi
   >>>
   runtime {
     docker: gatk_docker

--- a/tasks/broad/ImputationTasks.wdl
+++ b/tasks/broad/ImputationTasks.wdl
@@ -359,7 +359,7 @@ task UpdateHeader {
     File ref_dict
     String basename
     Boolean disable_sequence_dictionary_validation = true
-    String? task_pipeline_header_line
+    String? pipeline_header_line
 
     Int disk_size_gb = ceil(4*(size(vcf, "GiB") + size(vcf_index, "GiB"))) + 20
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
@@ -382,13 +382,13 @@ task UpdateHeader {
     ~{disable_sequence_dict_validation_flag}
 
     ## update header with pipeline_header_line if provided
-    if [ -n "~{default="" task_pipeline_header_line}" ]; then
+    if [ -n "~{default="" pipeline_header_line}" ]; then
       mv ~{basename}.vcf.gz temp.vcf.gz
       mv ~{basename}.vcf.gz.tbi temp.vcf.gz.tbi
 
       bcftools view -h --no-version temp.vcf.gz > header.txt
       TOTAL_LINES=$(wc -l < "header.txt")
-      sed -i "${TOTAL_LINES}i\##~{task_pipeline_header_line}" header.txt
+      sed -i "${TOTAL_LINES}i\##~{pipeline_header_line}" header.txt
 
       bcftools reheader -h header.txt -o ~{basename}.vcf.gz temp.vcf.gz
       bcftools index -t ~{basename}.vcf.gz


### PR DESCRIPTION
### Description
The imputation service would like to be able to add pipeline information to the header of the imputed vcf. Since this is something you probably wouldnt want by default. it is added as a optional parameter and added optionally.  

With header value passed in to workflow
https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/49bdb9ce-f750-4adc-9107-f70bad910a9c

With no header value passed into workflow
https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/ce6763de-70af-47a7-bd5b-6d5592cf6edb

screenshot of output header for when the head value was passed in

<img width="1294" height="157" alt="Screenshot 2025-09-03 at 2 59 17 PM" src="https://github.com/user-attachments/assets/ded38b66-224d-454c-a409-15e8fd9a6fe2" />

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
