### PR TITLE
TSPS-913 Add ref dict check to Glimpse2LowPassImputationQC

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -6,7 +6,7 @@ ExomeGermlineSingleSample	 3.2.7	2026-01-21
 ExomeReprocessing	 3.3.7	2026-01-21 
 Glimpse2LowPassImputation	 0.0.13	2026-05-19 
 Glimpse2LowPassImputationBatch	 0.0.5	2026-05-17 
-Glimpse2LowPassImputationQC	 1.0.1	2026-05-11 
+Glimpse2LowPassImputationQC	 1.0.2	2026-05-13
 Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -6,8 +6,8 @@ ExomeGermlineSingleSample	 3.2.7	2026-01-21
 ExomeReprocessing	 3.3.7	2026-01-21 
 Glimpse2LowPassImputation	 0.0.13	2026-05-19 
 Glimpse2LowPassImputationBatch	 0.0.5	2026-05-17 
-Glimpse2LowPassImputationQC	 1.0.3	2026-05-18
-Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
+Glimpse2LowPassImputationQC	 1.0.2	2026-05-15 
+Glimpse2LowPassImputationQuotaConsumed	 0.0.3	2026-05-15 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -6,8 +6,8 @@ ExomeGermlineSingleSample	 3.2.7	2026-01-21
 ExomeReprocessing	 3.3.7	2026-01-21 
 Glimpse2LowPassImputation	 0.0.13	2026-05-19 
 Glimpse2LowPassImputationBatch	 0.0.5	2026-05-17 
-Glimpse2LowPassImputationQC	 1.0.2	2026-05-15 
-Glimpse2LowPassImputationQuotaConsumed	 0.0.3	2026-05-15 
+Glimpse2LowPassImputationQC	 1.0.2	2026-05-19 
+Glimpse2LowPassImputationQuotaConsumed	 0.0.3	2026-05-19 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,10 +4,10 @@ BuildIndices	 5.1.1	2026-05-20
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.13	2026-05-19 
+Glimpse2LowPassImputation	 0.0.14	2026-05-20 
 Glimpse2LowPassImputationBatch	 0.0.5	2026-05-17 
-Glimpse2LowPassImputationQC	 1.0.2	2026-05-19 
-Glimpse2LowPassImputationQuotaConsumed	 0.0.3	2026-05-19 
+Glimpse2LowPassImputationQC	 1.0.2	2026-05-20 
+Glimpse2LowPassImputationQuotaConsumed	 0.0.3	2026-05-20 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -6,7 +6,7 @@ ExomeGermlineSingleSample	 3.2.7	2026-01-21
 ExomeReprocessing	 3.3.7	2026-01-21 
 Glimpse2LowPassImputation	 0.0.13	2026-05-19 
 Glimpse2LowPassImputationBatch	 0.0.5	2026-05-17 
-Glimpse2LowPassImputationQC	 1.0.2	2026-05-13
+Glimpse2LowPassImputationQC	 1.0.3	2026-05-18
 Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,7 @@
+# 0.0.14
+
+* Update QC workflow version
+
 # 0.0.13
 2026-05-19 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,6 +1,6 @@
 # 0.0.14
 
-* Update QC workflow version
+* Update QC workflow version and Quota Consumed workflow version
 
 # 0.0.13
 2026-05-19 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,6 +1,7 @@
 # 0.0.14
+2026-05-20 (Date of Last Commit)
 
-* Update QC workflow version and Quota Consumed workflow version
+* Updated `quota_consumed_version` to 0.0.3 and `input_qc_version` to 1.0.2 to reflect interface updates in auxiliary workflows
 
 # 0.0.13
 2026-05-19 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,10 +4,10 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.13"
+    String pipeline_version = "0.0.14"
     String batch_pipeline_version = "0.0.5"
     String quota_consumed_version = "0.0.2"
