### PR TITLE
fix: quote integer literals in placeholder `default` options

### DIFF
--- a/all_of_us/PCA/pca_only_no_labels.wdl
+++ b/all_of_us/PCA/pca_only_no_labels.wdl
@@ -75,7 +75,7 @@ task ConcatenateChromosomalVcfs {
     runtime {
         docker: bcftools_docker
         memory: "${memory_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disk: "local-disk ${disk_gb} HDD"
         preemptible: num_preemptible_attempts
     }
@@ -155,7 +155,7 @@ task create_hw_pca_training {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "${mem_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disks: "local-disk ${disk_gb} ${disk_type}" # large SSD is recommended for increased processing speed
     }
 }
@@ -244,7 +244,7 @@ task plot_pca {
     runtime {
         docker: "faizanbashir/python-datascience:3.6"
         memory: "${mem_gb} GB"
-        cpu: "${cpu}"
+        cpu: cpu
         disks: "local-disk ${disk_gb} HDD"
     }
 }

--- a/all_of_us/ancestry/determine_hq_sites_intersection.wdl
+++ b/all_of_us/ancestry/determine_hq_sites_intersection.wdl
@@ -178,7 +178,7 @@ task sitesOnlyAndHQFilterVcf {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "12 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -244,7 +244,7 @@ task merge_vcf_bgzs {
     runtime {
         docker: "mgibio/bcftools-cwl:1.12"
         memory: "120 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk 1500 HDD"
         bootDiskSizeGb: 1500
     }
@@ -303,7 +303,7 @@ task filter_by_sites_only {
     runtime {
         docker:"us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 100 HDD"
     }
 }
@@ -340,7 +340,7 @@ task intersect_vcfs_as_sites_only {
     runtime {
         docker: "us.gcr.io/broad-gatk/gatk:4.2.0.0"
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk 500 HDD"
     }
 }

--- a/all_of_us/ancestry/run_ancestry.wdl
+++ b/all_of_us/ancestry/run_ancestry.wdl
@@ -161,7 +161,7 @@ task create_hw_pca_training {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "123 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 500 HDD"
     }
 }
@@ -280,7 +280,7 @@ task call_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "240 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 700 HDD"
     }
 }
@@ -377,7 +377,7 @@ task plot_ancestry {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/ancestry/run_sample_outlier_qc.wdl
+++ b/all_of_us/ancestry/run_sample_outlier_qc.wdl
@@ -100,7 +100,7 @@ task join_ancestry_to_stats {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "15 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk 500 HDD"
     }
 }
@@ -187,7 +187,7 @@ task determine_outlier_qc {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "15 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 500 HDD"
     }
 }

