### PR TITLE
[TSPS-752] Use deterministic GLIMPSE image

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,8 +4,8 @@ BuildIndices	 5.1.0	2026-02-13
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.9	2026-05-11 
-Glimpse2LowPassImputationBatch	 0.0.2	2026-05-11 
+Glimpse2LowPassImputation	 0.0.10	2026-05-13 
+Glimpse2LowPassImputationBatch	 0.0.3	2026-05-13 
 Glimpse2LowPassImputationQC	 1.0.1	2026-05-11 
 Glimpse2LowPassImputationQuotaConsumed	 0.0.2	2026-05-11 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.10
+2026-05-13 (Date of Last Commit)
+
+* Update GLIMPSE docker image to latest, which includes a fix for non-deterministic output during phasing when using 1 CPU
+
 # 0.0.9
 2026-05-11 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.9"
-    String batch_pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.10"
+    String batch_pipeline_version = "0.0.3"
     String quota_consumed_version = "0.0.2"
     String input_qc_version = "1.0.1"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -34,7 +34,7 @@ workflow Glimpse2LowPassImputation {
         Int sample_batch_size = 1000
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-dsde-methods/glimpse:kachulis_ck_bam_reader_retry_cf5822c"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse@sha256:a0151730cefaaa9ef78b7f9644c63ebb00ce6cd470fa0d60349daa5eee020aec"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
         Int mem_gb_merge = 32 # TODO: this can be decreased by rewriting the RecomputeAndAnnotate to work in chunks instead of line by line
     }

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-05-13 (Date of Last Commit)
+
+* updates to support a newer version of the GLIMPSE docker image, which includes a fix for non-deterministic output during phasing when using 1 CPU.
+
 # 0.0.2
 2026-05-11 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.3"
 
     input {
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -423,7 +423,7 @@ task GlimpsePhase {
     command <<<
         set -euo pipefail
 
-        export GCS_OAUTH_TOKEN=$(/root/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
+        export GCS_OAUTH_TOKEN=$(/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
 
         cram_paths=( ~{sep=" " crams} )
         cram_index_paths=( ~{sep=" " cram_indices} )


### PR DESCRIPTION
### Description

https://broadworkbench.atlassian.net/browse/TSPS-752

Brings in the latest GLIMPSE image, which includes a fix for non-deterministic output during phasing with 1 CPU. Also includes a gcloud path update required as part of using the new image.

_Give your PR a **concise** yet **descriptive** title._
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed, or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
