### PR TITLE
TSPS-887  make low pass imputation workflow driven by contig input

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,7 +4,7 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.2	2026-03-19 
+Glimpse2LowPassImputation	 0.0.3	2026-03-25 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-03-25 (Date of Last Commit)
+
+* Reorganize wdl to be able to run on contigs more easily.  Now the workflow is fully driven by the `contigs` input
+
 # 0.0.2
 2026-03-19 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -2,6 +2,7 @@
 2026-03-25 (Date of Last Commit)
 
 * Reorganize wdl to be able to run on contigs more easily.  Now the workflow is fully driven by the `contigs` input
+* The wdl now expects the reference related files to all live under the same cloud base path
 
 # 0.0.2
 2026-03-19 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -43,6 +43,18 @@ workflow Glimpse2LowPassImputation {
 
     Int n_samples = select_first([CountSamples.nSamples, length(select_first([crams]))])
 
+    if (defined(crams)) {
+        if (length(select_first([crams])) > 1) {
+            call SplitIntoBatches {
+                input:
+                    batch_size = calling_batch_size,
+                    crams = select_first([crams]),
+                    cram_indices = select_first([cram_indices]),
+                    sample_ids = sample_ids
+            }
+        }
+    }
+
     scatter(contig in contigs) {
         File sites_vcf = reference_panel_prefix + "sites." + contig + ".vcf.gz"
         File sites_vcf_index =reference_panel_prefix + "sites." + contig + ".vcf.gz.tbi"
@@ -51,15 +63,6 @@ workflow Glimpse2LowPassImputation {
         File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
         if (defined(crams)) {
-            if (length(select_first([crams])) > 1) {
-                call SplitIntoBatches {
-                    input:
-                        batch_size = calling_batch_size,
-                        crams = select_first([crams]),
-                        cram_indices = select_first([cram_indices]),
-                        sample_ids = sample_ids
-                }
-            }
             Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
             Array[Array[String]] cram_indices_batches = select_first([SplitIntoBatches.cram_indices_batches, [select_first([cram_indices])]])
             Array[Array[String]] sample_ids_batches = select_first([SplitIntoBatches.sample_ids_batches, [select_first([sample_ids])]])

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -107,7 +107,6 @@ workflow Glimpse2LowPassImputation {
         call ComputeShardsAndMemoryPerShard {
             input:
                 reference_chunks_memory = reference_chunks,
-                contigs = contigs,
                 n_samples = n_samples
         }
 
@@ -231,7 +230,6 @@ task SplitIntoBatches {
 task ComputeShardsAndMemoryPerShard {
     input {
         File reference_chunks_memory
-        Array[String] contigs
         Int n_samples
     }
 
@@ -243,17 +241,13 @@ task ComputeShardsAndMemoryPerShard {
 
         df = pd.read_csv('~{reference_chunks_memory}', sep='\t', header=None, names=['contig', 'reference_shard', 'base_gb', 'slope_per_sample_gb'])
 
-        # filter dataframe by contig list
-        chromosomes_to_filter = ["~{sep='", "' contigs}"]
-        filtered_df = df[df['contig'].isin(chromosomes_to_filter)]
-
         # write out reference shards to process
-        filtered_df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)
+        df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)
 
         # calculate memory usage and save to file
-        filtered_df['mem_gb'] = filtered_df['base_gb'] + filtered_df['slope_per_sample_gb'] * ~{n_samples}
-        filtered_df['mem_gb'] = filtered_df['mem_gb'].apply(lambda x: min(256, int(np.ceil(x))))  # cap at 256 GB
-        filtered_df['mem_gb'].to_csv('memory_per_chunk.tsv', sep='\t', index=False, header=None)
+        df['mem_gb'] = filtered_df['base_gb'] + filtered_df['slope_per_sample_gb'] * ~{n_samples}
+        df['mem_gb'] = filtered_df['mem_gb'].apply(lambda x: min(256, int(np.ceil(x))))  # cap at 256 GB
+        df['mem_gb'].to_csv('memory_per_chunk.tsv', sep='\t', index=False, header=None)
         EOF
     >>>
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -58,9 +58,6 @@ workflow Glimpse2LowPassImputation {
         File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".gz.tbi"
         File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
-        File? input_vcf_scatter_1 = input_vcf
-        File? input_vcf_scatter_1_index = input_vcf_index
-
         if (defined(crams)) {
             Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
             Array[Array[String]] cram_indices_batches = select_first([SplitIntoBatches.cram_indices_batches, [select_first([cram_indices])]])
@@ -100,8 +97,8 @@ workflow Glimpse2LowPassImputation {
                 }
             }
 
-            File merged_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0]])
-            File merged_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0]])
+            File phase_input_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0], input_vcf])
+            File phase_input_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0],input_vcf_index])
         }
 
         ## this task is used to grab the reference chunk but does not affect memory usage of glimpsePhase.