-    String input_qc_version = "1.0.1"
+    String input_qc_version = "1.0.2"
 
     input {
         # if multiple data types are provided, the workflow will prioritize cram_manifest first, then crams/cram_indices/sample_ids

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2Low
 workflow Glimpse2LowPassImputation {
     String pipeline_version = "0.0.14"
     String batch_pipeline_version = "0.0.5"
-    String quota_consumed_version = "0.0.2"
+    String quota_consumed_version = "0.0.3"
     String input_qc_version = "1.0.2"
 
     input {

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,5 +1,5 @@
 # 0.0.3
-2026-05-15 (Date of Last Commit)
+2026-05-19 (Date of Last Commit)
 
 * Fix grep command
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,5 +1,5 @@
 # 0.0.3
-2026-05-19 (Date of Last Commit)
+2026-05-20 (Date of Last Commit)
 
 * Fix grep command
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.3
 2026-05-20 (Date of Last Commit)
 
-* Fix grep command
+* Fix grep command to be an accurate cram count
 
 # 0.0.2
 2026-05-11 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-05-15 (Date of Last Commit)
+
+* Fix grep command
+
 # 0.0.2
 2026-05-11 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/wdl/ImputationTasks.wdl" as tasks
 
 workflow QuotaConsumed {
     # if this changes, update the quota_consumed_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.3"
 
     input {
         # service expects only cram_manifest even though main wdl can alternatively take input arrays
@@ -42,7 +42,7 @@ task CountCramsFromManifest {
     command <<<
         set -e -o pipefail
 
-        grep ".cram" ~{cram_manifest} | wc -l > cram_manifest_count.txt
+        grep "\.cram" ~{cram_manifest} | wc -l > cram_manifest_count.txt
     >>>
 
     output {

--- a/pipelines/wdl/glimpse/low_pass_imputation/README.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/README.md
@@ -7,4 +7,5 @@ The `Glimpse2LowPassImputation` workflow is a WDL-based pipeline for low-pass wh
 The full documentation for the GLIMPSE2 Low-Pass Imputation pipeline can be found at the [WARP documentation site](https://broadinstitute.github.io/warp/docs/Pipelines/Glimpse2LowpassImputation_Pipeline/README) or plain [README](../../../../website/docs/Pipelines/Glimpse2LowPassImputation_Pipeline/README.md).
 
 ## Versioning
+
 See [Glimpse2LowPassImputation.changelog.md](Glimpse2LowPassImputation.changelog.md) for the full release history.

--- a/pipelines/wdl/glimpse/low_pass_imputation/README.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/README.md
@@ -7,5 +7,4 @@ The `Glimpse2LowPassImputation` workflow is a WDL-based pipeline for low-pass wh
 The full documentation for the GLIMPSE2 Low-Pass Imputation pipeline can be found at the [WARP documentation site](https://broadinstitute.github.io/warp/docs/Pipelines/Glimpse2LowpassImputation_Pipeline/README) or plain [README](../../../../website/docs/Pipelines/Glimpse2LowPassImputation_Pipeline/README.md).
 
 ## Versioning
-
 See [Glimpse2LowPassImputation.changelog.md](Glimpse2LowPassImputation.changelog.md) for the full release history.

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2026-05-06 (Date of Last Commit)
+
+* Add check for hg38 alignment in input CRAMs 
+
 # 1.0.1
 2026-05-11 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.2
-2026-05-06 (Date of Last Commit)
+2026-05-13 (Date of Last Commit)
 
-* Add check for hg38 alignment in input CRAMs 
+* Add check for correct reference alignment in input CRAMs 
 
 # 1.0.1
 2026-05-11 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.2
-2026-05-19 (Date of Last Commit)
+2026-05-20 (Date of Last Commit)
 
 * Add check for correct reference alignment in input CRAMs 
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.2
-2026-05-15 (Date of Last Commit)
+2026-05-19 (Date of Last Commit)
 
 * Add check for correct reference alignment in input CRAMs 
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.2
-2026-05-13 (Date of Last Commit)
+2026-05-15 (Date of Last Commit)
 
 * Add check for correct reference alignment in input CRAMs 
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -426,8 +426,8 @@ task ValidateCramContents {
                 if [ $n_bad_crams -gt $MAX_ITEMS_IN_ERROR_MESSAGES ]; then
                     first_part_of_message="Found more than $MAX_ITEMS_IN_ERROR_MESSAGES CRAM files not aligned to the expected reference ($ref_dict_basename)"
                     second_part_of_message="; first $MAX_ITEMS_IN_ERROR_MESSAGES are:"
-                    joined=$(printf ", %s" "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
-                    list_to_show="${joined:2}" # remove leading comma and space
+                    joined=$(IFS=","; echo "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
+                    list_to_show="${joined//,/, }" # Replaces every ',' with ', '
                     echo "$first_part_of_message$second_part_of_message $list_to_show"
                 else
                     if [ $n_bad_crams -eq 1 ]; then
@@ -436,8 +436,8 @@ task ValidateCramContents {
                         pluralized="s"
                     fi
                     first_part_of_message="Found $n_bad_crams CRAM file$pluralized not aligned to the expected reference ($ref_dict_basename)"
-                    joined=$(printf ", %s" "${crams_with_bad_or_missing_md5sums[*]}")
-                    list_to_show="${joined:2}" # remove leading comma and space
+                    joined=$(IFS=","; echo "${crams_with_bad_or_missing_md5sums[*]}")
+                    list_to_show="${joined//,/, }" # Replaces every ',' with ', '
                     echo "$first_part_of_message: $list_to_show"
                 fi
             } >> qc_messages.txt

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -345,8 +345,7 @@ task ValidateCramContents {
 
     command <<<
         # set up auth for accessing files using samtools
-        gcloud auth application-default print-access-token > token.txt
-        export HTS_AUTH_LOCATION="token.txt"
+        export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
 
         # configure billing project to use for requester pays buckets, if billing project provided
         if [ -n "$billing_project" ]; then
@@ -405,7 +404,7 @@ task ValidateCramContents {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-gatk/gatk:4.6.1.0"
+        docker: "us.gcr.io/broad-dsp-lrma/lr-gcloud-samtools:0.1.23.1"
         cpu: 1
         disks: "local-disk 10 HDD"
         memory: "4 GiB"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -353,11 +353,8 @@ task ValidateCramContents {
             export GCS_REQUESTER_PAYS_PROJECT=~{billing_project}
         fi
 
-        # collect reference MD5sums from the reference dictionary for the contigs in the reference panel
-        contigs=('chr1' 'chr2')
-        ref_dict='/scripts/Homo_sapiens_assembly38.dict'
-        cram='/scripts/NA12878_PLUMBING.cram'
-
+        contigs=("""~{sep=' ' contigs}""")
+        ref_dict="~{ref_dict}"
 
         declare -A ref_md5sums
         while read -r line; do
@@ -385,15 +382,17 @@ task ValidateCramContents {
         done
 
         # read cram headers to validate that they contain the expected reference alignment MD5sums
-        echo "Validating CRAM file: $cram"
-        header=$(samtools view -H "$cram")
-        for chrom in "${!ref_md5sums[@]}"; do
-            expected_md5=${ref_md5sums[$chrom]}
-            if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then
-                echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)" >> qc_messages.txt
-            else
-                echo "CRAM file $cram contains expected reference alignment MD5 for contig $chrom."
-            fi
+        for cram in """~{sep=' ' crams}""".split(); do
+            echo "Validating CRAM file: $cram"
+            header=$(samtools view -H "$cram")
+            for chrom in "${!ref_md5sums[@]}"; do
+                expected_md5=${ref_md5sums[$chrom]}
+                if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then
+                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)" >> qc_messages.txt
+                else
+                    echo "CRAM file $cram contains expected reference alignment MD5 for contig $chrom."
+                fi
+            done
         done
 
         # passes_qc is true if qc_messages is empty

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -384,6 +384,7 @@ task ValidateCramContents {
         done
 
         crams_with_bad_or_missing_md5sums=()
+        MAX_ITEMS_IN_ERROR_MESSAGES=5
         # read cram headers to validate that they contain the expected reference alignment MD5sums
         for cram in ~{sep=' ' crams}; do
             echo "Validating CRAM file: $cram"
@@ -410,7 +411,6 @@ task ValidateCramContents {
         done
 
         # if crams_with_bad_or_missing_md5sums is not empty, write an error message to qc_messages.txt
-        MAX_ITEMS_IN_ERROR_MESSAGES=5
         n_bad_crams=${#crams_with_bad_or_missing_md5sums[@]}
         if [ $n_bad_crams -ne 0 ]; then
             {

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -35,6 +35,7 @@ workflow InputQC {
         }
     }
 
+    # only check cram contents if the previous QC checks passed
     if (ConvertCramManifestToInputArrays.passes_qc && ValidateCramsAndIndicesAndSampleIds.passes_qc) {
         call ValidateCramContents {
             input:

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -382,7 +382,7 @@ task ValidateCramContents {
         done
 
         # read cram headers to validate that they contain the expected reference alignment MD5sums
-        for cram in """~{sep=' ' crams}""".split(); do
+        for cram in ~{sep=' ' crams}; do
             echo "Validating CRAM file: $cram"
             header=$(samtools view -H "$cram")
             for chrom in "${!ref_md5sums[@]}"; do

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -367,8 +367,10 @@ task ValidateCramContents {
         
         while read -r line; do
             if [[ $line == @SQ* ]]; then
-                chrom=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i~/^SN:/) print substr($i,4)}')
-                md5=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i~/^M5:/) print substr($i,4)}')
+                # chrom is in the 2nd column of the ref dict in format SN:<chromName>
+                chrom=$(echo "$line" | cut -f 2 | cut -d ":" -f 2)
+                # md5sum is in the 4th column of the ref dict in format M5:<md5sum>
+                md5=$(echo "$line" | cut -f 4 | cut -d ":" -f 2)
 
                 if [[ " ${contigs[@]} " =~ " ${chrom} " ]]; then
                     ref_md5sums["$chrom"]="$md5"
@@ -404,7 +406,12 @@ task ValidateCramContents {
                 fi
             done
             if [ "$cram_ok" = true ]; then
-                echo "CRAM file $cram contains expected reference alignment MD5sums for all expected contigs."
+                echo "CRAM file $cram contains expected reference alignment MD5sums for all expected contigs"
+            fi
+            # if we've found more than MAX_ITEMS_IN_ERROR_MESSAGES + 1 crams with bad or missing md5sums, we can stop checking the rest of the crams because the error message will be truncated anyway
+            if [ ${#crams_with_bad_or_missing_md5sums[@]} -gt $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) ]; then
+                echo "Found more than $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) CRAM files with bad or missing reference alignment MD5sums; skipping validation of remaining CRAM files" 
+                break
             fi
         done
 
@@ -413,19 +420,19 @@ task ValidateCramContents {
         n_bad_crams=${#crams_with_bad_or_missing_md5sums[@]}
         if [ $n_bad_crams -ne 0 ]; then
             {
-                if [ $n_bad_crams -eq 1 ]; then
-                    pluralized=""
-                else
-                    pluralized="s"
-                fi
-                first_part_of_message="Found $n_bad_crams CRAM file$pluralized not aligned to the expected reference ($ref_dict_basename)"
-                
                 # Show only first N items if list is too long
                 if [ $n_bad_crams -gt $MAX_ITEMS_IN_ERROR_MESSAGES ]; then
+                    first_part_of_message="Found more than $MAX_ITEMS_IN_ERROR_MESSAGES CRAM files not aligned to the expected reference ($ref_dict_basename)"
                     second_part_of_message="; first $MAX_ITEMS_IN_ERROR_MESSAGES are:"
                     list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
                     echo "$first_part_of_message$second_part_of_message $list_to_show"
                 else
+                    if [ $n_bad_crams -eq 1 ]; then
+                        pluralized=""
+                    else
+                        pluralized="s"
+                    fi
+                    first_part_of_message="Found $n_bad_crams CRAM file$pluralized not aligned to the expected reference ($ref_dict_basename)"
                     list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]}")
                     echo "$first_part_of_message: $list_to_show"
                 fi

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -389,8 +389,11 @@ task ValidateCramContents {
             head -n 5 <<< "$header" # print first 5 lines of header for debugging
             for chrom in "${!ref_md5sums[@]}"; do
                 expected_md5=${ref_md5sums[$chrom]}
+                echo "Checking for expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)"
+                echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"
                 if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then
-                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)" >> qc_messages.txt
+                    echo "writing QC message to file"
+                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom with M5:$expected_md5 in header)" >> qc_messages.txt
                 else
                     echo "CRAM file $cram contains expected reference alignment MD5 for contig $chrom."
                 fi

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -346,7 +346,6 @@ task ValidateCramContents {
     command <<<
         # set up auth for accessing files using samtools
         export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
-        touch qc_messages.txt
 
         # configure billing project to use for requester pays buckets, if billing project provided
         if [ -n "~{billing_project}" ]; then
@@ -354,7 +353,9 @@ task ValidateCramContents {
             export GCS_REQUESTER_PAYS_PROJECT=~{billing_project}
         fi
 
-        contigs=("""~{sep=' ' contigs}""")
+        touch qc_messages.txt
+
+        contigs=~{sep=' ' contigs}
         ref_dict="~{ref_dict}"
 
         declare -A ref_md5sums
@@ -370,8 +371,8 @@ task ValidateCramContents {
                     ref_md5sums["$chrom"]="$md5"
                     found_count=$((found_count + 1))
                     
-                    # Check if we've found all contigs
                     if [[ $found_count -eq $expected_count ]]; then
+                        echo "Found all ${found_count} expected contigs in reference dictionary."
                         break
                     fi
                 fi

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -406,9 +406,9 @@ task ValidateCramContents {
             if [ "$cram_ok" = true ]; then
                 echo "CRAM file $cram contains expected reference alignment MD5sums for all expected contigs"
             fi
-            # if we've found more than MAX_ITEMS_IN_ERROR_MESSAGES + 1 crams with bad or missing md5sums, we can stop checking the rest of the crams because the error message will be truncated anyway
-            if [ ${#crams_with_bad_or_missing_md5sums[@]} -gt $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) ]; then
-                echo "Found more than $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) CRAM files with bad or missing reference alignment MD5sums; skipping validation of remaining CRAM files" 
+            # if we've found more than MAX_ITEMS_IN_ERROR_MESSAGES crams with bad or missing md5sums, we can stop checking the rest of the crams because the error message will be truncated anyway
+            if [ ${#crams_with_bad_or_missing_md5sums[@]} -gt $((MAX_ITEMS_IN_ERROR_MESSAGES)) ]; then
+                echo "Found more than $((MAX_ITEMS_IN_ERROR_MESSAGES)) CRAM files with bad or missing reference alignment MD5sums; skipping validation of remaining CRAM files" 
                 break
             fi
             # if we've checked more than MAX_CRAMS_TO_CHECK crams, we will stop to limit runtime of this task

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -357,6 +357,9 @@ task ValidateCramContents {
         ref_dict="~{ref_dict}"
 
         declare -A ref_md5sums
+        expected_count=${#contigs[@]}
+        found_count=0
+        
         while read -r line; do
             if [[ $line == @SQ* ]]; then
                 chrom=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i~/^SN:/) print substr($i,4)}')
@@ -364,9 +367,10 @@ task ValidateCramContents {
 
                 if [[ " ${contigs[@]} " =~ " ${chrom} " ]]; then
                     ref_md5sums["$chrom"]="$md5"
-
+                    found_count=$((found_count + 1))
+                    
                     # Check if we've found all contigs
-                    if [[ $${#ref_md5sums[@]} -eq $${#contigs[@]} ]]; then
+                    if [[ $found_count -eq $expected_count ]]; then
                         break
                     fi
                 fi
@@ -382,6 +386,7 @@ task ValidateCramContents {
         for cram in ~{sep=' ' crams}; do
             echo "Validating CRAM file: $cram"
             header=$(samtools view -H "$cram")
+            head -n 5 <<< "$header" # print first 5 lines of header for debugging
             for chrom in "${!ref_md5sums[@]}"; do
                 expected_md5=${ref_md5sums[$chrom]}
                 if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow InputQC {
     # if this changes, update the input_qc_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
         # service expects only cram_manifest even though main wdl can alternatively take input arrays

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -342,6 +342,7 @@ task ValidateCramContents {
     }
 
     String billing_project = select_first([billing_project_for_rp, ""])
+    String ref_dict_basename = basename(ref_dict)
 
     command <<<
         # set up auth for accessing files using samtools
@@ -357,6 +358,7 @@ task ValidateCramContents {
 
         contigs=(~{sep=' ' contigs})
         ref_dict="~{ref_dict}"
+        ref_dict_basename="~{ref_dict_basename}"
 
         declare -A ref_md5sums
         expected_count=${#contigs[@]}
@@ -384,23 +386,52 @@ task ValidateCramContents {
             echo "  $chrom: ${ref_md5sums[$chrom]}"
         done
 
+        crams_with_bad_or_missing_md5sums=()
         # read cram headers to validate that they contain the expected reference alignment MD5sums
         for cram in ~{sep=' ' crams}; do
             echo "Validating CRAM file: $cram"
             header=$(samtools view -H "$cram")
-            head -n 5 <<< "$header" # print first 5 lines of header for debugging
+            cram_ok=true
             for chrom in "${!ref_md5sums[@]}"; do
                 expected_md5=${ref_md5sums[$chrom]}
-                echo "Checking for expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)"
                 echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"
                 if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then
-                    echo "writing QC message to file"
-                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom with M5:$expected_md5 in header)" >> qc_messages.txt
-                else
-                    echo "CRAM file $cram contains expected reference alignment MD5 for contig $chrom."
+                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom or it does not match the expected value."
+                    crams_with_bad_or_missing_md5sums+=("$cram")
+                    cram_ok=false
+                    break # no need to check other contigs for this cram if one is already missing or has a bad md5sum
                 fi
             done
+            if [ "$cram_ok" = true ]; then
+                echo "CRAM file $cram contains expected reference alignment MD5sums for all expected contigs."
+            fi
         done
+
+        # if crams_with_bad_or_missing_md5sums is not empty, write an error message to qc_messages.txt
+        MAX_ITEMS_IN_ERROR_MESSAGES=5
+        n_bad_crams=${#crams_with_bad_or_missing_md5sums[@]}
+        if [ $n_bad_crams -ne 0 ]; then
+            {
+                if [ $n_bad_crams -eq 1 ]; then
+                    pluralized=""
+                else
+                    pluralized="s"
+                fi
+                first_part_of_message="Found $n_bad_crams CRAM file$pluralized not aligned to the expected reference ($ref_dict_basename)"
+                
+                # Show only first N items if list is too long
+                if [ $n_bad_crams -gt $MAX_ITEMS_IN_ERROR_MESSAGES ]; then
+                    second_part_of_message="; first $MAX_ITEMS_IN_ERROR_MESSAGES are:"
+                    list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
+                    echo "$first_part_of_message$second_part_of_message $list_to_show"
+                else
+                    list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]}")
+                    echo "$first_part_of_message: $list_to_show"
+                fi
+            } >> qc_messages.txt
+        else
+            echo "All CRAM files contain the expected reference alignment MD5sums for the expected contigs."
+        fi
 
         # passes_qc is true if qc_messages is empty
         if [ ! -s qc_messages.txt ]; then

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -345,7 +345,8 @@ task ValidateCramContents {
 
     command <<<
         # set up auth for accessing files using samtools
-        export GCS_OAUTH_TOKEN=$(gcloud auth application-default print-access-token)
+        gcloud auth application-default print-access-token > token.txt
+        export HTS_AUTH_LOCATION="token.txt"
 
         # configure billing project to use for requester pays buckets, if billing project provided
         if [ -n "$billing_project" ]; then
@@ -365,11 +366,8 @@ task ValidateCramContents {
                 if [[ " ${contigs[@]} " =~ " ${chrom} " ]]; then
                     ref_md5sums["$chrom"]="$md5"
 
-                    echo  ${contigs[@]}
-                    echo ${chrom}
-                    
                     # Check if we've found all contigs
-                    if [[ ${#ref_md5sums[@]} -eq ${#contigs[@]} ]]; then
+                    if [[ $${#ref_md5sums[@]} -eq $${#contigs[@]} ]]; then
                         break
                     fi
                 fi

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -348,8 +348,8 @@ task ValidateCramContents {
         export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
 
         # configure billing project to use for requester pays buckets, if billing project provided
-        if [ -n "$billing_project" ]; then
-            echo "Using billing project '$billing_project' for requester pays buckets."
+        if [ -n "~{billing_project}" ]; then
+            echo "Using billing project '~{billing_project}' for requester pays buckets."
             export GCS_REQUESTER_PAYS_PROJECT=~{billing_project}
         fi
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -346,6 +346,7 @@ task ValidateCramContents {
     command <<<
         # set up auth for accessing files using samtools
         export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
+        touch qc_messages.txt
 
         # configure billing project to use for requester pays buckets, if billing project provided
         if [ -n "~{billing_project}" ]; then

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -385,8 +385,11 @@ task ValidateCramContents {
 
         crams_with_bad_or_missing_md5sums=()
         MAX_ITEMS_IN_ERROR_MESSAGES=5
+        cram_check_count=0
+        MAX_CRAMS_TO_CHECK=100 # to limit runtime of this task, we will only check the first 100 crams for the expected md5sums
         # read cram headers to validate that they contain the expected reference alignment MD5sums
         for cram in ~{sep=' ' crams}; do
+            cram_check_count=$((cram_check_count + 1))
             echo "Validating CRAM file: $cram"
             header=$(samtools view -H "$cram")
             cram_ok=true
@@ -406,6 +409,11 @@ task ValidateCramContents {
             # if we've found more than MAX_ITEMS_IN_ERROR_MESSAGES + 1 crams with bad or missing md5sums, we can stop checking the rest of the crams because the error message will be truncated anyway
             if [ ${#crams_with_bad_or_missing_md5sums[@]} -gt $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) ]; then
                 echo "Found more than $((MAX_ITEMS_IN_ERROR_MESSAGES + 1)) CRAM files with bad or missing reference alignment MD5sums; skipping validation of remaining CRAM files" 
+                break
+            fi
+            # if we've checked more than MAX_CRAMS_TO_CHECK crams, we will stop to limit runtime of this task
+            if [ $cram_check_count -ge $MAX_CRAMS_TO_CHECK ]; then
+                echo "Checked $MAX_CRAMS_TO_CHECK CRAM files; stopping further checks to limit runtime of this task" 
                 break
             fi
         done

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -35,6 +35,17 @@ workflow InputQC {
         }
     }
 
+    if (defined(ValidateCramsAndIndicesAndSampleIds.passes_qc) && ValidateCramsAndIndicesAndSampleIds.passes_qc) {
+        call ValidateCramContents {
+            input:
+                crams = ConvertCramManifestToInputArrays.crams,
+                cram_indices = ConvertCramManifestToInputArrays.cram_indices,
+                contigs = contigs,
+                ref_dict = ref_dict,
+                billing_project_for_rp = billing_project_for_rp
+        }
+    }
+
     output {
         Boolean passes_qc = select_first([ValidateCramsAndIndicesAndSampleIds.passes_qc, ConvertCramManifestToInputArrays.passes_qc])
         String qc_messages = select_first([ValidateCramsAndIndicesAndSampleIds.qc_messages, ConvertCramManifestToInputArrays.qc_messages])
@@ -304,6 +315,9 @@ task ValidateCramsAndIndicesAndSampleIds {
 
         EOF
         python3 script.py
+
+        # This task should always succeed
+        exit 0
     >>>
     
     runtime {
@@ -318,4 +332,67 @@ task ValidateCramsAndIndicesAndSampleIds {
         Boolean passes_qc = read_boolean("passes_qc.txt")
         String qc_messages = read_string("qc_messages.txt")
     }
+}
+
+task ValidateCramContents {
+    input {
+        Array[String] crams
+        Array[String] contigs
+        File ref_dict
+        String? billing_project_for_rp
+    }
+
+    String billing_project = select_first([billing_project_for_rp, ""])
+
+    command <<<
+        # set up auth for accessing files using samtools
+        export GCS_OAUTH_TOKEN=$(gcloud auth application-default print-access-token)
+
+        # configure billing project to use for requester pays buckets, if billing project provided
+        if [ -n "$billing_project" ]; then
+            echo "Using billing project '$billing_project' for requester pays buckets."
+            export GCS_REQUESTER_PAYS_PROJECT=~{billing_project}
+        fi
+
+        # collect reference MD5sums from the reference dictionary for the contigs in the reference panel
+        declare -A ref_md5sums
+        while read -r line; do
+            if [[ $line == @SQ* ]]; then
+                chrom=$(echo "$line" | grep -oP 'SN:\K\S+')
+                md5=$(echo "$line" | grep -oP 'M5:\K\S+')
+                if [[ " ${contigs[@]} " =~ " ${chrom} " ]]; then
+                    ref_md5sums["$chrom"]="$md5"
+                fi
+            fi
+        done < ~{ref_dict}
+        
+        # read cram headers to validate that they contain the expected reference alignment MD5sums
+        for cram in ~{sep=' ' crams}; do
+            echo "Validating CRAM file: $cram"
+            header=$(samtools view -H "$cram")
+            for chrom in "${!ref_md5sums[@]}"; do
+                expected_md5=${ref_md5sums[$chrom]}
+                if ! echo "$header" | grep -q "SN:$chrom" || ! echo "$header" | grep -q "M5:$expected_md5"; then
+                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 in header)" >&2
+                    exit 1
+                fi
+            done
+        done
+
+        # This task should always succeed
+        exit 0
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
+        cpu: 1
+        disks: "local-disk 10 HDD"
+        memory: "4 GiB"
+        maxRetries: 2
+    }
+
+    output {
+        Boolean passes_qc
+        String qc_messages
+    }    
 }

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -46,8 +46,8 @@ workflow InputQC {
     }
 
     output {
-        Boolean passes_qc = select_first([ValidateCramsAndIndicesAndSampleIds.passes_qc, ConvertCramManifestToInputArrays.passes_qc])
-        String qc_messages = select_first([ValidateCramsAndIndicesAndSampleIds.qc_messages, ConvertCramManifestToInputArrays.qc_messages])
+        Boolean passes_qc = select_first([ValidateCramContents.passes_qc, ValidateCramsAndIndicesAndSampleIds.passes_qc, ConvertCramManifestToInputArrays.passes_qc])
+        String qc_messages = select_first([ValidateCramContents.qc_messages, ValidateCramsAndIndicesAndSampleIds.qc_messages, ConvertCramManifestToInputArrays.qc_messages])
     }
 }
 
@@ -354,27 +354,46 @@ task ValidateCramContents {
         fi
 
         # collect reference MD5sums from the reference dictionary for the contigs in the reference panel
+        contigs=('chr1' 'chr2')
+        ref_dict='/scripts/Homo_sapiens_assembly38.dict'
+        cram='/scripts/NA12878_PLUMBING.cram'
+
+
         declare -A ref_md5sums
         while read -r line; do
             if [[ $line == @SQ* ]]; then
-                chrom=$(echo "$line" | grep -oP 'SN:\K\S+')
-                md5=$(echo "$line" | grep -oP 'M5:\K\S+')
+                chrom=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i~/^SN:/) print substr($i,4)}')
+                md5=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i~/^M5:/) print substr($i,4)}')
+
                 if [[ " ${contigs[@]} " =~ " ${chrom} " ]]; then
                     ref_md5sums["$chrom"]="$md5"
+
+                    echo  ${contigs[@]}
+                    echo ${chrom}
+                    
+                    # Check if we've found all contigs
+                    if [[ ${#ref_md5sums[@]} -eq ${#contigs[@]} ]]; then
+                        break
+                    fi
                 fi
             fi
-        done < ~{ref_dict}
-        
+        done < $ref_dict
+
+        echo "found relevant contigs with these md5sums in ref dict ${ref_dict}:"
+        for chrom in "${!ref_md5sums[@]}"; do
+            echo "  $chrom: ${ref_md5sums[$chrom]}"
+        done
+
         # read cram headers to validate that they contain the expected reference alignment MD5sums
-        for cram in ~{sep=' ' crams}; do
-            echo "Validating CRAM file: $cram"
-            header=$(samtools view -H "$cram")
-            for chrom in "${!ref_md5sums[@]}"; do
-                expected_md5=${ref_md5sums[$chrom]}
-                if ! echo "$header" | grep -q "SN:$chrom" || ! echo "$header" | grep -q "M5:$expected_md5"; then
-                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 in header)" >> qc_messages.txt
-                fi
-            done
+        echo "Validating CRAM file: $cram"
+        header=$(samtools view -H "$cram")
+        for chrom in "${!ref_md5sums[@]}"; do
+            expected_md5=${ref_md5sums[$chrom]}
+            if ! echo "$header" | grep -q "SN:$chrom.*M5:$expected_md5"; then
+                echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 on the same line in header)" >> qc_messages.txt
+            else
+                echo "CRAM file $cram contains expected reference alignment MD5 for contig $chrom."
+            fi
         done
 
         # passes_qc is true if qc_messages is empty

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -355,7 +355,7 @@ task ValidateCramContents {
 
         touch qc_messages.txt
 
-        contigs=~{sep=' ' contigs}
+        contigs=(~{sep=' ' contigs})
         ref_dict="~{ref_dict}"
 
         declare -A ref_md5sums

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -121,9 +121,6 @@ task ConvertCramManifestToInputArrays {
 
         EOF
         python3 script.py
-
-        # This task should always succeed
-        exit 0
     >>>
 
     runtime {
@@ -315,9 +312,6 @@ task ValidateCramsAndIndicesAndSampleIds {
 
         EOF
         python3 script.py
-
-        # This task should always succeed
-        exit 0
     >>>
     
     runtime {

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -426,7 +426,8 @@ task ValidateCramContents {
                 if [ $n_bad_crams -gt $MAX_ITEMS_IN_ERROR_MESSAGES ]; then
                     first_part_of_message="Found more than $MAX_ITEMS_IN_ERROR_MESSAGES CRAM files not aligned to the expected reference ($ref_dict_basename)"
                     second_part_of_message="; first $MAX_ITEMS_IN_ERROR_MESSAGES are:"
-                    list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
+                    joined=$(printf ", %s" "${crams_with_bad_or_missing_md5sums[*]:0:$MAX_ITEMS_IN_ERROR_MESSAGES}")
+                    list_to_show="${joined:2}" # remove leading comma and space
                     echo "$first_part_of_message$second_part_of_message $list_to_show"
                 else
                     if [ $n_bad_crams -eq 1 ]; then
@@ -435,7 +436,8 @@ task ValidateCramContents {
                         pluralized="s"
                     fi
                     first_part_of_message="Found $n_bad_crams CRAM file$pluralized not aligned to the expected reference ($ref_dict_basename)"
-                    list_to_show=$(IFS=", "; echo "${crams_with_bad_or_missing_md5sums[*]}")
+                    joined=$(printf ", %s" "${crams_with_bad_or_missing_md5sums[*]}")
+                    list_to_show="${joined:2}" # remove leading comma and space
                     echo "$first_part_of_message: $list_to_show"
                 fi
             } >> qc_messages.txt

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -35,11 +35,10 @@ workflow InputQC {
         }
     }
 
-    if (defined(ValidateCramsAndIndicesAndSampleIds.passes_qc) && ValidateCramsAndIndicesAndSampleIds.passes_qc) {
+    if (ConvertCramManifestToInputArrays.passes_qc && ValidateCramsAndIndicesAndSampleIds.passes_qc) {
         call ValidateCramContents {
             input:
                 crams = ConvertCramManifestToInputArrays.crams,
-                cram_indices = ConvertCramManifestToInputArrays.cram_indices,
                 contigs = contigs,
                 ref_dict = ref_dict,
                 billing_project_for_rp = billing_project_for_rp
@@ -373,11 +372,17 @@ task ValidateCramContents {
             for chrom in "${!ref_md5sums[@]}"; do
                 expected_md5=${ref_md5sums[$chrom]}
                 if ! echo "$header" | grep -q "SN:$chrom" || ! echo "$header" | grep -q "M5:$expected_md5"; then
-                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 in header)" >&2
-                    exit 1
+                    echo "CRAM file $cram is missing expected reference alignment MD5 for contig $chrom (expected SN:$chrom and M5:$expected_md5 in header)" >> qc_messages.txt
                 fi
             done
         done
+
+        # passes_qc is true if qc_messages is empty
+        if [ ! -s qc_messages.txt ]; then
+            echo "true" > passes_qc.txt
+        else
+            echo "false" > passes_qc.txt
+        fi
 
         # This task should always succeed
         exit 0
@@ -392,7 +397,7 @@ task ValidateCramContents {
     }
 
     output {
-        Boolean passes_qc
-        String qc_messages
+        Boolean passes_qc = read_boolean("passes_qc.txt")
+        String qc_messages = read_string("qc_messages.txt")
     }    
 }

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -408,7 +408,7 @@ task ValidateCramContents {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
+        docker: "us.gcr.io/broad-gatk/gatk:4.6.1.0"
         cpu: 1
         disks: "local-disk 10 HDD"
         memory: "4 GiB"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_files_dont_exist.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_files_dont_exist.json
@@ -3,7 +3,7 @@
   "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
   "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail_both_crams_and_manifest_inputs",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/fakeCramManifestManyFilesDontExist.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_not_hg38.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_not_hg38.json
@@ -3,7 +3,7 @@
   "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
   "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestManyNotHg38.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_not_hg38.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_many_not_hg38.json
@@ -1,0 +1,10 @@
+{
+  "Glimpse2LowPassImputationQC.reference_panel_prefix": "gs://broad-dsde-methods-bge-resources-public/GlimpseImputation/ReferencePanels/1000G_HGDP_with_trio_information_old_chrX",
+  "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
+  "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail",
+  "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestManyNotHg38.tsv",
+  "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"
+}

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_no_sample_ids.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_no_sample_ids.json
@@ -3,7 +3,7 @@
   "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
   "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail_cram_without_sample_ids",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/fakeCramManifestNoSampleIds.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_not_hg38.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_not_hg38.json
@@ -1,0 +1,10 @@
+{
+  "Glimpse2LowPassImputationQC.reference_panel_prefix": "gs://broad-dsde-methods-bge-resources-public/GlimpseImputation/ReferencePanels/1000G_HGDP_with_trio_information_old_chrX",
+  "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
+  "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail_cram_without_sample_ids",
+  "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestNotHg38.tsv",
+  "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"
+}

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_not_hg38.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_not_hg38.json
@@ -3,7 +3,7 @@
   "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
   "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test_fail_cram_without_sample_ids",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestNotHg38.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/pass_manifest.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/pass_manifest.json
@@ -5,6 +5,6 @@
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/fakeCramManifestGoodAccess.tsv",
+  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestPassQC.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"
 }

--- a/website/docs/Pipelines/Glimpse2LowPassImputation_Pipeline/README.md
+++ b/website/docs/Pipelines/Glimpse2LowPassImputation_Pipeline/README.md
@@ -171,6 +171,7 @@ The `InputQC` workflow validates CRAM-based inputs supplied by the `cram_manifes
 - CRAM file names end with `.cram` and indices end with `.crai`
 - input paths use `gs://` format and are accessible
 - CRAM file sizes do not exceed the configured maximum (default: 10 GB)
+- CRAM files are aligned to the expected reference
 - optional requester-pays validation via `billing_project_for_rp`
  
 ## Important notes


### PR DESCRIPTION
### Description

Adding a check for proper alignment of crams to the InputQC wdl for Glimpse2LowPassImputation. We only check the first 100 crams, since it takes ~0.6 seconds per cram to check the header. 

New test uses a t2t sample. Output:
```
{ "qc_messages": "Found 1 CRAM file not aligned to the expected reference (Homo_sapiens_assembly38.dict): gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.cram", "passes_qc": "false" }
```

New test with >5 non-hg38 crams. Output:
```
{ "qc_messages": "Found more than 5 CRAM files not aligned to the expected reference (Homo_sapiens_assembly38.dict); first 5 are: gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.chr20.cram, gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.chr20.1.cram, gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.chr20.2.cram, gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.chr20.3.cram, gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/NA12878.t2t.chr20.4.cram", "passes_qc": "false" }
```

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-913

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [x] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [x] If you made a changelog update, did you update the pipeline version number?
