### PR TITLE
add sample split plumbing test for imputation_beagle

### DIFF
--- a/pipelines/broad/arrays/imputation_beagle/test_inputs/Plumbing/NA12878_x10_hg38_arrays_split_samples.json
+++ b/pipelines/broad/arrays/imputation_beagle/test_inputs/Plumbing/NA12878_x10_hg38_arrays_split_samples.json
@@ -1,0 +1,9 @@
+{
+    "ImputationBeagle.multi_sample_vcf": "gs://broad-gotc-test-storage/imputation_beagle/scientific/vcfs/NA12878_10_duplicate.merged.cleaned.vcf.gz",
+    "ImputationBeagle.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+    "ImputationBeagle.reference_panel_path_prefix": "gs://broad-gotc-test-storage/imputation_beagle/scientific/1000G_HGDP_no_singletons_reference_panel/hgdp.tgp.gwaspy.AN_added.bcf.ac2",
+    "ImputationBeagle.contigs": ["chr21","chr22"],
+    "ImputationBeagle.genetic_maps_path": "gs://broad-gotc-test-storage/imputation_beagle/scientific/plink-genetic-maps/",
+    "ImputationBeagle.output_basename": "plumbing_test",
+    "ImputationBeagle.sample_chunk_size": 5
+}

--- a/verification/test-wdls/TestImputationBeagle.wdl
+++ b/verification/test-wdls/TestImputationBeagle.wdl
@@ -11,6 +11,8 @@ workflow TestImputationBeagle {
     input {
       Int chunkLength = 25000000
       Int chunkOverlaps = 5000000 # this is the padding that will be added to the beginning and end of each chunk to reduce edge effects
+      Int sample_chunk_size = 1000 # this is the number of samples that will be processed in parallel in each chunked scatter
+
       
       File multi_sample_vcf
       
@@ -34,6 +36,7 @@ workflow TestImputationBeagle {
       input:
         chunkLength = chunkLength,
         chunkOverlaps = chunkOverlaps,
+        sample_chunk_size = sample_chunk_size,
         multi_sample_vcf = multi_sample_vcf,
         ref_dict = ref_dict,
         contigs = contigs,


### PR DESCRIPTION
### Description

We are adding a test to make sure we test the sample split route of our wdl to feel more confident about changes we're making

test failing because truth inputs dont exist yet - https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/submission_history/7e185f1e-2e0a-4232-a904-28b0d9c31e3e

the other imputationbeagle test still succeeded - https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/submission_history/642d75a3-aa2f-4b61-8228-23e58b6aff70

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
