### PR TITLE
update StarAlign.wdl to move chemistry decision logic to the workflow…

### DIFF
--- a/WARP_WDL_Style_Guide.md
+++ b/WARP_WDL_Style_Guide.md
@@ -46,6 +46,28 @@
    - Cloud provider support inputs and validation
    - Output block organization
    - Error handling with ErrorWithMessage task
+   - **Workflow-level parameter derivation**
+     - Compute derived values (e.g. tool flags, directory paths, numeric parameters) as WDL expressions in the workflow, not as bash conditionals inside task command blocks
+     - Pass the computed values as explicit task inputs rather than raw enum/mode inputs that the task must interpret
+     - This keeps tasks focused on execution and makes the parameter contract visible in the WDL call site
+     - Example — instead of passing `Int chemistry` and branching in bash:
+       ```wdl
+       # Good: compute in workflow, pass to task
+       Int umi_len = if tenx_chemistry_version == 2 then 10 else 12
+       call MyTask { input: umi_len = umi_len }
+       ```
+       ```wdl
+       # Avoid: passing raw mode flag and branching in bash
+       call MyTask { input: chemistry = tenx_chemistry_version }
+       # ...where the task command block contains if/elif/else to derive umi_len
+       ```
+     - When a derived value requires string parsing that WDL 1.0 cannot express (e.g. parsing a read structure like `"8C18C9M1X"`), use a small dedicated utility task rather than embedding the logic in a large execution task
+   - **Input validation placement**
+     - Validate all user-facing inputs at the workflow level using `ErrorWithMessage` or a dedicated input-checking task (e.g. `checkOptimusInput`), not inside execution tasks
+     - Consolidate validation for a pipeline into a single task or workflow section so there is one place to check for all constraints
+     - Do not duplicate validation in both the workflow and the task — validate once upstream, then trust the inputs downstream
+   - **Derived values with embedded spaces**
+     - When a derived string contains spaces (e.g. `"GeneFull_Ex50pAS Gene"` for STAR's `--soloFeatures`), add a comment at the declaration site noting that the value is intentionally multi-word and must remain unquoted in the command block
 
 ## 6. Task Structure
 
@@ -60,6 +82,11 @@
 - Runtime parameter specification
   - Docker image handling for multi-cloud
   - Memory, CPU, disk sizing
+- **Task purity principle**
+  - Tasks should execute their tool with the parameters they are given, not decide *what* to run based on mode flags
+  - Bash conditionals in command blocks are appropriate for post-execution file handling (moving outputs, renaming files) but not for deriving tool parameters or validating inputs
+  - If a task currently branches on a mode input to select different tool flags, refactor by computing the flag values at the workflow level and passing them as explicit inputs
+  - This makes tasks reusable across workflows without carrying pipeline-specific validation logic
 
 ## 7. Docker Handling
 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,16 +9,16 @@ IlluminaGenotypingArray	 1.12.27	2026-01-21
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
-MultiSampleSmartSeq2SingleNucleus	 2.2.5	2026-02-24 
-Multiome	 6.1.5	2026-02-24 
+MultiSampleSmartSeq2SingleNucleus	 2.2.6	2026-03-31 
+Multiome	 6.1.6	2026-03-31 
 Optimus	 8.0.7	2026-03-31 
-PairedTag	 2.1.11	2026-02-24 
+PairedTag	 2.1.12	2026-03-31 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.6	2026-03-31 
-SlideTags	 1.0.8	2026-02-24 
+SlideTags	 1.0.9	2026-03-31 
 UltimaGenomicsJointGenotyping	 1.2.3	2025-08-11 
 UltimaGenomicsWholeGenomeCramOnly	 1.1.3	2026-01-21 
 UltimaGenomicsWholeGenomeGermline	 1.2.2	2026-01-29 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -11,13 +11,13 @@ ImputationBeagle	 3.0.1	2026-02-23
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.5	2026-02-24 
 Multiome	 6.1.5	2026-02-24 
-Optimus	 8.0.6	2026-02-24 
+Optimus	 8.0.7	2026-03-31 
 PairedTag	 2.1.11	2026-02-24 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
-SlideSeq	 3.6.5	2026-02-24 
+SlideSeq	 3.6.6	2026-03-31 
 SlideTags	 1.0.8	2026-02-24 
 UltimaGenomicsJointGenotyping	 1.2.3	2025-08-11 
 UltimaGenomicsWholeGenomeCramOnly	 1.1.3	2026-01-21 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -10,16 +10,16 @@ IlluminaGenotypingArray	 1.12.27	2026-01-21
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
-MultiSampleSmartSeq2SingleNucleus	 2.2.6	2026-03-31 
-Multiome	 6.1.6	2026-03-31 
-Optimus	 8.0.7	2026-03-31 
-PairedTag	 2.1.12	2026-03-31 
+MultiSampleSmartSeq2SingleNucleus	 2.2.7	2026-04-16 
+Multiome	 6.1.7	2026-04-16 
+Optimus	 9.0.0	2026-04-16 
+PairedTag	 2.1.13	2026-04-16 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.6	2026-03-31 
-SlideTags	 1.0.9	2026-03-31 
+SlideTags	 1.0.10	2026-04-16 
 UltimaGenomicsJointGenotyping	 1.2.3	2025-08-11 
 UltimaGenomicsWholeGenomeCramOnly	 1.1.3	2026-01-21 
 UltimaGenomicsWholeGenomeGermline	 1.2.2	2026-01-29 

--- a/pipelines/wdl/multiome/Multiome.changelog.md
+++ b/pipelines/wdl/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 6.1.7
+2026-04-16 (Date of Last Commit)
+
+* Updated StarAlign.wdl dependency; STARsoloFastq task now uses a separate output_base prefix for exon matrix files; this does not affect Multiome outputs as count_exons defaults to false
+
 # 6.1.6
 2026-03-31 (Date of Last Commit)
 

--- a/pipelines/wdl/multiome/Multiome.changelog.md
+++ b/pipelines/wdl/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 6.1.6
+2026-03-31 (Date of Last Commit)
+
+* Updated Optimus sub-workflow to v8.0.7 which moved conditional logic for STAR parameters out of task command blocks into workflow-level WDL expressions; this does not affect the outputs of this pipeline
+
 # 6.1.5
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/multiome/Multiome.wdl
+++ b/pipelines/wdl/multiome/Multiome.wdl
@@ -10,7 +10,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 workflow Multiome {
 
 
-    String pipeline_version = "6.1.5"
+    String pipeline_version = "6.1.6"
 
 
     input {

--- a/pipelines/wdl/multiome/Multiome.wdl
+++ b/pipelines/wdl/multiome/Multiome.wdl
@@ -10,7 +10,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 workflow Multiome {
 
 
-    String pipeline_version = "6.1.6"
+    String pipeline_version = "6.1.7"
 
 
     input {

--- a/pipelines/wdl/optimus/Optimus.changelog.md
+++ b/pipelines/wdl/optimus/Optimus.changelog.md
@@ -1,3 +1,10 @@
+# 9.0.0
+2026-04-16 (Date of Last Commit)
+
+* Fixed bug where exon-only sparse count matrix files overwrote the full-transcript matrix files when counting_mode is sn_rna and count_exons is true; exon matrix outputs now use a separate output_base prefix (input_id_exon)
+* Added three optional task outputs to STARsoloFastq for the exon NPZ files: sparse_counts_exon, row_index_exon, col_index_exon
+* Updated SingleNucleusOptimusH5adOutput call to pass the correct exon-only matrices instead of duplicating the full-transcript matrices
+
 # 8.0.7
 2026-03-31 (Date of Last Commit)
 

--- a/pipelines/wdl/optimus/Optimus.changelog.md
+++ b/pipelines/wdl/optimus/Optimus.changelog.md
@@ -1,3 +1,12 @@
+# 8.0.7
+2026-03-31 (Date of Last Commit)
+
+* Moved conditional logic for chemistry, counting mode, strand mode, and solo features out of STARsoloFastq bash command block into workflow-level WDL expressions
+* Added star_strand_mode validation to checkOptimusInput task
+* Replaced chemistry input with explicit umi_len, cb_len, solo_features, and solo_directory task inputs for STARsoloFastq
+* Removed redundant bash input validation from STARsoloFastq task (already validated by checkOptimusInput)
+* No functional changes to pipeline outputs
+
 # 8.0.6
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/optimus/Optimus.wdl
+++ b/pipelines/wdl/optimus/Optimus.wdl
@@ -78,7 +78,7 @@ workflow Optimus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "8.0.6"
+  String pipeline_version = "8.0.7"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))
@@ -148,6 +148,7 @@ workflow Optimus {
       force_no_check = force_no_check,
       counting_mode = counting_mode,
       count_exons = count_exons,
+      star_strand_mode = star_strand_mode,
       gcp_whitelist_v2 = gcp_whitelist_v2,
       gcp_whitelist_v3 = gcp_whitelist_v3,
       azure_whitelist_v2 = azure_whitelist_v2,
@@ -165,6 +166,14 @@ workflow Optimus {
       ubuntu_docker_path = ubuntu_docker_prefix + ubuntu_docker
   }
 
+  # Compute STAR parameters at workflow level instead of bash conditionals in task
+  Int umi_len = if tenx_chemistry_version == 2 then 10 else 12
+  Int cb_len = 16
+  String solo_features = if counting_mode == "sc_rna" then "Gene"
+                         else if count_exons then "GeneFull_Ex50pAS Gene"
+                         else "GeneFull_Ex50pAS"
+  String solo_directory = if counting_mode == "sc_rna" then "Solo.out/Gene" else "Solo.out/GeneFull_Ex50pAS"
+
   call StarAlign.STARsoloFastq as STARsoloFastq {
       input:
         r1_fastq = r1_fastq,
@@ -172,7 +181,10 @@ workflow Optimus {
         star_strand_mode = star_strand_mode,
         white_list = whitelist,
         tar_star_reference = tar_star_reference,
-        chemistry = tenx_chemistry_version,
+        umi_len = umi_len,
+        cb_len = cb_len,
+        solo_features = solo_features,
+        solo_directory = solo_directory,
         counting_mode = counting_mode,
         count_exons = count_exons,
         input_id = input_id,

--- a/pipelines/wdl/optimus/Optimus.wdl
+++ b/pipelines/wdl/optimus/Optimus.wdl
@@ -78,7 +78,7 @@ workflow Optimus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "8.0.7"
+  String pipeline_version = "9.0.0"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))
@@ -265,9 +265,9 @@ workflow Optimus {
         sparse_count_matrix = STARsoloFastq.sparse_counts,
         cell_id = STARsoloFastq.row_index,
         gene_id = STARsoloFastq.col_index,
-        sparse_count_matrix_exon = STARsoloFastq.sparse_counts,
-        cell_id_exon = STARsoloFastq.row_index,
-        gene_id_exon = STARsoloFastq.col_index,
+        sparse_count_matrix_exon = select_first([STARsoloFastq.sparse_counts_exon]),
+        cell_id_exon = select_first([STARsoloFastq.row_index_exon]),
+        gene_id_exon = select_first([STARsoloFastq.col_index_exon]),
         pipeline_version = "Optimus_v~{pipeline_version}",
         warp_tools_docker_path = docker_prefix + warp_tools_docker,
         gex_whitelist_gs_path = whitelist

--- a/pipelines/wdl/paired_tag/PairedTag.changelog.md
+++ b/pipelines/wdl/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 2.1.12
+2026-03-31 (Date of Last Commit)
+
+* Updated Optimus sub-workflow to v8.0.7 which moved conditional logic for STAR parameters out of task command blocks into workflow-level WDL expressions; this does not affect the outputs of this pipeline
+
 # 2.1.11
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/paired_tag/PairedTag.changelog.md
+++ b/pipelines/wdl/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 2.1.13
+2026-04-16 (Date of Last Commit)
+
+* Updated StarAlign.wdl dependency; STARsoloFastq task now uses a separate output_base prefix for exon matrix files; this does not affect PairedTag outputs as count_exons defaults to false
+
 # 2.1.12
 2026-03-31 (Date of Last Commit)
 

--- a/pipelines/wdl/paired_tag/PairedTag.wdl
+++ b/pipelines/wdl/paired_tag/PairedTag.wdl
@@ -9,7 +9,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow PairedTag {
 
-    String pipeline_version = "2.1.12"
+    String pipeline_version = "2.1.13"
 
     input {
         String input_id

--- a/pipelines/wdl/paired_tag/PairedTag.wdl
+++ b/pipelines/wdl/paired_tag/PairedTag.wdl
@@ -9,7 +9,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow PairedTag {
 
-    String pipeline_version = "2.1.11"
+    String pipeline_version = "2.1.12"
 
     input {
         String input_id

--- a/pipelines/wdl/slideseq/SlideSeq.changelog.md
+++ b/pipelines/wdl/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,11 @@
+# 3.6.6
+2026-03-31 (Date of Last Commit)
+
+* Moved read structure parsing out of STARsoloFastqSlideSeq bash command block into a new ParseReadStructure task called at the workflow level
+* Moved solo features conditional logic out of STARsoloFastqSlideSeq bash command block into a workflow-level WDL expression
+* Replaced read_structure input with explicit umi_len, cb_len, and solo_features task inputs for STARsoloFastqSlideSeq
+* No functional changes to pipeline outputs
+
 # 3.6.5
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/slideseq/SlideSeq.wdl
+++ b/pipelines/wdl/slideseq/SlideSeq.wdl
@@ -25,7 +25,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow SlideSeq {
 
-    String pipeline_version = "3.6.5"
+    String pipeline_version = "3.6.6"
 
     input {
         Array[File] r1_fastq
@@ -55,6 +55,11 @@ workflow SlideSeq {
     String gcp_ubuntu_docker_prefix = "gcr.io/gcp-runtimes/"
     String acr_ubuntu_docker_prefix = "dsppipelinedev.azurecr.io/"
     String ubuntu_docker_prefix = if cloud_provider == "gcp" then gcp_ubuntu_docker_prefix else acr_ubuntu_docker_prefix
+
+    String alpine_docker = "alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf652a8e4c2db858ff"
+    String gcp_alpine_docker_prefix = "bashell/"
+    String acr_alpine_docker_prefix = "dsppipelinedev.azurecr.io/"
+    String alpine_docker_prefix = if cloud_provider == "gcp" then gcp_alpine_docker_prefix else acr_alpine_docker_prefix
 
     String gcr_docker_prefix = "us.gcr.io/broad-gotc-prod/"
     String acr_docker_prefix = "dsppipelinedev.azurecr.io/"
@@ -100,6 +105,15 @@ workflow SlideSeq {
             sample_id = input_id,
             whitelist = bead_locations
     }
+
+    # Parse read structure into UMI and CB lengths, and compute solo_features at workflow level
+    call StarAlign.ParseReadStructure as ParseReadStructure {
+        input:
+            read_structure = read_structure,
+            alpine_docker_path = alpine_docker_prefix + alpine_docker
+    }
+    String slideseq_solo_features = if count_exons then "Gene GeneFull" else "GeneFull"
+
     scatter(idx in range(length(SplitFastq.fastq_R1_output_array))) {
         call StarAlign.STARsoloFastqSlideSeq as STARsoloFastqSlideSeq {
             input:
@@ -108,7 +122,9 @@ workflow SlideSeq {
                 whitelist = bead_locations,
                 tar_star_reference = tar_star_reference,
                 output_bam_basename = output_bam_basename + "_" + idx,
-                read_structure = read_structure,
+                umi_len = ParseReadStructure.umi_len,
+                cb_len = ParseReadStructure.cb_len,
+                solo_features = slideseq_solo_features,
                 count_exons = count_exons
         }
     }

--- a/pipelines/wdl/slidetags/SlideTags.changelog.md
+++ b/pipelines/wdl/slidetags/SlideTags.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.9
+2026-03-31 (Date of Last Commit)
+
+* Updated Optimus sub-workflow to v8.0.7 which moved conditional logic for STAR parameters out of task command blocks into workflow-level WDL expressions; this does not affect the outputs of this pipeline
+
 # 1.0.8
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/slidetags/SlideTags.changelog.md
+++ b/pipelines/wdl/slidetags/SlideTags.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.10
+2026-04-16 (Date of Last Commit)
+
+* Updated StarAlign.wdl dependency; STARsoloFastq task now uses a separate output_base prefix for exon matrix files; this does not affect SlideTags outputs as count_exons defaults to false
+
 # 1.0.9
 2026-03-31 (Date of Last Commit)
 

--- a/pipelines/wdl/slidetags/SlideTags.wdl
+++ b/pipelines/wdl/slidetags/SlideTags.wdl
@@ -6,7 +6,7 @@ import "../optimus/Optimus.wdl" as optimus
 
 workflow SlideTags {
 
-    String pipeline_version = "1.0.9"
+    String pipeline_version = "1.0.10"
 
     input {
 

--- a/pipelines/wdl/slidetags/SlideTags.wdl
+++ b/pipelines/wdl/slidetags/SlideTags.wdl
@@ -6,7 +6,7 @@ import "../optimus/Optimus.wdl" as optimus
 
 workflow SlideTags {
 
-    String pipeline_version = "1.0.8"
+    String pipeline_version = "1.0.9"
 
     input {
 

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.7
+2026-04-16 (Date of Last Commit)
+
+* Updated StarAlign.wdl dependency; STARsoloFastq task now uses a separate output_base prefix for exon matrix files; this does not affect MultiSampleSmartSeq2SingleNucleus outputs
+
 # 2.2.6
 2026-03-31 (Date of Last Commit)
 

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.6
+2026-03-31 (Date of Last Commit)
+
+* Updated StarAlign.wdl dependency which refactored task inputs and added a new ParseReadStructure utility task; the tasks used by this pipeline (StarAlignFastqMultisample, STARGenomeRefVersion) are unchanged and this does not affect the outputs of this pipeline
+
 # 2.2.5
 2026-02-24 (Date of Last Commit)
 

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -59,7 +59,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "2.2.5"
+  String pipeline_version = "2.2.6"
 
   if (false) {
      String? none = "None"

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -59,7 +59,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "2.2.6"
+  String pipeline_version = "2.2.7"
 
   if (false) {
      String? none = "None"

--- a/tasks/wdl/CheckInputs.wdl
+++ b/tasks/wdl/CheckInputs.wdl
@@ -61,6 +61,7 @@ task checkOptimusInput {
     String counting_mode
     Boolean force_no_check
     Boolean count_exons
+    String star_strand_mode
     Int disk = ceil(size(r1_fastq, "GiB")) + 50
     Int machine_mem_mb = 1000
     Int cpu = 1
@@ -97,6 +98,12 @@ task checkOptimusInput {
     then
       pass="false"
       echo "ERROR: Invalid value \"${counting_mode}\" for input \"counting_mode\""
+    fi
+
+    if [[ ! ("~{star_strand_mode}" == "Forward" || "~{star_strand_mode}" == "Reverse" || "~{star_strand_mode}" == "Unstranded") ]]
+    then
+      pass="false"
+      echo "ERROR: Invalid value \"~{star_strand_mode}\" for input \"star_strand_mode\". Should be Forward, Reverse, or Unstranded."
     fi
 
     if [[ ~{force_no_check} == "true" ]]

--- a/tasks/wdl/StarAlign.wdl
+++ b/tasks/wdl/StarAlign.wdl
@@ -389,6 +389,7 @@ task STARsoloFastq {
         local FEATURE_FILE=$3
         local MATRIX_FILE=$4
         local OUTPUT_DIR=$5
+        local OUTPUT_BASE=$6  # explicit output prefix for npz/npy files
 
         echo "Processing $MATRIX_NAME data..."
 
@@ -412,18 +413,19 @@ task STARsoloFastq {
         echo "tarring STAR txt files"
         tar -zcvf ~{input_id}.star_metrics.tar *.txt
        
-        # Create the compressed raw count matrix
+        # Create the compressed raw count matrix; --output_base keeps each matrix in its own files
         python3 /scripts/scripts/create-merged-npz-output.py \
-            --barcodes $BARCODE_FILE --features $FEATURE_FILE --matrix $MATRIX_FILE --input_id ~{input_id}
+            --barcodes $BARCODE_FILE --features $FEATURE_FILE --matrix $MATRIX_FILE \
+            --input_id ~{input_id} --output_base $OUTPUT_BASE
      
       }
 
-    # Process main matrix
-    process_matrix "matrix" "barcodes.tsv" "features.tsv" "matrix.mtx" "./output"
+    # Process main matrix (whole transcript / GeneFull_Ex50pAS)
+    process_matrix "matrix" "barcodes.tsv" "features.tsv" "matrix.mtx" "./output" "~{input_id}"
 
-    # Process snRNA matrix only if files exist
+    # Process snRNA/exon matrix only if files exist
     if [ -s "barcodes_sn_rna.tsv" ]; then
-        process_matrix "matrix_sn_rna" "barcodes_sn_rna.tsv" "features_sn_rna.tsv" "matrix_sn_rna.mtx" "./outputsnrna"
+        process_matrix "matrix_sn_rna" "barcodes_sn_rna.tsv" "features_sn_rna.tsv" "matrix_sn_rna.mtx" "./outputsnrna" "~{input_id}_exon"
     fi
 
     ls -lR
@@ -468,6 +470,10 @@ task STARsoloFastq {
     File row_index = "~{input_id}_sparse_counts_row_index.npy"
     File col_index = "~{input_id}_sparse_counts_col_index.npy"
     File sparse_counts = "~{input_id}_sparse_counts.npz"
+    # Exon-only NPZ outputs (only populated when counting_mode=sn_rna and count_exons=true)
+    File? row_index_exon = "~{input_id}_exon_sparse_counts_row_index.npy"
+    File? col_index_exon = "~{input_id}_exon_sparse_counts_col_index.npy"
+    File? sparse_counts_exon = "~{input_id}_exon_sparse_counts.npz"
     File? library_metrics="~{input_id}_library_metrics.csv"
     File? mtx_files ="~{input_id}.mtx_files.tar"
     File? filtered_mtx_files = "~{input_id}_filtered_mtx_files.tar"

--- a/tasks/wdl/StarAlign.wdl
+++ b/tasks/wdl/StarAlign.wdl
@@ -218,9 +218,12 @@ task STARsoloFastq {
     Array[File] r2_fastq
     File tar_star_reference
     File white_list
-    Int chemistry
+    Int umi_len
+    Int cb_len
     String star_strand_mode
-    String counting_mode # when counting_mode = sn_rna, runs Gene and GeneFullEx50pAS in single alignments
+    String solo_features
+    String solo_directory
+    String counting_mode
     String input_id
     String output_bam_basename
     Boolean? count_exons
@@ -267,59 +270,10 @@ task STARsoloFastq {
 
     ulimit -n 10000
 
-    UMILen=10
-    CBLen=16
-    if [ "~{chemistry}" == 2 ]
-    then
-        ## V2
-        UMILen=10
-        CBLen=16
-    elif [ "~{chemistry}" == 3 ]
-    then
-        ## V3
-        UMILen=12
-        CBLen=16
-    else
-        echo Error: unknown chemistry value: "$chemistry". Should be one of "tenX_v2" or "texX_v3".
-        exit 1;
-    fi
-
-    # Check that the star strand mode matches STARsolo aligner options
-    if [[ "~{star_strand_mode}" == "Forward" ]] || [[ "~{star_strand_mode}" == "Reverse" ]] || [[ "~{star_strand_mode}" == "Unstranded" ]]
-    then
-        ## single cell or whole cell
-        echo STAR mode is assigned
-    else
-        echo Error: unknown STAR strand mode: "~{star_strand_mode}". Should be Forward, Reverse, or Unstranded.
-        exit 1;
-    fi
-
     # prepare reference
     mkdir genome_reference
     tar -xf "~{tar_star_reference}" -C genome_reference --strip-components 1
     rm "~{tar_star_reference}"
-
-    COUNTING_MODE=""
-    if [[ "~{counting_mode}" == "sc_rna" ]]
-    then
-        # single cell or whole cell
-        COUNTING_MODE="Gene"
-        echo "Running in ~{counting_mode} mode. The Star parameter --soloFeatures will be set to $COUNTING_MODE"
-    elif [[ "~{counting_mode}" == "sn_rna" ]]
-    then
-        # single nuclei
-        if [[ ~{count_exons} == false ]]
-        then
-            COUNTING_MODE="GeneFull_Ex50pAS"
-            echo "Running in ~{counting_mode} mode. Count_exons is false and the Star parameter --soloFeatures will be set to $COUNTING_MODE"
-        else
-            COUNTING_MODE="GeneFull_Ex50pAS Gene"
-            echo "Running in ~{counting_mode} mode. Count_exons is true and the Star parameter --soloFeatures will be set to $COUNTING_MODE"     
-        fi
-    else
-        echo Error: unknown counting mode: "$counting_mode". Should be either sn_rna or sc_rna.
-        exit 1;
-    fi
 
     # convert limitBAMsortRAM from GB to bytes 
     RAM_limit_bytes=$((1073741824 * ~{limitBAMsortRAM})) 
@@ -334,8 +288,8 @@ task STARsoloFastq {
         --readFilesIn "~{sep=',' r2_fastq}" "~{sep=',' r1_fastq}" \
         --readFilesCommand "gunzip -c" \
         --soloCBwhitelist ~{white_list} \
-        --soloUMIlen $UMILen --soloCBlen $CBLen \
-        --soloFeatures $COUNTING_MODE \
+        --soloUMIlen ~{umi_len} --soloCBlen ~{cb_len} \
+        --soloFeatures ~{solo_features} \
         --clipAdapterType CellRanger4 \
         --outFilterScoreMin 30  \
         --soloCBmatchWLtype ~{soloCBmatchWLtype} \
@@ -357,12 +311,14 @@ task STARsoloFastq {
     echo -e "@CO\tReference genome used: ~{reference_path}" >> header.txt
     samtools reheader header.txt Aligned.sortedByCoord.out.bam > Aligned.sortedByCoord.out.reheader.bam
 
-    echo "UMI LEN " $UMILen
+    echo "UMI LEN " ~{umi_len}
     touch barcodes_sn_rna.tsv features_sn_rna.tsv matrix_sn_rna.mtx CellReads_sn_rna.stats Features_sn_rna.stats Summary_sn_rna.csv UMIperCellSorted_sn_rna.txt
       
     ###########################################################################
     # SAVE OUTPUT FILES
     ###########################################################################
+    SoloDirectory="~{solo_directory}"
+
     # Function to move .mtx files to /cromwell_root/
     move_mtx_files() {
       local directory=$1
@@ -403,26 +359,14 @@ task STARsoloFastq {
       done
     }
 
-    if [[ "~{counting_mode}" == "sc_rna" ]]
-    then
-      SoloDirectory="Solo.out/Gene"
-      echo "SoloDirectory is $SoloDirectory"
-      move_mtx_files "$SoloDirectory"
-      move_common_files "$SoloDirectory" ""
-    elif [[ "~{counting_mode}" == "sn_rna" ]]
-    then
-      SoloDirectory="Solo.out/GeneFull_Ex50pAS"
-      move_mtx_files "$SoloDirectory"     
-      if [[ "~{count_exons}" == "true" ]]; then
-        # Additional processing for sn_rna with exon counting
-        SoloDirectory2="Solo.out/Gene"
-        find "$SoloDirectory2/raw" -maxdepth 1 -type f -name "*.mtx" -print0 | xargs -0 -I{} sh -c 'new_name="$(basename {} .mtx)_sn_rna.mtx"; echo Renaming {}; mv {} "/cromwell_root/$new_name"'
-        move_common_files "$SoloDirectory2" "_sn_rna"  # Add snRNA for renaming
-      fi
-      move_common_files "$SoloDirectory" ""  # Standard snRNA renaming
-    else
-      echo Error: unknown counting mode: "$counting_mode". Should be either sn_rna or sc_rna.
+    move_mtx_files "$SoloDirectory"
+    if [[ "~{count_exons}" == "true" && "~{counting_mode}" == "sn_rna" ]]; then
+      # Additional processing for sn_rna with exon counting
+      SoloDirectory2="Solo.out/Gene"
+      find "$SoloDirectory2/raw" -maxdepth 1 -type f -name "*.mtx" -print0 | xargs -0 -I{} sh -c 'new_name="$(basename {} .mtx)_sn_rna.mtx"; echo Renaming {}; mv {} "/cromwell_root/$new_name"'
+      move_common_files "$SoloDirectory2" "_sn_rna"  # Add snRNA for renaming
     fi
+    move_common_files "$SoloDirectory" ""
 
     # filtered outputs in Solo.out/GeneFull_Ex50pAS/filtered: barcodes.tsv features.tsv matrix.mtx
     ls ${SoloDirectory}/filtered
@@ -725,7 +669,9 @@ task STARsoloFastqSlideSeq {
     File tar_star_reference
     File whitelist
     String output_bam_basename
-    String read_structure
+    Int umi_len
+    Int cb_len
+    String solo_features
     Boolean? count_exons
 
     # runtime values
@@ -738,38 +684,13 @@ task STARsoloFastqSlideSeq {
     Int preemptible = 3
   }
 
+  Int umi_start = 1 + cb_len
+
   command <<<
     set -e
     declare -a fastq1_files=(~{sep=' ' r1_fastq})
     declare -a fastq2_files=(~{sep=' ' r2_fastq})
     cut -f 1 ~{whitelist} > WhiteList.txt
-
-    nums=$(echo ~{read_structure} | sed 's/[[:alpha:]]/ /g')
-    read -a arr_num <<< $nums
-
-    chars=$(echo ~{read_structure} | sed 's/[[:digit:]]/ /g')
-    read -a arr_char <<< $chars
-
-    UMILen=0
-    CBLen=0
-    for (( i=0; i<${#arr_char[@]}; ++i));
-      do
-        if [[ ${arr_char[$i]} == 'C' ]]
-        then
-          CBLen=$(( CBLen + arr_num[$i] ))
-        elif [[ ${arr_char[$i]} == 'M' ]]
-        then
-          UMILen=$(( UMILen + arr_num[$i] ))
-        fi
-    done;
-    UMIstart=$(( 1 + CBLen))
-
-    # If this argument is true, we will count reads aligned to exons in addition
-    COUNTING_MODE="GeneFull"
-    if ~{count_exons}
-    then
-      COUNTING_MODE="Gene GeneFull"
-    fi
 
     # prepare reference
     mkdir genome_reference
@@ -779,17 +700,17 @@ task STARsoloFastqSlideSeq {
     STAR \
       --soloType Droplet \
       --soloCBwhitelist WhiteList.txt \
-      --soloFeatures $COUNTING_MODE \
+      --soloFeatures ~{solo_features} \
       --runThreadN ~{cpu} \
       --genomeDir genome_reference \
       --readFilesIn $fastq2_files $fastq1_files \
       --readFilesCommand "gunzip -c" \
       --soloInputSAMattrBarcodeSeq CR UR \
       --soloInputSAMattrBarcodeQual CY UY \
-      --soloCBlen $CBLen \
+      --soloCBlen ~{cb_len} \
       --soloCBstart 1 \
-      --soloUMIlen $UMILen \
-      --soloUMIstart $UMIstart \
+      --soloUMIlen ~{umi_len} \
+      --soloUMIstart ~{umi_start} \
       --outSAMtype BAM SortedByCoordinate \
       --clip3pAdapterSeq AAAAAA \
       --clip3pAdapterMMp 0.1 \
@@ -877,5 +798,51 @@ task STARGenomeRefVersion {
     disks: "local-disk ${disk} HDD"
     disk: disk + " GB" # TES
     cpu:"1"
+  }
+}
+
+task ParseReadStructure {
+  input {
+    String read_structure
+    String alpine_docker_path = "bashell/alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf652a8e4c2db858ff"
+  }
+
+  meta {
+    description: "Parses a read structure string (e.g. 8C18C9M1X) into UMI length and cell barcode length"
+  }
+
+  command <<<
+    set -e
+    nums=$(echo ~{read_structure} | sed 's/[[:alpha:]]/ /g')
+    read -a arr_num <<< $nums
+
+    chars=$(echo ~{read_structure} | sed 's/[[:digit:]]/ /g')
+    read -a arr_char <<< $chars
+
+    UMILen=0
+    CBLen=0
+    for (( i=0; i<${#arr_char[@]}; ++i)); do
+      if [[ ${arr_char[$i]} == 'C' ]]; then
+        CBLen=$(( CBLen + arr_num[$i] ))
+      elif [[ ${arr_char[$i]} == 'M' ]]; then
+        UMILen=$(( UMILen + arr_num[$i] ))
+      fi
+    done
+
+    echo $UMILen > umi_len.txt
+    echo $CBLen > cb_len.txt
+  >>>
+
+  output {
+    Int umi_len = read_int("umi_len.txt")
+    Int cb_len = read_int("cb_len.txt")
+  }
+
+  runtime {
+    docker: alpine_docker_path
+    cpu: 1
+    memory: "1 GiB"
+    disks: "local-disk 10 HDD"
+    disk: "10 GB"
   }
 }


### PR DESCRIPTION
…, not the tasks

### Description

StarAlign had complex branching logic dependent on mode an chemistry in its tasks that made the run modes hard to follow and keep track of. This moves the Booleans and logic into the Workflow level where the decisions are made in one place. Small changes to Optimus and SlideSeq to support this. Note this code is all functionally equivalent to previous versions--purely and engineering patch for code maintainability. Finally we updated the WARP Style Guide to indicate the reasons for not writing decision logic into WDL Tasks in the future.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ X] If you made a changelog update, did you update the pipeline version number?
