### PR TITLE
fix: update broken relative imports in deprecated pipelines

### DIFF
--- a/all_of_us/PCA/pca_only_no_labels.wdl
+++ b/all_of_us/PCA/pca_only_no_labels.wdl
@@ -75,7 +75,7 @@ task ConcatenateChromosomalVcfs {
     runtime {
         docker: bcftools_docker
         memory: "${memory_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disk: "local-disk ${disk_gb} HDD"
         preemptible: num_preemptible_attempts
     }
@@ -155,7 +155,7 @@ task create_hw_pca_training {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "${mem_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disks: "local-disk ${disk_gb} ${disk_type}" # large SSD is recommended for increased processing speed
     }
 }
@@ -244,7 +244,7 @@ task plot_pca {
     runtime {
         docker: "faizanbashir/python-datascience:3.6"
         memory: "${mem_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disks: "local-disk ${disk_gb} HDD"
     }
 }

--- a/all_of_us/ancestry/determine_hq_sites_intersection.wdl
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.wdl
@@ -178,7 +178,7 @@ task sitesOnlyAndHQFilterVcf {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "12 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -244,7 +244,7 @@ task merge_vcf_bgzs {
     runtime {
         docker: "mgibio/bcftools-cwl:1.12"
         memory: "120 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk 1500 HDD"
         bootDiskSizeGb: 1500
     }
@@ -303,7 +303,7 @@ task filter_by_sites_only {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 100 HDD"
     }
 }
@@ -340,7 +340,7 @@ task intersect_vcfs_as_sites_only {
     runtime {
         docker: "us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 500 HDD"
     }
 }

--- a/all_of_us/ancestry/run_ancestry.wdl
+++ b/all_of_us/ancestry/run_ancestry.wdl
@@ -161,7 +161,7 @@ task create_hw_pca_training {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "123 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 500 HDD"
     }
 }
@@ -280,7 +280,7 @@ task call_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "240 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 700 HDD"
     }
 }
@@ -377,7 +377,7 @@ task plot_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/ancestry/run_sample_outlier_qc.wdl
+++ b/all_of_us/ancestry/run_sample_outlier_qc.wdl
@@ -100,7 +100,7 @@ task join_ancestry_to_stats {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "15 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk 500 HDD"
     }
 }
@@ -187,7 +187,7 @@ task determine_outlier_qc {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "15 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 500 HDD"
     }
 }