@@ -114,14 +111,11 @@ workflow Glimpse2LowPassImputation {
 
         scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
 
-            File? input_vcf_scatter_2 = input_vcf_scatter_1
-            File? input_vcf_scatter_2_index = input_vcf_scatter_1_index
-
             call GlimpsePhase {
                 input:
                     reference_chunk = ComputeShardsAndMemoryPerShard.reference_chunk_file_paths[reference_chunk_index],
-                    input_vcf = select_first([merged_vcf,input_vcf_scatter_2]),
-                    input_vcf_index = select_first([merged_vcf_index,input_vcf_scatter_2_index]),
+                    input_vcf = phase_input_vcf,
+                    input_vcf_index = phase_input_vcf_index,
                     impute_reference_only_variants = impute_reference_only_variants,
                     call_indels = call_indels,
                     sample_ids = sample_ids,

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -2,15 +2,12 @@ version 1.0
 
 workflow Glimpse2LowPassImputation {
     input {
-        String pipeline_version = "0.0.2"
+        String pipeline_version = "0.0.3"
 
         # List of files, one per line
-        File reference_chunks
-        File sites_vcf
-        File sites_table
-        File sites_table_index
 
         Array[String] contigs
+        String reference_panel_prefix
 
         File? input_vcf
         File? input_vcf_index
@@ -32,7 +29,8 @@ workflow Glimpse2LowPassImputation {
         # batch size used when calling SplitIntoBatches to make variant calls from the crams
         Int calling_batch_size = 100
 
-        String docker = "us.gcr.io/broad-dsde-methods/glimpse:kachulis_ck_bam_reader_retry_cf5822c"
+        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
+        String glimpse_docker = "us.gcr.io/broad-dsde-methods/glimpse:kachulis_ck_bam_reader_retry_cf5822c"
         String docker_extract_num_sites_from_reference_chunk = "us.gcr.io/broad-dsde-methods/glimpse_extract_num_sites_from_reference_chunks:michaelgatzen_edc7f3a"
     }
 
@@ -45,114 +43,138 @@ workflow Glimpse2LowPassImputation {
 
     Int n_samples = select_first([CountSamples.nSamples, length(select_first([crams]))])
 
-    if (defined(crams)) {
-        if (length(select_first([crams])) > 1) {
-            call SplitIntoBatches {
-                input:
-                    batch_size = calling_batch_size,
-                    crams = select_first([crams]),
-                    cram_indices = select_first([cram_indices]),
-                    sample_ids = sample_ids
-            }
-        }
-        Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
-        Array[Array[String]] cram_indices_batches = select_first([SplitIntoBatches.cram_indices_batches, [select_first([cram_indices])]])
-        Array[Array[String]] sample_ids_batches = select_first([SplitIntoBatches.sample_ids_batches, [select_first([sample_ids])]])
+    scatter(contig in contigs) {
+        File sites_vcf = reference_panel_prefix + "sites." + contig + ".vcf.gz"
+        File sites_vcf_index =reference_panel_prefix + "sites." + contig + ".vcf.gz.tbi"
+        File sites_table = reference_panel_prefix + "sites_table." + contig + ".vcf.gz"
+        File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".vcf.gz.tbi"
+        File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
-        scatter(i in range(length(crams_batches))) {
-            call BcftoolsMpileup {
+        if (defined(crams)) {
+            if (length(select_first([crams])) > 1) {
+                call SplitIntoBatches {
+                    input:
+                        batch_size = calling_batch_size,
+                        crams = select_first([crams]),
+                        cram_indices = select_first([cram_indices]),
+                        sample_ids = sample_ids
+                }
+            }
+            Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
+            Array[Array[String]] cram_indices_batches = select_first([SplitIntoBatches.cram_indices_batches, [select_first([cram_indices])]])
+            Array[Array[String]] sample_ids_batches = select_first([SplitIntoBatches.sample_ids_batches, [select_first([sample_ids])]])
+
+            scatter(i in range(length(crams_batches))) {
+                call BcftoolsMpileup {
+                    input:
+                        crams = crams_batches[i],
+                        cram_indices = cram_indices_batches[i],
+                        sample_ids = sample_ids_batches[i],
+                        fasta = fasta,
+                        fasta_index = fasta_index,
+                        call_indels = call_indels,
+                        sites_vcf = sites_vcf,
+                }
+
+                call BcftoolsCall {
+                    input:
+                        mpileup_bcf = BcftoolsMpileup.output_bcf,
+                        sites_table = sites_table,
+                        sites_table_index = sites_table_index,
+                }
+
+                call BcftoolsNorm {
+                    input:
+                        calls_bcf = BcftoolsCall.output_bcf,
+                }
+            }
+
+            if (length(BcftoolsNorm.output_vcf) > 1) {
+                call BcftoolsMerge {
+                    input:
+                        vcfs = BcftoolsNorm.output_vcf,
+                        vcf_indices = BcftoolsNorm.output_vcf_index,
+                        output_basename = output_basename
+                }
+            }
+
+            File merged_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0]])
+            File merged_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0]])
+        }
+
+        ## this task is used to grab the reference chunk but does not affect memory usage of glimpsePhase.
+        ## still tbd which method makes the most sense cost wise
+        call ComputeShardsAndMemoryPerShard {
+            input:
+                reference_chunks_memory = reference_chunks,
+                contigs = contigs,
+                n_samples = n_samples
+        }
+
+        scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
+
+            call GlimpsePhase {
                 input:
-                    crams = crams_batches[i],
-                    cram_indices = cram_indices_batches[i],
-                    sample_ids = sample_ids_batches[i],
+                    reference_chunk = ComputeShardsAndMemoryPerShard.reference_chunk_file_paths[reference_chunk_index],
+                    input_vcf = select_first([merged_vcf,input_vcf]),
+                    input_vcf_index = select_first([merged_vcf_index,input_vcf_index]),
+                    impute_reference_only_variants = impute_reference_only_variants,
+                    n_burnin = n_burnin,
+                    n_main = n_main,
+                    effective_population_size = effective_population_size,
+                    call_indels = call_indels,
+                    sample_ids = sample_ids,
                     fasta = fasta,
                     fasta_index = fasta_index,
-                    call_indels = call_indels,
-                    sites_vcf = sites_vcf,
-            }
-
-            call BcftoolsCall {
-                input:
-                    mpileup_bcf = BcftoolsMpileup.output_bcf,
-                    sites_table = sites_table,
-                    sites_table_index = sites_table_index,
-            }
-
-            call BcftoolsNorm {
-                input:
-                    calls_bcf = BcftoolsCall.output_bcf,
+                    docker = glimpse_docker
             }
         }
 
-        if (length(BcftoolsNorm.output_vcf) > 1) {
-            call BcftoolsMerge {
-                input:
-                    vcfs = BcftoolsNorm.output_vcf,
-                    vcf_indices = BcftoolsNorm.output_vcf_index,
-                    output_basename = output_basename
-            }
-        }
-
-        File merged_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0]])
-        File merged_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0]])
-    }
-
-    ## this task is used to grab the reference chunk but does not affect memory usage of glimpsePhase.
-    ## still tbd which method makes the most sense cost wise
-    call ComputeShardsAndMemoryPerShard {
-        input:
-            reference_chunks_memory = reference_chunks,
-            contigs = contigs,
-            n_samples = n_samples
-    }
-
-    scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
-
-        call GlimpsePhase {
+        call GlimpseLigate {
             input:
-                reference_chunk = ComputeShardsAndMemoryPerShard.reference_chunk_file_paths[reference_chunk_index],
-                input_vcf = select_first([merged_vcf,input_vcf]),
-                input_vcf_index = select_first([merged_vcf_index,input_vcf_index]),
-                impute_reference_only_variants = impute_reference_only_variants,
-                n_burnin = n_burnin,
-                n_main = n_main,
-                effective_population_size = effective_population_size,
-                call_indels = call_indels,
-                sample_ids = sample_ids,
-                fasta = fasta,
-                fasta_index = fasta_index,
-                docker = docker
+                imputed_chunks = GlimpsePhase.imputed_vcf,
+                imputed_chunks_indices = GlimpsePhase.imputed_vcf_index,
+                output_basename = output_basename,
+                ref_dict = ref_dict,
+                docker = glimpse_docker
         }
+        Array[File] contig_coverage_metrics = select_all(GlimpsePhase.coverage_metrics)
     }
 
