### PR TITLE
PR to feature branch: remove reference to sample scale col

### DIFF
--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -200,7 +200,7 @@ task ComputeShardsAndMemoryPerShard {
         import numpy as np
 
 
-        df = pd.read_csv('~{reference_chunks_memory}', sep='\t', header=None, names=['contig', 'reference_shard', 'base_gb', 'slope_per_sample_gb'])
+        df = pd.read_csv('~{reference_chunks_memory}', sep='\t', header=None, usecols=[0,1,2], names=['contig', 'reference_shard', 'base_gb'])
 
         # write out reference shards to process
         df['reference_shard'].to_csv('reference_shard_file_paths.tsv', sep='\t', index=False, header=None)


### PR DESCRIPTION
### Description

Dropping reference to the `slope_per_sample_gb` column containing the sample scaling factor, which we don't use.

Test run using a chunk file with 3 columns: https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/3b71b8c2-d929-4e10-a4a8-7b0a32ed7e4b

Test run using a chunk file with 4 columns (testing backwards compatibility): https://app.terra.bio/#workspaces/allofus-drc-imputation/Imputation_Server_Hydrogen_Dev/submission_history/98126108-ca4e-4c0e-9387-da2e57e74e68

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
