### PR TITLE
TSPS-716 add quota consumed wdl for low pass imputation pipeline

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -85,6 +85,10 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
 
+  - name: Glimpse2LowPassImputationQuotaConsumed
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+
   - name: get_wgs_median_coverage
     subclass: WDL
     primaryDescriptorPath: /all_of_us/mitochondria/get_wgs_median_coverage.wdl

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,7 +4,8 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.4	2026-04-01 
+Glimpse2LowPassImputation	 0.0.4	2026-04-02
+Glimpse2LowPassImputationQuotaConsumed	 0.0.1	2026-04-02
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,8 +4,8 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.4	2026-04-02
-Glimpse2LowPassImputationQuotaConsumed	 0.0.1	2026-04-02
+Glimpse2LowPassImputation	 0.0.5	2026-04-03 
+Glimpse2LowPassImputationQuotaConsumed	 0.0.1	2026-04-02 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.5
+2026-04-03 (Date of Last Commit)
+
+* add quota consumed wdl version
+
 # 0.0.4
 2026-04-01 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputation {
     input {
-        String pipeline_version = "0.0.4"
+        String pipeline_version = "0.0.5"
         String quota_consumed_version = "0.0.1"
 
         Array[String] contigs

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -7,7 +7,7 @@ workflow Glimpse2LowPassImputation {
 
         Array[String] contigs
 
-        # this is the path the a directory that contains sites vcf, sites table, and reference chunks file. should end with a "/"
+        # this is the path to a directory that contains sites vcf, sites table, and reference chunks file. should end with a "/"
         String reference_panel_prefix
 
         File? input_vcf

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -3,8 +3,7 @@ version 1.0
 workflow Glimpse2LowPassImputation {
     input {
         String pipeline_version = "0.0.4"
-
-        # List of files, one per line
+        String quota_consumed_version = "0.0.1"
 
         Array[String] contigs
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 workflow Glimpse2LowPassImputation {
+    String pipeline_version = "0.0.5"
+    String quota_consumed_version = "0.0.1"
+    
     input {
-        String pipeline_version = "0.0.5"
-        String quota_consumed_version = "0.0.1"
-
         Array[String] contigs
 
         # this is the path to a directory that contains sites vcf, sites table, and reference chunks file. should end with a "/"

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,0 +1,4 @@
+# 0.0.1
+2026-04-02 (Date of Last Commit)
+
+* first draft of quota consumed wdl for low pass imputation.  checks the size of the cram array input or the number of crams in the manifest file

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
@@ -24,12 +24,49 @@ workflow QuotaConsumed {
         File ref_dict
     }
 
-    call tasks.CountSamples {
-        input:
-            vcf = multi_sample_vcf
+    # validate that either crams, or cram manifest is provided
+    if (defined(crams)) {
+        Int quota_consumed = length(select_first([crams]))
+    }
+
+    if (defined(cram_manifest)) {
+        call CountCramsFromManifest {
+            input:
+                cram_manifest = select_first([cram_manifest])
+        }
     }
 
     output {
-        Int quota_consumed = CountSamples.nSamples
+        Int quota_consumed = select_first([quota_consumed, CountCramsFromManifest.cram_manifest_count, 0])
+    }
+}
+
+task CountCramsFromManifest {
+    input {
+        File cram_manifest
+
+        String docker = "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
+        Int cpu = 1
+        Int memory_mb = 4000
+        Int disk_size_gb = ceil(size(cram_manifest, "GiB")) + 10
+    }
+
+    command <<<
+        set -e -o pipefail
+
+        grep ".cram" ~{cram_manifest} | wc -l > cram_manifest_count.txt
+    >>>
+
+    output {
+        Int cram_manifest_count = read_int("cram_manifest_count.txt")
+    }
+    runtime {
+        docker: docker
+        disks: "local-disk ${disk_size_gb} HDD"
+        memory: "${memory_mb} MiB"
+        cpu: cpu
+        preemptible: 0
+        maxRetries: 1
+        noAddress: true
     }
 }

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
@@ -1,0 +1,35 @@
+version 1.0
+
+import "../../../../tasks/wdl/ImputationTasks.wdl" as tasks
+
+workflow QuotaConsumed {
+    # if this changes, update the quota_consumed_version value in Glimpse2LowPassImputation.wdl
+    String pipeline_version = "0.0.1"
+
+    input {
+        Array[String] contigs
+
+        # this is the path the a directory that contains sites vcf, sites table, and reference chunks file.  should end with a "/
+        String reference_panel_prefix
+
+        # service currently does not accept VCFs as input
+        Array[File]? crams
+        Array[File]? cram_indices
+        Array[String]? sample_ids
+        File? cram_manifest
+        File fasta
+        File fasta_index
+        String output_basename
+
+        File ref_dict
+    }
+
+    call tasks.CountSamples {
+        input:
+            vcf = multi_sample_vcf
+    }
+
+    output {
+        Int quota_consumed = CountSamples.nSamples
+    }
+}

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
@@ -9,7 +9,7 @@ workflow QuotaConsumed {
     input {
         Array[String] contigs
 
-        # this is the path the a directory that contains sites vcf, sites table, and reference chunks file.  should end with a "/
+        # this is the path to a directory that contains sites vcf, sites table, and reference chunks file. should end with a "/"
         String reference_panel_prefix
 
         # service currently does not accept VCFs as input


### PR DESCRIPTION
### Description

jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-716

The teaspoons service requires each wdl pipeline have a quota consumed wdl that tells the service how much quota the submission should consume. for low pass genome it can come from two places

if `crams` is defined, it will return then number of items in that array
if `cram_manifest` is defined, it will return the number of lines that contain ".cram" in them
otherwise it will return 0

cram defined - https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/64ca0d85-05ee-48b6-b8b8-506f406df5c0

cram_manifest defined - https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/e73f87bb-cb0e-40e4-934f-7d7407a39760
contents of the manifest file
```
header
blah_1.cram
sadfasdf	blah_2.cram

```

neither defined - https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/5f40d383-4b84-45fe-a690-439b40e669af

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
