### PR TITLE
TSPS-626 TSPS-643 Update array imputation qc for bgzip and sorted vcfs

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,4 +1,4 @@
-ArrayImputationQC	 1.2.0	2025-09-29 
+ArrayImputationQC	 1.2.1	2025-10-01 
 ArrayImputationQuotaConsumed	 1.1.0	2025-09-29 
 BuildIndices	 4.2.1	2025-09-26 
 CramToUnmappedBams	 1.1.3	2024-08-02 
@@ -6,7 +6,7 @@ ExomeGermlineSingleSample	 3.2.4	2025-02-21
 ExomeReprocessing	 3.3.4	2025-02-21 
 IlluminaGenotypingArray	 1.12.24	2024-11-04 
 Imputation	 1.1.22	2025-09-18 
-ImputationBeagle	 2.2.0	2025-09-29 
+ImputationBeagle	 2.2.1	2025-10-01 
 JointGenotyping	 1.7.2	2024-11-04 
 MultiSampleSmartSeq2SingleNucleus	 2.2.2	 2025-06-20 
 Multiome	 6.1.3	2025-08-15 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.changelog.md
@@ -1,3 +1,8 @@
+# 1.2.1
+2025-10-01 (Date of Last Commit)
+
+* Add check for vcf being bgzipped and in sorted order
+
 # 1.2.0
 2025-09-29 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ArrayImputationQC.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/broad/ImputationBeagleQcTasks.wdl" as tasks
 
 workflow InputQC {
     # if this changes, update the input_qc_version value in ImputationBeagle.wdl
-    String pipeline_version = "1.2.0"
+    String pipeline_version = "1.2.1"
 
 
     input {

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.1
+2025-10-01 (Date of Last Commit)
+
+* update input_qc_version to 1.2.1
+
 # 2.2.0
 2025-09-29 (Date of Last Commit)
 

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.changelog.md
@@ -1,7 +1,7 @@
 # 2.2.1
 2025-10-01 (Date of Last Commit)
 
-* update input_qc_version to 1.2.1
+* update input_qc_version to 1.2.1 to match latest changes in InputQC wdl
 
 # 2.2.0
 2025-09-29 (Date of Last Commit)

--- a/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
+++ b/pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl
@@ -5,8 +5,8 @@ import "../../../../tasks/broad/ImputationTasks.wdl" as tasks
 import "../../../../tasks/broad/ImputationBeagleTasks.wdl" as beagleTasks
 
 workflow ImputationBeagle {
-  String pipeline_version = "2.2.0"
-  String input_qc_version = "1.2.0"
+  String pipeline_version = "2.2.1"
+  String input_qc_version = "1.2.1"
   String quota_consumed_version = "1.1.0"
 
   input {

--- a/tasks/broad/ImputationBeagleQcTasks.wdl
+++ b/tasks/broad/ImputationBeagleQcTasks.wdl
@@ -62,7 +62,7 @@ task QcChecks {
 
         # check for sorted or non bgzf compressed vcf
         bcftools index -t ~{vcf_input} 2> index_stderr.txt
-        if grep -qE "unsorted positions|not coninuous" index_stderr.txt; then
+        if grep -qiE "unsorted positions|not continuous" index_stderr.txt; then
             echo "Input VCF is not sorted" >> qc_messages.txt;
         fi
 

--- a/tasks/broad/ImputationBeagleQcTasks.wdl
+++ b/tasks/broad/ImputationBeagleQcTasks.wdl
@@ -60,8 +60,17 @@ task QcChecks {
             echo "Found data for chromosomes: ${filtered_chromosomes[*]}."
         fi
 
+        # check for sorted or non bgzf compressed vcf
+        bcftools index -t ~{vcf_input} 2> index_stderr.txt
+        if grep -qE "unsorted positions|not coninuous" "$file"; then
+            echo "Input VCF is not sorted" >> qc_messages.txt;
+        fi
+
+        if grep -q "not BGZF compressed" "$file"; then
+            echo "Input VCF is BGZF compressed" >> qc_messages.txt;
+        fi
+
         # check reference header lines if they exist
-        bcftools index -t ~{vcf_input} # necessary for gatk ValidateVariants command
         gatk ValidateVariants \
         -V ~{vcf_input} \
         --sequence-dictionary ~{ref_dict} \

--- a/tasks/broad/ImputationBeagleQcTasks.wdl
+++ b/tasks/broad/ImputationBeagleQcTasks.wdl
@@ -67,7 +67,7 @@ task QcChecks {
         fi
 
         if grep -q "not BGZF compressed" index_stderr.txt; then
-            echo "Input VCF is BGZF compressed" >> qc_messages.txt;
+            echo "Input VCF is not BGZF compressed" >> qc_messages.txt;
         fi
 
         # check reference header lines if they exist

--- a/tasks/broad/ImputationBeagleQcTasks.wdl
+++ b/tasks/broad/ImputationBeagleQcTasks.wdl
@@ -62,11 +62,11 @@ task QcChecks {
 
         # check for sorted or non bgzf compressed vcf
         bcftools index -t ~{vcf_input} 2> index_stderr.txt
-        if grep -qE "unsorted positions|not coninuous" "$file"; then
+        if grep -qE "unsorted positions|not coninuous" index_stderr.txt; then
             echo "Input VCF is not sorted" >> qc_messages.txt;
         fi
 
-        if grep -q "not BGZF compressed" "$file"; then
+        if grep -q "not BGZF compressed" index_stderr.txt; then
             echo "Input VCF is BGZF compressed" >> qc_messages.txt;
         fi
 


### PR DESCRIPTION
### Description
We have had some users submit vcfs that were not sorted and others who have submitted vcfs that were not bgzipped.  This updates the qc wdl to return useful error messages to the users

not in order position - https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/4f9b0faa-19e0-40f1-a07f-fc90e1987bdb

not in order chromosome - https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/079c94df-0858-4864-8c62-b25e068708b6

not bgzipped - https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/782d2d6c-5283-4f6d-abb5-48cdac4a8896

good input - https://app.terra.bio/#workspaces/allofus-drc-imputation/AOU_ANVIL_imputation_reference_panel_validation/submission_history/f097365f-f2e8-4358-aab0-2f2b72408841

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