--- a/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl
+++ b/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl
@@ -100,7 +100,7 @@ task join_ancestry_to_demographics {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -144,7 +144,7 @@ task plot_first_pcs {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "7 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }
@@ -246,7 +246,7 @@ task plot_metrics_and_fitting {
     runtime {
         docker: "hailgenetics/hail:0.2.67"
         memory: "26 GB"
-        cpu: "4"
+        cpu: 4
         disks: "local-disk 100 HDD"
     }
 }

--- a/all_of_us/pgx/CyriusStarAlleleCalling.wdl
+++ b/all_of_us/pgx/CyriusStarAlleleCalling.wdl
@@ -77,7 +77,7 @@ task PrintReads {
         docker: "us.gcr.io/broad-gotc-prod/gatk:1.3.0-4.2.6.1-1649964384"
         preemptible: preemptible_tries
         memory: "10000 MiB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
     }
     output {

--- a/all_of_us/pgx/StargazerFromJointVCF.wdl
+++ b/all_of_us/pgx/StargazerFromJointVCF.wdl
@@ -121,7 +121,7 @@ task SelectVariants {
     >>>
     runtime {
         memory: "7 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: "us.gcr.io/broad-gatk/gatk:4.4.0.0"
     }

--- a/all_of_us/rna_seq/AggregateSusieWorkflow.wdl
+++ b/all_of_us/rna_seq/AggregateSusieWorkflow.wdl
@@ -30,7 +30,7 @@ task AggregateSusie{
         docker: "ghcr.io/aou-multiomics-analysis/aggregate_susie:main@sha256:ede17b5112eadb765f22cdfbd2a987da96087a1e2f0ad224994c16f1af645443"
         disks: "local-disk 500 SSD"
         memory: "~{Memory}GB"
-        cpu: "~{NumThreads}"
+        cpu: NumThreads
     }
     
  
@@ -77,7 +77,7 @@ task AnnotateSusie {
         docker: "ghcr.io/aou-multiomics-analysis/aggregate_susie:main@sha256:ede17b5112eadb765f22cdfbd2a987da96087a1e2f0ad224994c16f1af645443"
         disks: "local-disk 500 SSD"
         memory: "~{Memory}GB"
-        cpu: "1"
+        cpu: 1
     }
 
 

--- a/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl
+++ b/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl
@@ -26,7 +26,7 @@ task PrepareSpliceData {
         docker: "ghcr.io/aou-multiomics-analysis/prepare_qtl@sha256:b9986a803ad82aee02945e9131f180fc028c73eadb889184e23aff8dabf573fe"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/GTEx/aggregate_rsem_results.wdl
+++ b/all_of_us/rna_seq/GTEx/aggregate_rsem_results.wdl
@@ -52,7 +52,7 @@ task rsem_aggregate_results {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
         preemptible: "${num_preempt}"
     }
 

--- a/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl
+++ b/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl
@@ -27,7 +27,7 @@ task leafcutter_bam_to_junc {
         docker: "gcr.io/broad-cga-francois-gtex/leafcutter:latest"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
     }
 

--- a/all_of_us/rna_seq/leafcutter_cluster.wdl
+++ b/all_of_us/rna_seq/leafcutter_cluster.wdl
@@ -62,7 +62,7 @@ task leafcutter_cluster {
         docker: "us.gcr.io/broad-gotc-prod/leafcutter:1.0.0"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
     }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl
@@ -59,7 +59,7 @@ workflow CaclulateAF {
             docker: "quay.io/biocontainers/plink2:2.0.0a.6.9--h9948957_0"
             memory: "~{memory}GB"
             disks: "local-disk ~{disk_space} HDD"
-            cpu: "~{num_threads}"
+            cpu: num_threads
 
         }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculateGenotypeDosage.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculateGenotypeDosage.wdl
@@ -50,7 +50,7 @@ task BcftoolsDosage {
     runtime {
         docker: "quay.io/eqtlcatalogue/susie-finemapping:v20.08.1"
         memory: "32G"
-        cpu: "${threads}"
+        cpu: threads
         disks: "local-disk 500 SSD"
     }
 

--- a/all_of_us/rna_seq/prepare_QTL/calculate_phenotypePCs.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/calculate_phenotypePCs.wdl
@@ -18,7 +18,7 @@ task ComputePCs{
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
-        cpu: "~{num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/prepare_QTL/prepare_eQTL.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/prepare_eQTL.wdl
@@ -30,7 +30,7 @@ task eqtl_prepare_expression {
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/prepare_QTL/prepare_sQTL.wdl
+++ b/all_of_us/rna_seq/prepare_QTL/prepare_sQTL.wdl
@@ -22,7 +22,7 @@ task PrepareSpliceData {
         docker: "us.gcr.io/broad-gotc-prod/aou_rna_prepareqtl:0.0.1"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
-        cpu: "${num_threads}"
+        cpu: num_threads
     }
 
     output {

--- a/all_of_us/rna_seq/susieR_workflow.wdl
+++ b/all_of_us/rna_seq/susieR_workflow.wdl
@@ -73,7 +73,7 @@ task PrepInputs {
         disks: "local-disk 500 SSD"
         preemptible: "${NumPrempt}"
         memory: "2GB"
-        cpu: "1"
+        cpu: 1
     }
     
     output {
@@ -121,7 +121,7 @@ task susieR {
         disks: "local-disk 500 SSD"
         bootDiskSizeGb: 25
         preemptible: "${NumPrempt}"
-        cpu: "1"
+        cpu: 1
     }
 
     output {

--- a/all_of_us/rna_seq/tensorQTL_cis_permutations/tensorqtl_cis_permutations.wdl
+++ b/all_of_us/rna_seq/tensorQTL_cis_permutations/tensorqtl_cis_permutations.wdl
@@ -50,7 +50,7 @@ task tensorqtl_cis_permutations {
         memory: "~{memory}GB"
         disks: "local-disk ~{disk_space} HDD"
         bootDiskSizeGb: 25
-        cpu: "~{num_threads}"
+        cpu: num_threads
         preemptible: "~{num_preempt}"
         gpuType: "nvidia-tesla-p100"
         gpuCount: "~{num_gpus}"

--- a/pipelines/wdl/build_indices/BuildIndices.wdl
+++ b/pipelines/wdl/build_indices/BuildIndices.wdl
@@ -362,7 +362,7 @@ task CalculateChromosomeSizes {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 50 HDD"
   }
   output {
@@ -536,7 +536,7 @@ task BuildStarSingleNucleus {
     memory: "64 GiB"
     disks: "local-disk ${disk} HDD"
     disk: disk + " GB" # TES
-    cpu:"16"
+    cpu: 16
   }
 }
 
@@ -652,7 +652,7 @@ String reference_name = "bwa-mem2-2.2.1-~{organism}-~{genome_source}-build-~{gen
     memory: "96GB"
     disks: "local-disk 100 HDD"
     disk: "100 GB" # TES
-    cpu: "4"
+    cpu: 4
   }
 
   output {
@@ -805,7 +805,7 @@ task RecordMetadata {
     docker: "ubuntu:20.04"
     memory: "5 GiB"
     disks: "local-disk 100 HDD"
-    cpu: "1"
+    cpu: 1
   }
 }
 

--- a/tasks/wdl/Alignment.wdl
+++ b/tasks/wdl/Alignment.wdl
@@ -116,7 +116,7 @@ task SamToFastqAndBwaMemAndMba {
     docker: "us.gcr.io/broad-gotc-prod/samtools-picard-bwa:1.0.2-0.7.15-2.26.10-1643840748"
     preemptible: preemptible_tries
     memory: "14 GiB"
-    cpu: "16"
+    cpu: 16
     disks: "local-disk " + disk_size + " HDD"
   }
   output {

--- a/tasks/wdl/BamProcessing.wdl
+++ b/tasks/wdl/BamProcessing.wdl
@@ -50,7 +50,7 @@ task SortSam {
   runtime {
     docker: docker
     disks: "local-disk " + disk_size + " HDD"
-    cpu: "1"
+    cpu: 1
     memory: "${machine_mem_mb} MiB"
     preemptible: preemptible_tries
   }

--- a/tasks/wdl/CopyFilesFromCloudToCloud.wdl
+++ b/tasks/wdl/CopyFilesFromCloudToCloud.wdl
@@ -68,7 +68,7 @@ task CopyFilesFromCloudToCloud {
   # We don't have to use an external IP.
   runtime {
     memory: "2 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 20 HDD"
     docker: "us.gcr.io/broad-gotc-prod/dsde-toolbox:stable_04-18-2022"
     preemptible: 3

--- a/tasks/wdl/Funcotator.wdl
+++ b/tasks/wdl/Funcotator.wdl
@@ -160,9 +160,9 @@ task Funcotate {
       -O ~{output_vcf} \
       ~{true="-L" false="" defined(interval_list)} ~{default="" interval_list} \
       ~{true="--transcript-selection-mode" false="" defined(transcript_selection_mode)} ~{default="" transcript_selection_mode} \
-      ~{true="--transcript-list" false="" defined(transcript_selection_list)} ~{default="" sep=" --transcript-list " transcript_selection_list} \
-      ~{true="--annotation-default" false="" defined(annotation_defaults)} ~{default="" sep=" --annotation-default " annotation_defaults} \
-      ~{true="--annotation-override" false="" defined(annotation_overrides)} ~{default="" sep=" --annotation-override " annotation_overrides} \
+      ~{sep=" " prefix("--transcript-list ", select_first([transcript_selection_list, []]))} \
+      ~{sep=" " prefix("--annotation-default ", select_first([annotation_defaults, []]))} \
+      ~{sep=" " prefix("--annotation-override ", select_first([annotation_overrides, []]))} \
       ~{true="--remove-filtered-variants" false="" filter_funcotations} \
       ~{default="" extra_args}
   >>>

--- a/tasks/wdl/GermlineVariantDiscovery.wdl
+++ b/tasks/wdl/GermlineVariantDiscovery.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller_GATK35_GVCF {
     docker: docker
     preemptible: preemptible_tries
     memory: "10000 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -164,7 +164,7 @@ task HaplotypeCaller_GATK4_VCF {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "~{memory_size_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -380,7 +380,7 @@ task CNNScoreVariants {
     docker: gatk_docker
     preemptible: preemptible_tries
     memory: "15000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
   }
@@ -436,7 +436,7 @@ task FilterVariantTranches {
 
   runtime {
     memory: "7000 MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries

--- a/tasks/wdl/GermlineVariantDiscovery.wdl
+++ b/tasks/wdl/GermlineVariantDiscovery.wdl
@@ -64,7 +64,7 @@ task HaplotypeCaller_GATK35_GVCF {
       --max_alternate_alleles 3 \
       -variant_index_parameter 128000 \
       -variant_index_type LINEAR \
-      -contamination ~{default=0 contamination} \
+      -contamination ~{default="0" contamination} \
       --read_filter OverclippedRead
 
   }
@@ -147,7 +147,7 @@ task HaplotypeCaller_GATK4_VCF {
       -I ~{input_bam} \
       -L ~{interval_list} \
       -O ~{output_file_name} \
-      -contamination ~{default=0 contamination} \
+      -contamination ~{default="0" contamination} \
       -G StandardAnnotation -G StandardHCAnnotation ~{true="-G AS_StandardAnnotation" false="" make_gvcf} \
       ~{true="--dragen-mode" false="" run_dragen_mode_variant_calling} \
       ~{false="--disable-spanning-event-genotyping" true="" use_spanning_event_genotyping} \

--- a/tasks/wdl/IlluminaGenotypingArrayTasks.wdl
+++ b/tasks/wdl/IlluminaGenotypingArrayTasks.wdl
@@ -538,7 +538,7 @@ task MergePedIntoVcf {
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.11"
     memory: "3500 MiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     preemptible: preemptible_tries
   }

--- a/tasks/wdl/JointGenotypingTasks.wdl
+++ b/tasks/wdl/JointGenotypingTasks.wdl
@@ -301,7 +301,7 @@ task HardFilterAndMakeSitesOnlyVcf {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -363,7 +363,7 @@ task IndelsVariantRecalibrator {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -431,7 +431,7 @@ task SNPsVariantRecalibratorCreateModel {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -578,7 +578,7 @@ task GatherTranches {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "2"
+    cpu: 2
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -638,7 +638,7 @@ task ApplyRecalibration {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -685,7 +685,7 @@ task GatherVcfs {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1
@@ -856,7 +856,7 @@ task GatherVariantCallingMetrics {
 
   runtime {
     memory: "~{machine_mem_mb} MiB"
-    cpu: "1"
+    cpu: 1
     bootDiskSizeGb: 15
     disks: "local-disk " + disk_size_gb + " HDD"
     preemptible: 1

--- a/tasks/wdl/Qc.wdl
+++ b/tasks/wdl/Qc.wdl
@@ -431,9 +431,9 @@ task ValidateSamFile {
       OUTPUT=~{report_filename} \
       REFERENCE_SEQUENCE=~{ref_fasta} \
       ~{"MAX_OUTPUT=" + max_output} \
-      IGNORE=~{default="null" sep=" IGNORE=" ignore} \
+      ~{sep=" " prefix("IGNORE=", select_first([ignore, ["null"]]))} \
       MODE=VERBOSE \
-      ~{default='SKIP_MATE_VALIDATION=false' true='SKIP_MATE_VALIDATION=true' false='SKIP_MATE_VALIDATION=false' is_outlier_data} \
+      ~{true='SKIP_MATE_VALIDATION=true' false='SKIP_MATE_VALIDATION=false' select_first([is_outlier_data, false])} \
       IS_BISULFITE_SEQUENCED=false
   }
   runtime {

--- a/tasks/wdl/StarAlign.wdl
+++ b/tasks/wdl/StarAlign.wdl
@@ -876,6 +876,6 @@ task STARGenomeRefVersion {
     memory: "2 GiB"
     disks: "local-disk ${disk} HDD"
     disk: disk + " GB" # TES
-    cpu:"1"
+    cpu: 1
   }
 }

--- a/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
+++ b/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
@@ -41,7 +41,7 @@ task TerraCopyFilesFromCloudToCloud {
 
   runtime {
     memory: "16 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 32 HDD"
     docker: "gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-slim"
     preemptible: 3

--- a/tasks/wdl/UltimaGenomicsWholeGenomeGermlineTasks.wdl
+++ b/tasks/wdl/UltimaGenomicsWholeGenomeGermlineTasks.wdl
@@ -811,7 +811,7 @@ task CollectWgsMetrics {
     USE_FAST_ALGORITHM=false \
     COUNT_UNPAIRED=true \
     COVERAGE_CAP=12500 \
-    READ_LENGTH=~{default=250 read_length}
+    READ_LENGTH=~{default="250" read_length}
   }
 
   runtime {
@@ -863,7 +863,7 @@ task CollectRawWgsMetrics {
     OUTPUT=~{metrics_filename} \
     COUNT_UNPAIRED=true \
     USE_FAST_ALGORITHM=false \
-    READ_LENGTH=~{default=250 read_length}
+    READ_LENGTH=~{default="250" read_length}
   }
 
   runtime {

--- a/tasks/wdl/Utilities.wdl
+++ b/tasks/wdl/Utilities.wdl
@@ -149,7 +149,7 @@ task ConvertToCram {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: preemptible_tries
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
@@ -180,7 +180,7 @@ task ConvertToBam {
     docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
     preemptible: 3
     memory: "3 GiB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk 200 HDD"
   }
   output {

--- a/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
+++ b/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl
@@ -45,7 +45,7 @@ task BuildBWAreference {
 	 memory: "96GB"
 	 disks: "local-disk 100 HDD"
      disk: "100 GB" # TES
-	 cpu: "4"
+	 cpu: 4
      }
 
      output {

--- a/verification/VerifyMetrics.wdl
+++ b/verification/VerifyMetrics.wdl
@@ -84,7 +84,7 @@ task CompareMetricFiles {
       --INPUT ~{file1} \
       --INPUT ~{file2} \
       --OUTPUT ~{output_file} \
-      ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore} \
+      ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)} \
       ~{sep=" " extra_args}
   >>>
 

--- a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl
+++ b/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl
@@ -99,7 +99,7 @@ task CompareOldMetricFiles {
     --INPUT ~{file1} \
     --INPUT ~{file2} \
     --OUTPUT ~{output_file} \
-    ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore}
+    ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)}
   >>>
 
   runtime {

--- a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl
+++ b/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl
@@ -184,7 +184,7 @@ task CompareOldMetricFiles {
     --INPUT ~{file1} \
     --INPUT ~{file2} \
     --OUTPUT ~{output_file} \
-    ~{true="--METRICS_TO_IGNORE" false="" length(metrics_to_ignore) > 0} ~{default="" sep=" --METRICS_TO_IGNORE " metrics_to_ignore}
+    ~{sep=" " prefix("--METRICS_TO_IGNORE ", metrics_to_ignore)}
   >>>
 
   runtime {


### PR DESCRIPTION
Placeholder options like `default` expect string values per the WDL spec. This quotes the bare integer literals (`default=0` to `default="0"`, `default=250` to `default="250"`) in `GermlineVariantDiscovery.wdl` and `UltimaGenomicsWholeGenomeGermlineTasks.wdl`.

Depends on #1812.