--- a/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl
+++ b/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl
@@ -100,7 +100,7 @@ task join_ancestry_to_demographics {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -144,7 +144,7 @@ task plot_first_pcs {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -246,7 +246,7 @@ task plot_metrics_and_fitting {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "26 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/pgx/CyriusStarAlleleCalling.wdl
+++ b/all_of_us/pgx/CyriusStarAlleleCalling.wdl
@@ -77,7 +77,7 @@ task PrintReads {
         docker: "us.gcr.io/broad-gotc-prod/gatk:1.3.0-4.2.6.1-1649964384"
         preemptible: preemptible_tries
         memory: "10000 MiB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
     }
     output {

--- a/all_of_us/pgx/StargazerFromJointVCF.wdl
+++ b/all_of_us/pgx/StargazerFromJointVCF.wdl
@@ -121,7 +121,7 @@ task SelectVariants {
     >>>
     runtime {
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: "us.gcr.io/broad-gatk/gatk:4.4.0.0"
     }

--- a/all_of_us/rna_seq/AggregateSusieWorkflow.wdl
+++ b/all_of_us/rna_seq/AggregateSusieWorkflow.wdl
@@ -30,7 +30,7 @@ task AggregateSusie{
         docker: "ghcr.io/aou-multiomics-analysis/aggregate_susie:main@sha256:ede17b5112eadb765f22cdfbd2a987da96087a1e2f0ad224994c16f1af645443"
         disks: "local-disk 500 SSD"
         memory: "~{Memory}GB"
-        cpu: "~{NumThreads}"
+        cpu: NumThreads
     }
     
  
@@ -77,7 +77,7 @@ task AnnotateSusie {
         docker: "ghcr.io/aou-multiomics-analysis/aggregate_susie:main@sha256:ede17b5112eadb765f22cdfbd2a987da96087a1e2f0ad224994c16f1af645443"
         disks: "local-disk 500 SSD"
         memory: "~{Memory}GB"
-        cpu: "1"
+        cpu: 1
     }
 
 

--- a/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl
+++ b/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl
@@ -26,7 +26,7 @@ task PrepareSpliceData {
         docker: "ghcr.io/aou-multiomics-analysis/prepare_qtl@sha256:b9986a803ad82aee02945e9131f180fc028c73eadb889184e23aff8dabf573fe"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/GTEx/aggregate_rsem_results.wdl
+++ b/all_of_us/rna_seq/GTEx/aggregate_rsem_results.wdl
@@ -52,7 +52,7 @@ task rsem_aggregate_results {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl
+++ b/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl
@@ -27,7 +27,7 @@ task leafcutter_bam_to_junc {
         docker: "gcr.io/broad-cga-francois-gtex/leafcutter:latest"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
     }
 

--- a/all_of_us/rna_seq/leafcutter_cluster.wdl
+++ b/all_of_us/rna_seq/leafcutter_cluster.wdl
@@ -62,7 +62,7 @@ task leafcutter_cluster {
         docker: "us.gcr.io/broad-gotc-prod/leafcutter:1.0.0"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
     }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl
@@ -59,7 +59,7 @@ workflow CaclulateAF {
             docker: "quay.io/biocontainers/plink2:2.0.0a.6.9--h9948957_0"
             memory: "~{memory}GB"
             disks: "local-disk ~{disk_space} HDD"
-            cpu: "~{num_threads}"
+            cpu: num_threads
 
         }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculateGenotypeDosage.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculateGenotypeDosage.wdl
@@ -50,7 +50,7 @@ task BcftoolsDosage {
     runtime {
         docker: "quay.io/eqtlcatalogue/susie-finemapping:v20.08.1"
         memory: "32G"
-        cpu: "${threads}"
+        cpu: threads
         disks: "local-disk 500 SSD"
     }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculate_phenotypePCs.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculate_phenotypePCs.wdl
@@ -18,7 +18,7 @@ task ComputePCs{
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/prepare_QTL/prepare_eQTL.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/prepare_eQTL.wdl
@@ -30,7 +30,7 @@ task eqtl_prepare_expression {
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/prepare_QTL/prepare_sQTL.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/prepare_sQTL.wdl
@@ -22,7 +22,7 @@ task PrepareSpliceData {
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/susieR_workflow.wdl
+++ b/all_of_us/rna_seq/susieR_workflow.wdl
@@ -73,7 +73,7 @@ task PrepInputs {
         disks: "local-disk 500 SSD"
         preemptible: "${NumPrempt}"
         memory: "2GB"
-        cpu: "1"
+        cpu: 1
     }
     
     output {
@@ -121,7 +121,7 @@ task susieR {
         disks: "local-disk 500 SSD"
         bootDiskSizeGb: 25
         preemptible: "${NumPrempt}"
-        cpu: "1"
+        cpu: 1
     }
 
     output {

--- a/all_of_us/rna_seq/tensorQTL_cis_permutations/tensorqtl_cis_permutations.wdl
+++ b/all_of_us/rna_seq/tensorQTL_cis_permutations/tensorqtl_cis_permutations.wdl
@@ -50,7 +50,7 @@ task tensorqtl_cis_permutations {
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
         bootDiskSizeGb: 25
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
         gpuType: "nvidia-tesla-p100"
         gpuCount: "~{num_gpus}"

--- a/deprecated/pipelines/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
+++ b/deprecated/pipelines/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl
@@ -2,9 +2,9 @@ version 1.0
 
 # BroadInternalUltimaGenomics is now deprecated 2025-03-06
 
-import "../../../../../../../pipelines/wdl/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl" as UltimaGenomicsWholeGenomeGermline
-import "../../../../../../../structs/dna_seq/UltimaGenomicsWholeGenomeGermlineStructs.wdl" as Structs
-import "../../../../../../../pipelines/wdl/qc/CheckFingerprint.wdl" as FP
+import "../../../../../../pipelines/wdl/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl" as UltimaGenomicsWholeGenomeGermline
+import "../../../../../../structs/dna_seq/UltimaGenomicsWholeGenomeGermlineStructs.wdl" as Structs
+import "../../../../qc-check-fingerprint/CheckFingerprint.wdl" as FP
 
 workflow BroadInternalUltimaGenomics {
 

--- a/deprecated/pipelines/dna_seq/germline/single_sample/UltimaGenomics/TestBroadInternalUltimaGenomics.wdl
+++ b/deprecated/pipelines/dna_seq/germline/single_sample/UltimaGenomics/TestBroadInternalUltimaGenomics.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl" as BroadInternalUltimaGenomics
-import "../../verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl" as VerifyUltimaGenomicsWholeGenomeGermline
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "BroadInternalUltimaGenomics.wdl" as BroadInternalUltimaGenomics
+import "../../../../../../verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl" as VerifyUltimaGenomicsWholeGenomeGermline
+import "../../../../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestBroadInternalUltimaGenomics {
 

--- a/deprecated/pipelines/external_exome_reprocessing/ExternalExomeReprocessing.wdl
+++ b/deprecated/pipelines/external_exome_reprocessing/ExternalExomeReprocessing.wdl
@@ -2,8 +2,8 @@ version 1.0
 
 # ExternalExomeReprocessing is now deprecated 2025-03-06
 
-import "../../../../../pipelines/wdl/reprocessing/exome/ExomeReprocessing.wdl" as ExomeReprocessing
-import "../../../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "../../../pipelines/wdl/reprocessing/exome/ExomeReprocessing.wdl" as ExomeReprocessing
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalExomeReprocessing {
 

--- a/deprecated/pipelines/external_exome_reprocessing/TestExternalExomeReprocessing.wdl
+++ b/deprecated/pipelines/external_exome_reprocessing/TestExternalExomeReprocessing.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
 
-import "../../pipelines/wdl/reprocessing/external/exome/ExternalExomeReprocessing.wdl" as ExternalExomeReprocessing
-import "../../verification/VerifyExternalReprocessing.wdl" as VerifyExternalReprocessing
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "ExternalExomeReprocessing.wdl" as ExternalExomeReprocessing
+import "VerifyExternalReprocessing.wdl" as VerifyExternalReprocessing
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestExternalExomeReprocessing {
 

--- a/deprecated/pipelines/external_wgs_reprocessing/ExternalWholeGenomeReprocessing.wdl
+++ b/deprecated/pipelines/external_wgs_reprocessing/ExternalWholeGenomeReprocessing.wdl
@@ -1,7 +1,7 @@
 version 1.0
 # ExternalWholeGenomeReprocessing is now deprecated
-import "../../../../../pipelines/wdl/reprocessing/wgs/WholeGenomeReprocessing.wdl" as WholeGenomeReprocessing
-import "../../../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "../../../pipelines/wdl/reprocessing/wgs/WholeGenomeReprocessing.wdl" as WholeGenomeReprocessing
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow ExternalWholeGenomeReprocessing {
 

--- a/deprecated/pipelines/external_wgs_reprocessing/TestExternalWholeGenomeReprocessing.wdl
+++ b/deprecated/pipelines/external_wgs_reprocessing/TestExternalWholeGenomeReprocessing.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl" as ExternalWholeGenomeReprocessing
-import "../../verification/VerifyExternalReprocessing.wdl" as VerifyExternalReprocessing
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "ExternalWholeGenomeReprocessing.wdl" as ExternalWholeGenomeReprocessing
+import "../external_exome_reprocessing/VerifyExternalReprocessing.wdl" as VerifyExternalReprocessing
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestExternalWholeGenomeReprocessing {
 

--- a/deprecated/pipelines/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl
+++ b/deprecated/pipelines/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl
@@ -2,8 +2,8 @@ version 1.0
 
 # GDCWholeGenomeSomaticSingleSample is now deprecated 2025-03-06
 
-import "../../../../../../../pipelines/wdl/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl" as ToUbams
-import "../../../../../../../tasks/wdl/CheckContaminationSomatic.wdl" as CheckContamination
+import "../../../pipelines/wdl/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl" as ToUbams
+import "../../../tasks/wdl/CheckContaminationSomatic.wdl" as CheckContamination
 
 struct FastqPairRecord {
     File forward_fastq

--- a/deprecated/pipelines/gdc_genome/TestGDCWholeGenomeSomaticSingleSample.wdl
+++ b/deprecated/pipelines/gdc_genome/TestGDCWholeGenomeSomaticSingleSample.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl" as GDCWholeGenomeSomaticSingleSample
-import "../../verification/VerifyGDCSomaticSingleSample.wdl" as VerifyGDCSomaticSingleSample
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "GDCWholeGenomeSomaticSingleSample.wdl" as GDCWholeGenomeSomaticSingleSample
+import "VerifyGDCSomaticSingleSample.wdl" as VerifyGDCSomaticSingleSample
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestGDCWholeGenomeSomaticSingleSample {
 

--- a/deprecated/pipelines/gdc_genome/VerifyGDCSomaticSingleSample.wdl
+++ b/deprecated/pipelines/gdc_genome/VerifyGDCSomaticSingleSample.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../verification/VerifyMetrics.wdl" as MetricsVerification
-import "../verification/VerifyTasks.wdl" as VerifyTasks
+import "../../../verification/VerifyMetrics.wdl" as MetricsVerification
+import "../../../verification/VerifyTasks.wdl" as VerifyTasks
 
 workflow VerifyGDCSomaticSingleSample {
 

--- a/deprecated/pipelines/internal_imputation/BroadInternalImputation.wdl
+++ b/deprecated/pipelines/internal_imputation/BroadInternalImputation.wdl
@@ -2,9 +2,9 @@ version 1.0
 
 # BroadInternalImputation is now deprecated 2025-03-06
 
-import "../../../../../pipelines/wdl/arrays/imputation/Imputation.wdl" as ImputationPipeline
-import "../../../../../tasks/wdl/InternalImputationTasks.wdl" as InternalImputationTasks
-import "../../../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
+import "../../../pipelines/wdl/arrays/imputation/Imputation.wdl" as ImputationPipeline
+import "InternalImputationTasks.wdl" as InternalImputationTasks
+import "../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
 
 workflow BroadInternalImputation {
     meta {

--- a/deprecated/pipelines/internal_rna_seq/BroadInternalRNAWithUMIs.wdl
+++ b/deprecated/pipelines/internal_rna_seq/BroadInternalRNAWithUMIs.wdl
@@ -2,10 +2,10 @@ version 1.0
 
 # BroadInternalRNAWithUMIs is now deprecated 2025-03-06
 
-import "../../../../pipelines/wdl/rna_seq/RNAWithUMIsPipeline.wdl" as RNAWithUMIs
-import "../../../../pipelines/wdl/qc/CheckFingerprint.wdl" as FP
-import "../../../../tasks/wdl/RNAWithUMIsTasks.wdl" as tasks
-import "../../../../tasks/wdl/Utilities.wdl" as utils
+import "../../../pipelines/wdl/rna_seq/RNAWithUMIsPipeline.wdl" as RNAWithUMIs
+import "../qc-check-fingerprint/CheckFingerprint.wdl" as FP
+import "../../../tasks/wdl/RNAWithUMIsTasks.wdl" as tasks
+import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow BroadInternalRNAWithUMIs {
 

--- a/deprecated/pipelines/internal_rna_seq/TestBroadInternalRNAWithUMIs.wdl
+++ b/deprecated/pipelines/internal_rna_seq/TestBroadInternalRNAWithUMIs.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/internal/rna_seq/BroadInternalRNAWithUMIs.wdl" as BroadInternalRNAWithUMIs
-import "../../verification/VerifyRNAWithUMIs.wdl" as VerifyRNAWithUMIs
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "BroadInternalRNAWithUMIs.wdl" as BroadInternalRNAWithUMIs
+import "../../../verification/VerifyRNAWithUMIs.wdl" as VerifyRNAWithUMIs
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestBroadInternalRNAWithUMIs {
 

--- a/deprecated/pipelines/internal_single_sample_arrays/BroadInternalArrays.wdl
+++ b/deprecated/pipelines/internal_single_sample_arrays/BroadInternalArrays.wdl
@@ -1,8 +1,8 @@
 version 1.0
 # BroadInternalArrays is now deprecated 2025-03-06
-import "../../../../../pipelines/wdl/arrays/single_sample/Arrays.wdl" as ArraysPipeline
-import "../../../../../tasks/wdl/InternalArraysTasks.wdl" as InternalArraysTasks
-import "../../../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
+import "../single_sample_arrays/Arrays.wdl" as ArraysPipeline
+import "../../../tasks/wdl/InternalArraysTasks.wdl" as InternalArraysTasks
+import "../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
 
 workflow BroadInternalArrays {
     meta {

--- a/deprecated/pipelines/joint_genotyping_bychromosome/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl
+++ b/deprecated/pipelines/joint_genotyping_bychromosome/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 # JointGenotypingByChromosomePartOne is now deprecated 2025-03-06
 
-import "../../../../../../tasks/wdl/JointGenotypingTasks.wdl" as Tasks
+import "../../../../../../../tasks/wdl/JointGenotypingTasks.wdl" as Tasks
 
 # Joint Genotyping for hg38 Exomes and Whole Genomes (has not been tested on hg19)
 workflow JointGenotypingByChromosomePartOne {

--- a/deprecated/pipelines/joint_genotyping_bychromosome/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl
+++ b/deprecated/pipelines/joint_genotyping_bychromosome/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl
@@ -1,6 +1,6 @@
 version 1.0
 # The JointGenotypingByChromosomePartTwo is deprecated 2025-03-06
-import "../../../../../../tasks/wdl/JointGenotypingTasks.wdl" as Tasks
+import "../../../../../../../tasks/wdl/JointGenotypingTasks.wdl" as Tasks
 
 # Joint Genotyping for hg38 Exomes and Whole Genomes (has not been tested on hg19)
 workflow JointGenotypingByChromosomePartTwo {

--- a/deprecated/pipelines/multi_sample_arrays/TestMultiSampleArrays.wdl
+++ b/deprecated/pipelines/multi_sample_arrays/TestMultiSampleArrays.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/arrays/multi_sample/MultiSampleArrays.wdl" as MultiSampleArrays
-import "../../verification/VerifyMultiSampleArrays.wdl" as VerifyMultiSampleArrays
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "MultiSampleArrays.wdl" as MultiSampleArrays
+import "VerifyMultiSampleArrays.wdl" as VerifyMultiSampleArrays
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestMultiSampleArrays {
 

--- a/deprecated/pipelines/multi_sample_arrays/VerifyMultiSampleArrays.wdl
+++ b/deprecated/pipelines/multi_sample_arrays/VerifyMultiSampleArrays.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../verification/VerifyTasks.wdl" as Tasks
+import "../../../verification/VerifyTasks.wdl" as Tasks
 
 ## Copyright Broad Institute, 2018
 ##

--- a/deprecated/pipelines/qc-check-fingerprint/TestCheckFingerprint.wdl
+++ b/deprecated/pipelines/qc-check-fingerprint/TestCheckFingerprint.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/qc/CheckFingerprint.wdl" as CheckFingerprint
-import "../../verification/VerifyCheckFingerprint.wdl" as VerifyCheckFingerprint
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "CheckFingerprint.wdl" as CheckFingerprint
+import "VerifyCheckFingerprint.wdl" as VerifyCheckFingerprint
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestCheckFingerprint {
 

--- a/deprecated/pipelines/qc-check-fingerprint/VerifyCheckFingerprint.wdl
+++ b/deprecated/pipelines/qc-check-fingerprint/VerifyCheckFingerprint.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../verification/VerifyMetrics.wdl" as MetricsVerification
-import "../verification/VerifyTasks.wdl" as Tasks
+import "../../../verification/VerifyMetrics.wdl" as MetricsVerification
+import "../../../verification/VerifyTasks.wdl" as Tasks
 
 ## Copyright Broad Institute, 2021
 ##

--- a/deprecated/pipelines/scATAC/TestscATAC.wdl
+++ b/deprecated/pipelines/scATAC/TestscATAC.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/scATAC/scATAC.wdl" as scATAC
-import "../../verification/VerifyscATAC.wdl" as VerifyscATAC
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "scATAC.wdl" as scATAC
+import "VerifyscATAC.wdl" as VerifyscATAC
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestscATAC {
 

--- a/deprecated/pipelines/scATAC/VerifyscATAC.wdl
+++ b/deprecated/pipelines/scATAC/VerifyscATAC.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "../verification/VerifyTasks.wdl" as VerifyTasks
+import "../../../verification/VerifyTasks.wdl" as VerifyTasks
 
 workflow VerifyscATAC {
   input {

--- a/deprecated/pipelines/single_sample_arrays/Arrays.wdl
+++ b/deprecated/pipelines/single_sample_arrays/Arrays.wdl
@@ -2,10 +2,10 @@ version 1.0
 
 # The Arrays pipeline is now deprecated 2025-03-06
 
-import "../../../../pipelines/wdl/genotyping/illumina/IlluminaGenotypingArray.wdl" as IlluminaGenotyping
-import "../../../../tasks/wdl/InternalArraysTasks.wdl" as InternalArraysTasks
-import "../../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
-import "../../../../tasks/wdl/Utilities.wdl" as utils
+import "../../../pipelines/wdl/genotyping/illumina/IlluminaGenotypingArray.wdl" as IlluminaGenotyping
+import "../../../tasks/wdl/InternalArraysTasks.wdl" as InternalArraysTasks
+import "../../../tasks/wdl/InternalTasks.wdl" as InternalTasks
+import "../../../tasks/wdl/Utilities.wdl" as utils
 
 ## Copyright Broad Institute, 2019
 ##

--- a/deprecated/pipelines/single_sample_arrays/TestArrays.wdl
+++ b/deprecated/pipelines/single_sample_arrays/TestArrays.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
-import "../../pipelines/wdl/arrays/single_sample/Arrays.wdl" as Arrays
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
-import "../../verification/VerifyArrays.wdl" as VerifyArrays
+import "Arrays.wdl" as Arrays
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "VerifyArrays.wdl" as VerifyArrays
 
 workflow TestArrays {
 

--- a/deprecated/pipelines/single_sample_arrays/VerifyArrays.wdl
+++ b/deprecated/pipelines/single_sample_arrays/VerifyArrays.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../verification/VerifyIlluminaGenotypingArray.wdl" as VerifyIlluminaGenotypingArray
-import "../verification/VerifyTasks.wdl" as VerifyTasks
+import "../../../verification/VerifyIlluminaGenotypingArray.wdl" as VerifyIlluminaGenotypingArray
+import "../../../verification/VerifyTasks.wdl" as VerifyTasks
 
 ## Copyright Broad Institute, 2018
 ##

--- a/deprecated/pipelines/smartseq2_multisample/MultiSampleSmartSeq2.wdl
+++ b/deprecated/pipelines/smartseq2_multisample/MultiSampleSmartSeq2.wdl
@@ -1,8 +1,8 @@
 version 1.0
 # MultiSampleSmartSeq2 is now deprecated 2025-03-06
 
-import "../../../pipelines/wdl/smartseq2_single_sample/SmartSeq2SingleSample.wdl" as single_cell_run
-import "../../../tasks/wdl/LoomUtils.wdl" as LoomUtils
+import "../smartseq2_single_sample/SmartSeq2SingleSample.wdl" as single_cell_run
+import "LoomUtils.wdl" as LoomUtils
        
 workflow MultiSampleSmartSeq2 {
   meta {

--- a/deprecated/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/deprecated/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -6,7 +6,7 @@ import "../../../tasks/wdl/HISAT2.wdl" as HISAT2
 import "../../../tasks/wdl/Picard.wdl" as Picard
 import "../../../tasks/wdl/RSEM.wdl" as RSEM
 import "../../../tasks/wdl/GroupMetricsOutputs.wdl" as GroupQCs
-import "../../../tasks/wdl/LoomUtils.wdl" as LoomUtils
+import "../smartseq2_multisample/LoomUtils.wdl" as LoomUtils
 
 workflow SmartSeq2SingleSample {
   meta {

--- a/deprecated/pipelines/validate_chip/TestValidateChip.wdl
+++ b/deprecated/pipelines/validate_chip/TestValidateChip.wdl
@@ -1,10 +1,10 @@
 version 1.0
 
 
-import "../../pipelines/wdl/arrays/validate_chip/ValidateChip.wdl" as ValidateChip
-import "../../verification/VerifyValidateChip.wdl" as VerifyValidateChip
-import "../../tasks/wdl/Utilities.wdl" as Utilities
-import "../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
+import "ValidateChip.wdl" as ValidateChip
+import "VerifyValidateChip.wdl" as VerifyValidateChip
+import "../../../tasks/wdl/Utilities.wdl" as Utilities
+import "../../../tasks/wdl/CopyFilesFromCloudToCloud.wdl" as Copy
 
 workflow TestValidateChip {
 

--- a/deprecated/pipelines/validate_chip/ValidateChip.wdl
+++ b/deprecated/pipelines/validate_chip/ValidateChip.wdl
@@ -1,7 +1,7 @@
 version 1.0
 # The ValidateChip pipeline is deprecated 2025-03-06
-import "../../../../tasks/wdl/IlluminaGenotypingArrayTasks.wdl" as GenotypingTasks
-import "../../../../tasks/wdl/InternalArraysTasks.wdl" as InternalTasks
+import "../../../tasks/wdl/IlluminaGenotypingArrayTasks.wdl" as GenotypingTasks
+import "../../../tasks/wdl/InternalArraysTasks.wdl" as InternalTasks
 
 ## Copyright Broad Institute, 2019
 ##

--- a/deprecated/pipelines/validate_chip/VerifyValidateChip.wdl
+++ b/deprecated/pipelines/validate_chip/VerifyValidateChip.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "../verification/VerifyTasks.wdl" as Tasks
-import "../verification/VerifyMetrics.wdl" as MetricsVerification
+import "../../../verification/VerifyTasks.wdl" as Tasks
+import "../../../verification/VerifyMetrics.wdl" as MetricsVerification
 
 ## Copyright Broad Institute, 2018
 ##

--- a/pipelines/wdl/build_indices/BuildIndices.wdl
+++ b/pipelines/wdl/build_indices/BuildIndices.wdl
@@ -362,7 +362,7 @@ task CalculateChromosomeSizes {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 50 HDD"
   }
   output {
@@ -536,7 +536,7 @@ task BuildStarSingleNucleus {
     memory: "64 GiB"
     disks: "local-disk ${disk} HDD"
     disk: disk + " GB" # TES
-    cpu:"16"
+    cpu: 16
   }
 }
 
@@ -652,7 +652,7 @@ String reference_name = "bwa-mem2-2.2.1-~{organism}-~{genome_source}-build-~{gen
     memory: "96GB"
     disks: "local-disk 100 HDD"
     disk: "100 GB" # TES
-    cpu: "4"
+    cpu: 4
   }
 
   output {
@@ -805,7 +805,7 @@ task RecordMetadata {
     docker: "ubuntu:20.04"
     memory: "5 GiB"
     disks: "local-disk 100 HDD"
-    cpu: "1"
+    cpu: 1
   }
 }
 

--- a/tasks/wdl/Alignment.wdl
+++ b/tasks/wdl/Alignment.wdl
@@ -116,7 +116,7 @@ task SamToFastqAndBwaMemAndMba {
     docker: "us.gcr.io/broad-gotc-prod/samtools-picard-bwa:1.0.2-0.7.15-2.26.10-1643840748"
     preemptible: preemptible_tries
     memory: "14 GiB"
-    cpu: "16"
+    cpu: 16
     disks: "local-disk " + disk_size + " HDD"
   }
   output {

--- a/tasks/wdl/BamProcessing.wdl
+++ b/tasks/wdl/BamProcessing.wdl
@@ -50,7 +50,7 @@ task SortSam {
   runtime {
     docker: docker
     disks: "local-disk " + disk_size + " HDD"
-    cpu: "1"
+    cpu: 1
     memory: "${machine_mem_mb} MiB"
     preemptible: preemptible_tries
   }

--- a/tasks/wdl/CopyFilesFromCloudToCloud.wdl
+++ b/tasks/wdl/CopyFilesFromCloudToCloud.wdl
@@ -68,7 +68,7 @@ task CopyFilesFromCloudToCloud {
   # We don't have to use an external IP.
   runtime {
     memory: "2 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 20 HDD"
     docker: "us.gcr.io/broad-gotc-prod/dsde-toolbox:stable_04-18-2022"
     preemptible: 3

--- a/tasks/wdl/Funcotator.wdl
+++ b/tasks/wdl/Funcotator.wdl
@@ -160,9 +160,9 @@ task Funcotate {
       -O ~{output_vcf} \
       ~{true="-L" false="" defined(interval_list)} ~{default="" interval_list} \
       ~{true="--transcript-selection-mode" false="" defined(transcript_selection_mode)} ~{default="" transcript_selection_mode} \
-      ~{true="--transcript-list" false="" defined(transcript_selection_list)} ~{default="" sep=" --transcript-list " transcript_selection_list} \
-      ~{true="--annotation-default" false="" defined(annotation_defaults)} ~{default="" sep=" --annotation-default " annotation_defaults} \
-      ~{true="--annotation-override" false="" defined(annotation_overrides)} ~{default="" sep=" --annotation-override " annotation_overrides} \
+      ~{sep=" " prefix("--transcript-list ", select_first([transcript_selection_list, []]))} \
+      ~{sep=" " prefix("--annotation-default ", select_first([annotation_defaults, []]))} \
+      ~{sep=" " prefix("--annotation-override ", select_first([annotation_overrides, []]))} \
       ~{true="--remove-filtered-variants" false="" filter_funcotations} \
       ~{default="" extra_args}
   >>>

--- a/tasks/wdl/GermlineVariantDiscovery.wdl
+++ b/tasks/wdl/GermlineVariantDiscovery.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller_GATK35_GVCF {
     docker: docker
     preemptible: preemptible_tries
     memory: "10000 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -164,7 +164,7 @@ task HaplotypeCaller_GATK4_VCF {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "~{memory_size_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -380,7 +380,7 @@ task CNNScoreVariants {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "15000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -436,7 +436,7 @@ task FilterVariantTranches {
 
   runtime {
     memory: "7000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries

--- a/tasks/wdl/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/wdl/IlluminaGenotypingArrayTasks.wdl
@@ -538,7 +538,7 @@ task MergePedIntoVcf {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.11"
     memory: "3500 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries
   }

--- a/tasks/wdl/JointGenotypingTasks.wdl
+++ b/tasks/wdl/JointGenotypingTasks.wdl
@@ -301,7 +301,7 @@ task HardFilterAndMakeSitesOnlyVcf {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -363,7 +363,7 @@ task IndelsVariantRecalibrator {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -431,7 +431,7 @@ task SNPsVariantRecalibratorCreateModel {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -578,7 +578,7 @@ task GatherTranches {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -638,7 +638,7 @@ task ApplyRecalibration {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -685,7 +685,7 @@ task GatherVcfs {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -856,7 +856,7 @@ task GatherVariantCallingMetrics {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1

--- a/tasks/wdl/Qc.wdl
+++ b/tasks/wdl/Qc.wdl
@@ -431,9 +431,9 @@ task ValidateSamFile {
       OUTPUT=~{report_filename} \
       REFERENCE_SEQUENCE=~{ref_fasta} \
       ~{"MAX_OUTPUT=" + max_output} \
-      IGNORE=~{default="null" sep=" IGNORE=" ignore} \
+      ~{sep=" " prefix("IGNORE=", select_first([ignore, ["null"]]))} \
       MODE=VERBOSE \
-      ~{default='SKIP_MATE_VALIDATION=false' true='SKIP_MATE_VALIDATION=true' false='SKIP_MATE_VALIDATION=false' is_outlier_data} \
+      ~{true='SKIP_MATE_VALIDATION=true' false='SKIP_MATE_VALIDATION=false' select_first([is_outlier_data, false])} \
       IS_BISULFITE_SEQUENCED=false
   }
   runtime {

--- a/tasks/wdl/StarAlign.wdl
+++ b/tasks/wdl/StarAlign.wdl
@@ -876,6 +876,6 @@ task STARGenomeRefVersion {
     memory: "2 GiB"
     disks: "local-disk ${disk} HDD"
     disk: disk + " GB" # TES
-    cpu:"1"
+    cpu: 1
   }
 }

--- a/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
+++ b/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
@@ -41,7 +41,7 @@ task TerraCopyFilesFromCloudToCloud {
 
   runtime {
     memory: "16 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 32 HDD"
     docker: "gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-slim"
     preemptible: 3

--- a/tasks/wdl/Utilities.wdl
+++ b/tasks/wdl/Utilities.wdl
@@ -149,7 +149,7 @@ task ConvertToCram {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: preemptible_tries
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -180,7 +180,7 @@ task ConvertToBam {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 200 HDD"
   }
   output {

--- a/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
+++ b/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
@@ -45,7 +45,7 @@ task BuildBWAreference {
 	 memory: "96GB"
 	 disks: "local-disk 100 HDD"
      disk: "100 GB" # TES
-	 cpu: "4"
+	 cpu: 4
      }
 
      output {

--- a/verification/VerifyMetrics.wdl
+++ b/verification/VerifyMetrics.wdl
@@ -84,7 +84,7 @@ task CompareMetricFiles {
       --INPUT ~{file1} \
       --INPUT ~{file2} \
       --OUTPUT ~{output_file} \
-      ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore} \
+      ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)} \
       ~{sep=" " extra_args}
   >>>
 

--- a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl
+++ b/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl
@@ -99,7 +99,7 @@ task CompareOldMetricFiles {
     --INPUT ~{file1} \
     --INPUT ~{file2} \
     --OUTPUT ~{output_file} \
-    ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore}
+    ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)}
   >>>
 
   runtime {

--- a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl
+++ b/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl
@@ -184,7 +184,7 @@ task CompareOldMetricFiles {
     --INPUT ~{file1} \
     --INPUT ~{file2} \
     --OUTPUT ~{output_file} \
-    ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore}
+    ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)}
   >>>
 
   runtime {


### PR DESCRIPTION
When files were moved into `deprecated/pipelines/` starting in 784c460f7 (#1541) and further reorganized in 973e83145 (#1646), the relative import paths weren't updated to account for the new directory depth. This fixes all 79 broken imports across 29 files.

Depends on #1812.