### PR TITLE
TSPS-908 add changes to use memory from ref_chunks tsv files

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,10 +4,10 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.8	2026-05-08
-Glimpse2LowPassImputationBatch	 0.0.1	2026-04-30
-Glimpse2LowPassImputationQC	 1.0.1	2026-05-11
-Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11
+Glimpse2LowPassImputation	 0.0.9	2026-05-11 
+Glimpse2LowPassImputationBatch	 0.0.2	2026-05-11 
+Glimpse2LowPassImputationQC	 1.0.1	2026-05-11 
+Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,10 +4,10 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.8	2026-05-08 
-Glimpse2LowPassImputationBatch	 0.0.1	2026-04-30 
-Glimpse2LowPassImputationQC	 1.0.1	2026-05-11 
-Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
+Glimpse2LowPassImputation	 0.0.8	2026-05-08
+Glimpse2LowPassImputationBatch	 0.0.1	2026-04-30
+Glimpse2LowPassImputationQC	 1.0.1	2026-05-11
+Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.9
+2026-05-11 (Date of Last Commit)
+
+* add batch wdl pipeline version
+
 # 0.0.8
 2026-05-08 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,7 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.8"
+    String pipeline_version = "0.0.9"
+    String batch_pipeline_version = "0.0.2"
     String quota_consumed_version = "0.0.2"
     String input_qc_version = "1.0.1"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.2
+2026-05-11 (Date of Last Commit)
+
+* update glimpse phase task to use memory from ComputeShardsAndMemoryPerShard task
+
 # 0.0.1
 2026-04-30 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.2
 2026-05-11 (Date of Last Commit)
 
-* update glimpse phase task to use memory from ComputeShardsAndMemoryPerShard task
+* update GlimpsePhase task to use memory from ComputeShardsAndMemoryPerShard task
 
 # 0.0.1
 2026-04-30 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -200,7 +200,7 @@ task ComputeShardsAndMemoryPerShard {
         import numpy as np
 
 
-        df = pd.read_csv('~{reference_chunks_memory}', sep='\t', header=None, names=['contig', 'reference_shard', 'base_gb', 'slope_per_sample_gb'])
+        df = pd.read_csv('~{reference_chunks_memory}', sep='\t', header=None, usecols=[0,1,2], names=['contig', 'reference_shard', 'base_gb'])
 
         # write out reference shards to process
         df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -5,7 +5,8 @@ version 1.0
 # which can handle larger sample sizes by splitting into batches and then merging results.
 
 workflow Glimpse2LowPassImputationBatch {
-    String pipeline_version = "0.0.1"
+    # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
+    String pipeline_version = "0.0.2"
 
     input {
 
@@ -93,8 +94,6 @@ workflow Glimpse2LowPassImputationBatch {
         File phase_input_vcf = select_first([BcftoolsMerge.merged_vcf, BcftoolsNorm.output_vcf[0]])
         File phase_input_vcf_index = select_first([BcftoolsMerge.merged_vcf_index, BcftoolsNorm.output_vcf_index[0]])
 
-        ## this task is used to grab the reference chunk but does not affect memory usage of glimpsePhase.
-        ## still tbd which method makes the most sense cost wise
         call ComputeShardsAndMemoryPerShard {
             input:
                 reference_chunks_memory = reference_chunks,
@@ -113,6 +112,7 @@ workflow Glimpse2LowPassImputationBatch {
                     sample_ids = sample_ids,
                     fasta = fasta,
                     fasta_index = fasta_index,
+                    mem_gb = ComputeShardsAndMemoryPerShard.mem_gb_per_chunk[reference_chunk_index],
                     docker = glimpse_docker
             }
         }
@@ -210,7 +210,7 @@ task ComputeShardsAndMemoryPerShard {
         df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)
 
         # calculate memory usage and save to file
-        df['mem_gb'] = df['base_gb'] + df['slope_per_sample_gb'] * ~{n_samples}
+        df['mem_gb'] = df['base_gb']
         df['mem_gb'] = df['mem_gb'].apply(lambda x: min(256, int(np.ceil(x))))  # cap at 256 GB
         df['mem_gb'].to_csv('memory_per_chunk.tsv', sep='\t', index=False, header=None)
         EOF
@@ -368,7 +368,7 @@ task BcftoolsMerge {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/bcftools:v1.3"
+        docker: "us.gcr.io/broad-dsde-methods/vcfeval_docker:v1.1"
         disks: "local-disk " + disk_size_gb + " HDD"
         memory: mem_gb + " GiB"
         cpu: cpu

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -34,8 +34,6 @@ workflow Glimpse2LowPassImputationBatch {
         String glimpse_docker = "us.gcr.io/broad-dsde-methods/glimpse:kachulis_ck_bam_reader_retry_cf5822c"
     }
 
-    Int n_samples = length(crams)
-
     if (length(crams) > 1) {
         call SplitIntoBatches {
             input:
@@ -96,8 +94,7 @@ workflow Glimpse2LowPassImputationBatch {
 
         call ComputeShardsAndMemoryPerShard {
             input:
-                reference_chunks_memory = reference_chunks,
-                n_samples = n_samples
+                reference_chunks_memory = reference_chunks
         }
 
         scatter (reference_chunk_index in range(length(ComputeShardsAndMemoryPerShard.reference_chunk_file_paths))) {
@@ -195,7 +192,6 @@ task SplitIntoBatches {
 task ComputeShardsAndMemoryPerShard {
     input {
         File reference_chunks_memory
-        Int n_samples
     }
 
     command <<<


### PR DESCRIPTION
### Description

This PR is making updates so that the memory provided to the glimpse phase task is associated with the ref panel being imputed over instead of being hardcoded to 16GB.

Ticket - https://broadworkbench.atlassian.net/browse/TSPS-908

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