-    call GlimpseLigate {
+    call GatherVcfsNoIndex {
         input:
-            imputed_chunks = GlimpsePhase.imputed_vcf,
-            imputed_chunks_indices = GlimpsePhase.imputed_vcf_index,
-            output_basename = output_basename,
-            ref_dict = ref_dict,
-            docker = docker
+            input_vcfs = GlimpseLigate.imputed_vcf,
+            output_vcf_basename = output_basename + ".imputed",
+            gatk_docker = gatk_docker
     }
 
-    if (length(select_all(GlimpsePhase.coverage_metrics)) > 0) {
+    call CreateVcfIndexAndMd5 {
+        input:
+            vcf_input = GatherVcfsNoIndex.output_vcf,
+            gatk_docker = gatk_docker,
+            preemptible = 0
+    }
+
+    Array[File] genome_coverage_metrics = flatten(contig_coverage_metrics)
+    if (length(genome_coverage_metrics) > 0) {
         call CombineCoverageMetrics {
             input:
-                cov_metrics = select_all(GlimpsePhase.coverage_metrics),
+                cov_metrics = genome_coverage_metrics,
                 output_basename = output_basename
         }
     }
 
     call CollectQCMetrics {
         input:
-            imputed_vcf = GlimpseLigate.imputed_vcf,
+            imputed_vcf = GatherVcfsNoIndex.output_vcf,
             output_basename = output_basename
     }
 
 
     output {
-        File imputed_vcf = GlimpseLigate.imputed_vcf
-        File imputed_vcf_index = GlimpseLigate.imputed_vcf_index
-        File imputed_vcf_md5sum = GlimpseLigate.imputed_vcf_md5sum
+        File imputed_vcf = CreateVcfIndexAndMd5.output_vcf
+        File imputed_vcf_index = CreateVcfIndexAndMd5.output_vcf_index
+        File imputed_vcf_md5sum = CreateVcfIndexAndMd5.output_vcf_md5sum
 
         File qc_metrics = CollectQCMetrics.qc_metrics
         File? coverage_metrics = CombineCoverageMetrics.coverage_metrics
@@ -537,9 +559,6 @@ task GlimpseLigate {
         bcftools view -h --no-version ligated.vcf.gz > old_header.vcf
         java -jar /picard.jar UpdateVcfSequenceDictionary -I old_header.vcf --SD ~{ref_dict} -O new_header.vcf
         bcftools reheader -h new_header.vcf -o ~{output_basename}.imputed.vcf.gz ligated.vcf.gz
-        tabix ~{output_basename}.imputed.vcf.gz
-
-        md5sum ~{output_basename}.imputed.vcf.gz | awk '{ print $1 }' > ~{output_basename}.imputed.vcf.gz.md5sum
     >>>
 
     runtime {
@@ -553,8 +572,6 @@ task GlimpseLigate {
 
     output {
         File imputed_vcf = "~{output_basename}.imputed.vcf.gz"
-        File imputed_vcf_index = "~{output_basename}.imputed.vcf.gz.tbi"
-        File imputed_vcf_md5sum = "~{output_basename}.imputed.vcf.gz.md5sum"
     }
 }
 
@@ -676,5 +693,79 @@ task CombineCoverageMetrics
 
     output {
         File coverage_metrics="~{output_basename}.coverage_metrics.txt"
+    }
+}
+
+task GatherVcfsNoIndex {
+    input {
+        Array[File] input_vcfs
+        String output_vcf_basename
+
+        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
+        Int cpu = 2
+        Int memory_mb = 10000
+        Int disk_size_gb = ceil(3*size(input_vcfs, "GiB")) + 10
+    }
+    Int command_mem = memory_mb - 1500
+    Int max_heap = memory_mb - 1000
+
+    command <<<
+        set -e -o pipefail
+
+        gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
+        GatherVcfs \
+        -I ~{sep=' -I ' input_vcfs} \
+        --REORDER_INPUT_BY_FIRST_VARIANT \
+        -O ~{output_vcf_basename}.vcf.gz
+    >>>
+    runtime {
+        docker: gatk_docker
+        disks: "local-disk ${disk_size_gb} SSD"
+        memory: "${memory_mb} MiB"
+        cpu: cpu
+        maxRetries: 1
+        noAddress: true
+    }
+    output {
+        File output_vcf = "~{output_vcf_basename}.vcf.gz"
+    }
+}
+
+task CreateVcfIndexAndMd5 {
+    input {
+        File vcf_input
+
+        Int disk_size_gb = ceil(1.1*size(vcf_input, "GiB")) + 10
+        Int cpu = 1
+        Int memory_mb = 6000
+        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        Int preemptible = 3
+    }
+    Int command_mem = memory_mb - 1500
+    Int max_heap = memory_mb - 1000
+
+    String vcf_basename = basename(vcf_input)
+
+    command <<<
+        set -e -o pipefail
+
+        ln -sf ~{vcf_input} ~{vcf_basename}
+
+        bcftools index -t ~{vcf_basename}
+        md5sum ~{vcf_basename} | awk '{ print $1 }' > ~{vcf_basename}.md5sum
+    >>>
+    runtime {
+        docker: gatk_docker
+        disks: "local-disk ${disk_size_gb} SSD"
+        memory: "${memory_mb} MiB"
+        cpu: cpu
+        preemptible: preemptible
+        maxRetries: 1
+        noAddress: true
+    }
+    output {
+        File output_vcf = "~{vcf_basename}"
+        File output_vcf_index = "~{vcf_basename}.tbi"
+        File output_vcf_md5sum = "~{vcf_basename}.md5sum"
     }
 }

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -58,8 +58,8 @@ workflow Glimpse2LowPassImputation {
         File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".gz.tbi"
         File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
-        File? input_vcf = input_vcf
-        File? input_vcf_index = input_vcf_index
+        File? input_vcf_scatter_1 = input_vcf
+        File? input_vcf_scatter_1_index = input_vcf_index
 
         if (defined(crams)) {
             Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
@@ -114,8 +114,8 @@ workflow Glimpse2LowPassImputation {
 
         scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
 
-            File? input_vcf = input_vcf
-            File? input_vcf_index = input_vcf_index
+            File? input_vcf_scatter_2 = input_vcf_scatter_1
+            File? input_vcf_scatter_2_index = input_vcf_scatter_1_index
 
             call GlimpsePhase {
                 input:

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -58,8 +58,8 @@ workflow Glimpse2LowPassImputation {
     scatter(contig in contigs) {
         File sites_vcf = reference_panel_prefix + "sites." + contig + ".vcf.gz"
         File sites_vcf_index =reference_panel_prefix + "sites." + contig + ".vcf.gz.tbi"
-        File sites_table = reference_panel_prefix + "sites_table." + contig + ".vcf.gz"
-        File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".vcf.gz.tbi"
+        File sites_table = reference_panel_prefix + "sites_table." + contig + ".gz"
+        File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".gz.tbi"
         File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
         if (defined(crams)) {
@@ -276,7 +276,7 @@ task BcftoolsMpileup {
         File sites_vcf
 
         Int seed = 12345
-        Int mem_gb = 4
+        Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 0
     }
@@ -318,7 +318,7 @@ task BcftoolsCall {
         File sites_table
         File sites_table_index
 
-        Int mem_gb = 4
+        Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 3
     }
@@ -350,7 +350,7 @@ task BcftoolsNorm {
     input {
         File calls_bcf
 
-        Int mem_gb = 4
+        Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 3
     }

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,9 +4,9 @@ workflow Glimpse2LowPassImputation {
     input {
         String pipeline_version = "0.0.3"
 
-        # List of files, one per line
-
         Array[String] contigs
+
+        # this is the path the a directory that contains sites vcf, sites tabke, and reference chunks file.  should end with a "/
         String reference_panel_prefix
 
         File? input_vcf
@@ -296,7 +296,6 @@ task BcftoolsMpileup {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
-        maxRetries: max_retries
         maxRetries: max_retries
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -22,16 +22,12 @@ workflow Glimpse2LowPassImputation {
 
         Boolean impute_reference_only_variants = false
         Boolean call_indels = false
-        Int? n_burnin
-        Int? n_main
-        Int? effective_population_size
 
         # batch size used when calling SplitIntoBatches to make variant calls from the crams
         Int calling_batch_size = 100
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
         String glimpse_docker = "us.gcr.io/broad-dsde-methods/glimpse:kachulis_ck_bam_reader_retry_cf5822c"
-        String docker_extract_num_sites_from_reference_chunk = "us.gcr.io/broad-dsde-methods/glimpse_extract_num_sites_from_reference_chunks:michaelgatzen_edc7f3a"
     }
 
     if (defined(input_vcf)) {
@@ -121,9 +117,6 @@ workflow Glimpse2LowPassImputation {
                     input_vcf = select_first([merged_vcf,input_vcf]),
                     input_vcf_index = select_first([merged_vcf_index,input_vcf_index]),
                     impute_reference_only_variants = impute_reference_only_variants,
-                    n_burnin = n_burnin,
-                    n_main = n_main,
-                    effective_population_size = effective_population_size,
                     call_indels = call_indels,
                     sample_ids = sample_ids,
                     fasta = fasta,
@@ -279,11 +272,10 @@ task BcftoolsMpileup {
         Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 0
+        Int max_retries = 3
     }
 
     Int disk_size_gb = ceil(1.5*size(crams, "GiB") + size(fasta, "GiB") + size(sites_vcf, "GiB")) + 10
-
-    String out_basename = "batch"
 
     command <<<
         set -xeuo pipefail
@@ -304,6 +296,8 @@ task BcftoolsMpileup {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        maxRetries: max_retries
+        maxRetries: max_retries
     }
 
     output {
@@ -321,11 +315,10 @@ task BcftoolsCall {
         Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 3
+        Int max_retries = 3
     }
 
     Int disk_size_gb = ceil(3*size(mpileup_bcf, "GiB") + size(sites_table, "GiB")) + 10
-
-    String out_basename = "batch"
 
     command <<<
         set -xeuo pipefail
@@ -339,6 +332,7 @@ task BcftoolsCall {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        maxRetries: max_retries
     }
 
     output {
@@ -353,18 +347,17 @@ task BcftoolsNorm {
         Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 3
+        Int max_retries = 3
     }
 
     Int disk_size_gb = ceil(3*size(calls_bcf, "GiB")) + 10
-
-    String out_basename = "batch"
 
     command <<<
         set -xeuo pipefail
 
 
-        bcftools norm -m -both -Oz -o ~{out_basename}.vcf.gz ~{calls_bcf}
-        bcftools index -t ~{out_basename}.vcf.gz
+        bcftools norm -m -both -Oz -o normalized.vcf.gz ~{calls_bcf}
+        bcftools index -t normalized.vcf.gz
     >>>
 
     runtime {
@@ -373,11 +366,12 @@ task BcftoolsNorm {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        maxRetries: max_retries
     }
 
     output {
-        File output_vcf = "~{out_basename}.vcf.gz"
-        File output_vcf_index = "~{out_basename}.vcf.gz.tbi"
+        File output_vcf = "normalized.vcf.gz"
+        File output_vcf_index = "normalized.vcf.gz.tbi"
     }
 }
 
@@ -385,9 +379,10 @@ task BcftoolsMerge {
     input {
         Array[File] vcfs
         Array[File] vcf_indices
-        Int mem_gb = 4
+        Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 0
+        Int max_retries = 3
 
         String output_basename
     }
@@ -406,6 +401,7 @@ task BcftoolsMerge {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        maxRetries: max_retries
     }
 
     output {
@@ -738,8 +734,6 @@ task CreateVcfIndexAndMd5 {
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
         Int preemptible = 3
     }
-    Int command_mem = memory_mb - 1500
-    Int max_heap = memory_mb - 1000
 
     String vcf_basename = basename(vcf_input)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -120,8 +120,8 @@ workflow Glimpse2LowPassImputation {
             call GlimpsePhase {
                 input:
                     reference_chunk = ComputeShardsAndMemoryPerShard.reference_chunk_file_paths[reference_chunk_index],
-                    input_vcf = select_first([merged_vcf,input_vcf]),
-                    input_vcf_index = select_first([merged_vcf_index,input_vcf_index]),
+                    input_vcf = select_first([merged_vcf,input_vcf_scatter_2]),
+                    input_vcf_index = select_first([merged_vcf_index,input_vcf_scatter_2_index]),
                     impute_reference_only_variants = impute_reference_only_variants,
                     call_indels = call_indels,
                     sample_ids = sample_ids,

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -58,6 +58,9 @@ workflow Glimpse2LowPassImputation {
         File sites_table_index = reference_panel_prefix + "sites_table." + contig + ".gz.tbi"
         File reference_chunks = reference_panel_prefix + "reference_chunks." + contig + ".txt"
 
+        File? input_vcf = input_vcf
+        File? input_vcf_index = input_vcf_index
+
         if (defined(crams)) {
             Array[Array[String]] crams_batches = select_first([SplitIntoBatches.crams_batches, [select_first([crams])]])
             Array[Array[String]] cram_indices_batches = select_first([SplitIntoBatches.cram_indices_batches, [select_first([cram_indices])]])
@@ -110,6 +113,9 @@ workflow Glimpse2LowPassImputation {
         }
 
         scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
+
+            File? input_vcf = input_vcf
+            File? input_vcf_index = input_vcf_index
 
             call GlimpsePhase {
                 input:
@@ -312,7 +318,7 @@ task BcftoolsCall {
         File sites_table
         File sites_table_index
 
-        Int mem_gb = 6
+        Int mem_gb = 12
         Int cpu = 1
         Int preemptible = 3
         Int max_retries = 3

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -98,7 +98,7 @@ workflow Glimpse2LowPassImputation {
             }
 
             File phase_input_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0], input_vcf])
-            File phase_input_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0],input_vcf_index])
+            File phase_input_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0], input_vcf_index])
         }
 
         ## this task is used to grab the reference chunk but does not affect memory usage of glimpsePhase.

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -248,8 +248,8 @@ task ComputeShardsAndMemoryPerShard {
         df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)
 
         # calculate memory usage and save to file
-        df['mem_gb'] = filtered_df['base_gb'] + filtered_df['slope_per_sample_gb'] * ~{n_samples}
-        df['mem_gb'] = filtered_df['mem_gb'].apply(lambda x: min(256, int(np.ceil(x))))  # cap at 256 GB
+        df['mem_gb'] = df['base_gb'] + df['slope_per_sample_gb'] * ~{n_samples}
+        df['mem_gb'] = df['mem_gb'].apply(lambda x: min(256, int(np.ceil(x))))  # cap at 256 GB
         df['mem_gb'].to_csv('memory_per_chunk.tsv', sep='\t', index=False, header=None)
         EOF
     >>>


### PR DESCRIPTION
### Description
These changes make it so the computation done in the workflow is driven by the `contigs` input.  The workflow becomes  more user friendly for both our service and for users using the wdl directly.  The downside is that now the reference related files need to live in the same cloud base path.

chr20 run - https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/474ebcfe-5a0a-4e76-833a-c8df096e1f43

chr1 + chr20 run - https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/e0c5e12d-42c0-407d-972c-c203be894563

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
