### PR TITLE
Optimus update to support V4

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,11 +43,6 @@ import "../../../tasks/wdl/UnmappedBamToAlignedBam.wdl" as ToBam
 import "../../../structs/dna_seq/DNASeqStructs.wdl"
 ```
 
-Verify no legacy paths remain: the following command should return nothing.
-```bash
-grep -rn 'tasks/broad\|tasks/skylab\|pipelines/broad\|pipelines/skylab' pipelines tasks verification
-```
-
 ### Sub-workflow Input Contract
 A WDL file defines a **single input contract for all callers**. You cannot expose an input to one workflow but hide it from another that imports the same WDL. To remove a parameter from one consumer, you must remove it from the shared task/sub-workflow **and** from every caller.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,10 +85,12 @@ Each pipeline has a `<PipelineName>.changelog.md` file. For each new version:
 When a shared task changes, every workflow that imports it may need a version bump. Common dependency chains:
 
 - `tasks/wdl/StarAlign.wdl` → **Optimus**, **SlideSeq**, **Multiome** (via Optimus), **PairedTag** (via Optimus), **SlideTags** (via Optimus), **MultiSampleSmartSeq2SingleNucleus**
-- `tasks/wdl/CheckInputs.wdl` → **Optimus** and its wrappers (Multiome, PairedTag, SlideTags)
+- `tasks/wdl/CheckInputs.wdl` → **Optimus** (via `checkOptimusInput`) and its wrappers (**Multiome**, **PairedTag**, **SlideTags**); also **MultiSampleSmartSeq2SingleNucleus** (via `checkInputArrays`, a separate task in the same file). Note: SlideSeq imports this file but never calls any of its tasks — changes to CheckInputs.wdl task signatures do not functionally affect SlideSeq through this import.
 - `tasks/wdl/Metrics.wdl` → Most Skylab-origin pipelines
 
 For each dependent pipeline, either bump the version with a changelog note **or** add a "no functional impact" note explaining why the change is benign for that pipeline.
+
+> **Important:** passing womtool validation is **not sufficient** to satisfy cascading bump requirements. Womtool only checks task call signatures — it does not enforce changelog updates. When CI reports "X.changelog.md has not been changed and needs to be updated", that is a cascading bump violation: patch-bump the WDL version, add a changelog entry (even "no functional impact"), and update `pipeline_versions.txt`.
 
 ### Test Inputs
 Test JSON inputs live at two locations per pipeline:
@@ -112,7 +114,7 @@ Use build scripts for releases:
 ## Critical Workflows
 
 ### WDL Validation (MANDATORY)
-The womtool JAR is expected at at a user-specific location such as `~/womtool-90.jar`, the appropriate version of Java must also be availible. A convenience wrapper also exists at `scripts/validate_wdls.sh`.
+The womtool JAR is expected at a user-specific location such as `~/womtool-90.jar`. The appropriate version of Java must also be available. A convenience wrapper also exists at `scripts/validate_wdls.sh`.
 
 Validate a single file:
 ```bash
@@ -152,15 +154,19 @@ done
 ## Structural Conventions
 
 ### Multi-cloud Support
-Pipelines support GCP/Azure via `cloud_provider` input and conditional docker selection:
+Pipelines support GCP/Azure via a `cloud_provider` input. The pattern varies by pipeline origin:
+
+**Broad-origin pipelines** (DNA-seq, arrays, genotyping) maintain dual docker registries and validate `cloud_provider` at runtime:
 ```wdl
 String gatk_docker_gcp = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
 String gatk_docker_azure = "terrapublic.azurecr.io/gatk:4.6.1.0"
 String gatk_docker = if cloud_provider == "gcp" then gatk_docker_gcp else gatk_docker_azure
 ```
 
+**Skylab-origin pipelines** (Optimus, Multiome, ATAC-seq, PairedTag, SlideTags, SlideSeq, RNAWithUMIs, MultiSampleSmartSeq2) default `cloud_provider = "gcp"` and do **not** maintain Azure docker registries. Do not add Azure docker alternatives to these pipelines.
+
 ### Error Handling
-Use `ErrorWithMessage` task for input validation:
+Use `ErrorWithMessage` task for input validation. For broad-origin pipelines validating `cloud_provider`:
 ```wdl
 if ((cloud_provider != "gcp") && (cloud_provider != "azure")) {
   call utils.ErrorWithMessage as ErrorMessageIncorrectInput {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,11 @@ The human-facing guides (last three rows) are canonical for style. Anything *age
 
 1. **Validate all modified WDLs** — and every WDL that imports them (transitively). See *WDL Validation (MANDATORY)* in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 2. **Changelog and versioning** — follow [changelog_style.md](changelog_style.md).
-3. **After merging develop**, grep for duplicate `pipeline_version` lines — keep the higher one.
-4. **Sub-workflow contract** — removing an input from a shared WDL requires removing it from every caller.
-5. **Stale example/test inputs** — when you rename a workflow or remove/rename inputs, audit `pipelines/wdl/<name>/example_inputs/*.json` and `test_inputs/**/*.json`; they break silently because they are not checked by womtool.
-6. **Touching a pipeline's interface** — also update the pipeline's docs page under `website/docs/Pipelines/<Name>_Pipeline/README.md` and run `yarn --cwd=website build` to catch broken links.
+3. **Cascading version bumps** — when modifying a shared task (`tasks/wdl/`), every pipeline that imports it (directly or transitively) needs either a patch bump + changelog note **or** an explicit "no functional impact" entry. See the dependency chains in [.github/copilot-instructions.md](.github/copilot-instructions.md#cascading-version-bumps). Validation passing is not sufficient — changelogs must also be updated.
+4. **After merging develop**, grep for duplicate `pipeline_version` lines — keep the higher one.
+5. **Sub-workflow contract** — removing an input from a shared WDL requires removing it from every caller.
+6. **Stale example/test inputs** — when you rename a workflow or remove/rename inputs, audit `pipelines/wdl/<name>/example_inputs/*.json` and `test_inputs/**/*.json`; they break silently because they are not checked by womtool.
+7. **Touching a pipeline's interface** — also update the pipeline's docs page under `website/docs/Pipelines/<Name>_Pipeline/README.md` and run `yarn --cwd=website build` to catch broken links.
 
 ## Agent-Specific Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,31 +48,19 @@ When you change a pipeline's interface, update **both** artifacts (or, at minimu
 
 ### Validating documentation changes
 
-Before claiming docs work is done, run a full build:
-
-```bash
-yarn --cwd=website install   # first time only
-yarn --cwd=website build     # validates frontmatter and all links
-```
-
-`yarn --cwd=website start` is fine for previewing but does not fail on broken links — always use `build` to validate.
-
-### Cross-page links within the docs site
-
-For links from one pipeline page to another, prefer a relative path that works in Docusaurus, e.g. `[Multiome](../Multiome_Pipeline/README.md)`. When the target does **not** have a docs page, link to the GitHub source (e.g. `https://github.com/broadinstitute/warp/tree/master/pipelines/wdl/peak_calling`) rather than a non-resolving relative path.
-
-### WDL inline-Python heredoc convention
-
-Use unquoted `<<CODE` heredocs for inline Python inside `command { ... }` blocks so that `~{}` WDL interpolation still works. Quoted heredoc terminators such as `<<'PYEOF'` suppress WDL interpolation and are not used in this repo. Canonical reference: [WARP_WDL_Style_Guide.md](WARP_WDL_Style_Guide.md) §9.
-
-### GPU runtime keys
-
-For GPU tasks, the runtime keys understood by both Cromwell on Terra/GCP and by womtool are `gpuType`, `gpuCount`, and `nvidiaDriverVersion` (camelCase). Some snake_case aliases (`hardware_gpu_type`, `nvidia_driver_version`) are accepted by certain Cromwell configurations but are not universally portable — prefer the camelCase form when authoring new pipelines.
+See *Documentation → Validate docs changes* in [.github/copilot-instructions.md](.github/copilot-instructions.md). The key distinction: `yarn --cwd=website start` does not fail on broken links — always use `yarn --cwd=website build` before marking docs work complete.
 
 ### `input_id` output prefix pattern
 
 When a pipeline emits per-sample artifacts, accept a `String input_id` workflow input and prefix every output filename with `~{input_id}_`. This matches the convention used by scANVI, Optimus, Multiome, and other Skylab-origin pipelines.
 
+### Optimus/Skylab chemistry and reference assets
+
+When adding support for a new 10x chemistry in Optimus:
+- Use `tenx_chemistry_version` (Integer, e.g. `4`) for the major chemistry version and `tenx_chemistry_subversion` (optional String, e.g. `"v4_TRU"`) for whitelist variant selection within that version.
+- Optimus whitelist files live at `gs://gcp-public-data--broad-references/optimus_whitelists/`. Do **not** use the old `RNA/resources/` path (which contained a `febrary` typo and is incorrect).
+- Validate that inputs required by a given chemistry (e.g. `i1_fastq` for v4) are enforced via `ErrorWithMessage` when the chemistry version demands them.
+
 ### When you discover a recurring agent mistake
 
-Record it here (under *Agent-Specific Notes*) or in [.github/copilot-instructions.md](.github/copilot-instructions.md) — not in the human-facing style guides. Keep entries short and link out to the canonical reference rather than duplicating it.
+Record it here (under *Agent-Specific Notes*) or in [.github/copilot-instructions.md](.github/copilot-instructions.md) — not in the human-facing style guides. Keep entries short and link out to the canonical reference rather than duplicating it. **Before adding a new note, check whether the information is already in copilot-instructions.md** — prefer a one-line reference over a duplicate section.

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -12,16 +12,16 @@ IlluminaGenotypingArray	 1.12.27	2026-01-21
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
-MultiSampleSmartSeq2SingleNucleus	 2.2.6	2026-04-02 
-Multiome	 7.0.0	2026-04-02 
+MultiSampleSmartSeq2SingleNucleus	 2.2.7	2026-05-15 
+Multiome	 7.0.1	2026-05-15 
 Optimus	 9.1.0	2026-05-15 
-PairedTag	 3.0.0	2026-04-02 
+PairedTag	 3.0.1	2026-05-15 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
-SlideSeq	 3.6.6	2026-04-02 
-SlideTags	 2.0.0	2026-04-02 
+SlideSeq	 3.6.7	2026-05-15 
+SlideTags	 2.0.1	2026-05-15 
 UltimaGenomicsJointGenotyping	 1.2.3	2025-08-11 
 UltimaGenomicsWholeGenomeCramOnly	 1.1.3	2026-01-21 
 UltimaGenomicsWholeGenomeGermline	 1.2.2	2026-01-29 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -14,7 +14,7 @@ ImputationBeagle	 3.0.1	2026-02-23
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.6	2026-04-02 
 Multiome	 7.0.0	2026-04-02 
-Optimus	 9.0.0	2026-04-02 
+Optimus	 9.1.0	2026-05-15 
 PairedTag	 3.0.0	2026-04-02 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit

--- a/pipelines/wdl/multiome/Multiome.changelog.md
+++ b/pipelines/wdl/multiome/Multiome.changelog.md
@@ -1,3 +1,8 @@
+# 7.0.1
+2026-05-15 (Date of Last Commit)
+
+* Updated shared dependency CheckInputs.wdl to support 10x v4 (GEM-X) chemistry; no functional impact on Multiome outputs
+
 # 7.0.0
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/multiome/Multiome.wdl
+++ b/pipelines/wdl/multiome/Multiome.wdl
@@ -9,7 +9,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow Multiome {
 
-    String pipeline_version = "7.0.0"
+    String pipeline_version = "7.0.1"
 
     input {
         String cloud_provider

--- a/pipelines/wdl/optimus/Optimus.changelog.md
+++ b/pipelines/wdl/optimus/Optimus.changelog.md
@@ -1,3 +1,13 @@
+# 9.1.0
+2026-05-15 (Date of Last Commit)
+
+* Added native support for 10x 3' v4 (GEM-X) chemistry by accepting `tenx_chemistry_version = 4`; added `tenx_chemistry_subversion` input (`"v4"` for Cell Ranger v8.0/v8.0.1, `"v4_TRU"` for Cell Ranger v9.0 and later) to select the correct barcode whitelist
+* Added runtime check that `i1_fastq` is provided when `tenx_chemistry_version` is 4
+* Corrected barcode whitelist GCS paths to use the canonical `optimus_whitelists/` bucket prefix and fixed `febrary` → `february` typo in the v3 whitelist path
+* Removed all Azure cloud options (ACR docker prefixes, Azure whitelist URLs, Azure CellBender branch); `cloud_provider` input is retained and defaults to `"gcp"`
+* Added two v4 example input files: `human_v4_example.json` (Cell Ranger v8.0/v8.0.1) and `human_v4_TRU_example.json` (Cell Ranger v9.0+)
+* Added v4 chemistry documentation page to the WARP docs site
+
 # 9.0.0
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/optimus/Optimus.wdl
+++ b/pipelines/wdl/optimus/Optimus.wdl
@@ -7,7 +7,6 @@ import "../../../tasks/wdl/RunEmptyDrops.wdl" as RunEmptyDrops
 import "../../../tasks/wdl/CheckInputs.wdl" as OptimusInputChecks
 import "../../../tasks/wdl/H5adUtils.wdl" as H5adUtils
 import "../../../tasks/wdl/Utilities.wdl" as utils
-import "https://raw.githubusercontent.com/aawdeh/CellBender/aa-cbwithoutcuda/wdl/cellbender_remove_background_azure.wdl" as CellBender_no_cuda # imported for Azure CellBender GPU workflow, which requires a different base image without CUDA drivers
 import "https://raw.githubusercontent.com/broadinstitute/CellBender/v0.3.0/wdl/cellbender_remove_background.wdl" as CellBender
 
 workflow Optimus {
@@ -17,7 +16,7 @@ workflow Optimus {
   }
 
   input {
-    String cloud_provider
+    String cloud_provider = "gcp"
 
     # Mode for counting either "sc_rna" or "sn_rna"
     String counting_mode = "sc_rna"
@@ -44,12 +43,14 @@ workflow Optimus {
     Boolean run_cellbender = false
     Int cellbender_memory_GB = 32
 
-    # Chemistry options include: 2 or 3
+    # Chemistry options include: 2, 3, or 4
     Int tenx_chemistry_version
-    # Whitelist is selected based on the input tenx_chemistry_version
+    # For v4 chemistry: "v4" (Cell Ranger v8.0/v8.0.1) or "v4_TRU" (Cell Ranger v9.0 and later; default when unspecified)
+    String? tenx_chemistry_subversion
+    # Whitelist is selected based on tenx_chemistry_version (and tenx_chemistry_subversion for v4)
     File whitelist = checkOptimusInput.whitelist_out
 
-    # read_structure is based on v2 or v3 chemistry
+    # read_structure is based on v2, v3, or v4 chemistry
     String read_struct = checkOptimusInput.read_struct_out
 
     # Emptydrops lower cutoff
@@ -75,16 +76,19 @@ workflow Optimus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "9.0.0"
+  String pipeline_version = "9.1.0"
 
   # this is used to scatter matched [r1_fastq, r2_fastq, i1_fastq] arrays
   Array[Int] indices = range(length(r1_fastq))
 
-  # 10x parameters
-  File gcp_whitelist_v2 = "gs://gcp-public-data--broad-references/RNA/resources/737k-august-2016.txt"
-  File gcp_whitelist_v3 = "gs://gcp-public-data--broad-references/RNA/resources/3M-febrary-2018.txt"
-  File azure_whitelist_v2 = "https://datasetpublicbroadref.blob.core.windows.net/dataset/RNA/resources/737k-august-2016.txt?sv=2020-04-08&si=prod&sr=c&sig=DQxmjB4D1lAfOW9AxIWbXwZx6ksbwjlNkixw597JnvQ%3D"
-  File azure_whitelist_v3 = "https://datasetpublicbroadref.blob.core.windows.net/dataset/RNA/resources/3M-febrary-2018.txt?sv=2020-04-08&si=prod&sr=c&sig=DQxmjB4D1lAfOW9AxIWbXwZx6ksbwjlNkixw597JnvQ%3D"
+  # 10x barcode whitelists (canonical paths; see documentation Barcode whitelist options table)
+  File whitelist_v2 = "gs://gcp-public-data--broad-references/optimus_whitelists/737K-august-2016.txt"
+  File whitelist_v3 = "gs://gcp-public-data--broad-references/optimus_whitelists/3M-february-2018.txt"
+  # v4 whitelist selection depends on tenx_chemistry_subversion:
+  #   "v4"     -> Cell Ranger v8.0 and v8.0.1
+  #   "v4_TRU" -> Cell Ranger v9.0 and later (used when tenx_chemistry_subversion is unspecified)
+  File whitelist_v4 = "gs://gcp-public-data--broad-references/optimus_whitelists/3M-3pgex-may-2023.txt"
+  File whitelist_v4_TRU = "gs://gcp-public-data--broad-references/optimus_whitelists/3M-3pgex-may-2023_TRU.txt"
 
   # Takes the first read1 FASTQ from the inputs to check for chemistry match
   File r1_single_fastq = r1_fastq[0]
@@ -99,35 +103,19 @@ workflow Optimus {
   String samtools_star = "samtools-star:1.0.0-1.11-2.7.11a-1731516196"
   String samtools_star_python = "samtools-star-python:1.0.0"
 
-  #TODO how do we handle these?
   String alpine_docker = "alpine-bash@sha256:965a718a07c700a5204c77e391961edee37477634ce2f9cf652a8e4c2db858ff"
-  String gcp_alpine_docker_prefix = "bashell/"
-  String acr_alpine_docker_prefix = "dsppipelinedev.azurecr.io/"
-  String alpine_docker_prefix = if cloud_provider == "gcp" then gcp_alpine_docker_prefix else acr_alpine_docker_prefix
+  String alpine_docker_prefix = "bashell/"
 
   String ubuntu_docker = "ubuntu_16_0_4@sha256:025124e2f1cf4d29149958f17270596bffe13fc6acca6252977c572dd5ba01bf"
-  String gcp_ubuntu_docker_prefix = "gcr.io/gcp-runtimes/"
-  String acr_ubuntu_docker_prefix = "dsppipelinedev.azurecr.io/"
-  String ubuntu_docker_prefix = if cloud_provider == "gcp" then gcp_ubuntu_docker_prefix else acr_ubuntu_docker_prefix
+  String ubuntu_docker_prefix = "gcr.io/gcp-runtimes/"
 
-  String gcr_docker_prefix = "us.gcr.io/broad-gotc-prod/"
-  String acr_docker_prefix = "dsppipelinedev.azurecr.io/"
-
-  # choose docker prefix based on cloud provider
-  String docker_prefix = if cloud_provider == "gcp" then gcr_docker_prefix else acr_docker_prefix
-
-  # make sure either gcp or azr is supplied as cloud_provider
-  if ((cloud_provider != "gcp") && (cloud_provider != "azure")) {
-    call utils.ErrorWithMessage as ErrorMessageIncorrectInput {
-      input:
-        message = "cloud_provider must be supplied with either 'gcp' or 'azure'."
-    }
-  }
+  # all pipeline tasks use the GCP (GCR) docker registry
+  String docker_prefix = "us.gcr.io/broad-gotc-prod/"
 
   parameter_meta {
     r1_fastq: "forward read, contains cell barcodes and molecule barcodes"
     r2_fastq: "reverse read, contains cDNA fragment generated from captured mRNA"
-    i1_fastq: "(optional) index read, for demultiplexing of multiple samples on one flow cell."
+    i1_fastq: "index read used for demultiplexing; required when tenx_chemistry_version is 4"
     input_id: "name of sample matching this file, inserted into read group header"
     input_id_metadata_field: "String that describes the metadata field containing the input_id"
     input_name: "User provided sample name or cell_names"
@@ -135,9 +123,18 @@ workflow Optimus {
     tar_star_reference: "star genome reference"
     annotations_gtf: "gtf containing annotations for gene tagging (must match star reference)"
     whitelist: "10x genomics cell barcode allowlist"
-    tenx_chemistry_version: "10X Genomics v2 (10 bp UMI) or v3 chemistry (12bp UMI)"
+    tenx_chemistry_version: "10X Genomics chemistry version: 2 (10 bp UMI), 3 (12 bp UMI), or 4 / GEM-X (12 bp UMI; requires i1_fastq)"
+    tenx_chemistry_subversion: "For v4 chemistry only: 'v4' for Cell Ranger v8.0/v8.0.1 whitelist; 'v4_TRU' for Cell Ranger v9.0+ whitelist (default when unspecified)"
     force_no_check: "Set to true to override input checks and allow pipeline to proceed with invalid input"
     star_strand_mode: "STAR mode for handling stranded reads. Options are 'Forward', 'Reverse, or 'Unstranded.' Default is Forward."
+  }
+
+  # For v4 chemistry, i1_fastq is required
+  if (tenx_chemistry_version == 4 && !defined(i1_fastq)) {
+    call utils.ErrorWithMessage as ErrorI1FastqRequired {
+      input:
+        message = "i1_fastq is required when tenx_chemistry_version is 4."
+    }
   }
 
   call OptimusInputChecks.checkOptimusInput {
@@ -145,14 +142,14 @@ workflow Optimus {
       force_no_check = force_no_check,
       counting_mode = counting_mode,
       star_strand_mode = star_strand_mode,
-      gcp_whitelist_v2 = gcp_whitelist_v2,
-      gcp_whitelist_v3 = gcp_whitelist_v3,
-      azure_whitelist_v2 = azure_whitelist_v2,
-      azure_whitelist_v3 = azure_whitelist_v3,
+      whitelist_v2 = whitelist_v2,
+      whitelist_v3 = whitelist_v3,
+      whitelist_v4 = whitelist_v4,
+      whitelist_v4_TRU = whitelist_v4_TRU,
+      tenx_chemistry_subversion = tenx_chemistry_subversion,
       tenx_chemistry_version = tenx_chemistry_version,
       r1_fastq = r1_single_fastq,
       ignore_r1_read_length = ignore_r1_read_length,
-      cloud_provider = cloud_provider,
       alpine_docker_path = alpine_docker_prefix + alpine_docker
   }
 
@@ -240,35 +237,18 @@ workflow Optimus {
 
   # Call CellBender
   if (run_cellbender) {
-    if (cloud_provider == "gcp") {
-      call CellBender.run_cellbender_remove_background_gpu as CellBender {
-        input:
-          sample_name = input_id,
-          input_file_unfiltered = final_h5ad_output,
-          hardware_boot_disk_size_GB = 20,
-          hardware_cpu_count = 4,
-          hardware_disk_size_GB = 50,
-          hardware_gpu_type = "nvidia-tesla-t4",
-          hardware_memory_GB = cellbender_memory_GB,
-          hardware_preemptible_tries = 2,
-          hardware_zones = "us-central1-a us-central1-c",
-          nvidia_driver_version = "470.82.01"
-      }
-    }
-    if (cloud_provider == "azure") {
-      call CellBender_no_cuda.run_cellbender_remove_background_gpu as CellBender_no_cuda {
-        input:
-          sample_name = input_id,
-          input_file_unfiltered = final_h5ad_output,
-          hardware_boot_disk_size_GB = 20,
-          hardware_cpu_count = 4,
-          hardware_disk_size_GB = 50,
-          hardware_gpu_type = "nvidia-tesla-t4",
-          hardware_memory_GB = cellbender_memory_GB,
-          hardware_preemptible_tries = 2,
-          hardware_zones = "us-central1-a us-central1-c",
-          nvidia_driver_version = "470.82.01"
-      }
+    call CellBender.run_cellbender_remove_background_gpu as CellBender {
+      input:
+        sample_name = input_id,
+        input_file_unfiltered = final_h5ad_output,
+        hardware_boot_disk_size_GB = 20,
+        hardware_cpu_count = 4,
+        hardware_disk_size_GB = 50,
+        hardware_gpu_type = "nvidia-tesla-t4",
+        hardware_memory_GB = cellbender_memory_GB,
+        hardware_preemptible_tries = 2,
+        hardware_zones = "us-central1-a us-central1-c",
+        nvidia_driver_version = "470.82.01"
     }
   }
 

--- a/pipelines/wdl/optimus/README.md
+++ b/pipelines/wdl/optimus/README.md
@@ -1,8 +1,6 @@
-## Announcing a new site for WARP documentation!
+## Optimus summary
 
-Optimus documentation has moved! Read more about the [Optimus Pipeline](https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/README) on the new [WARP documentation site](https://broadinstitute.github.io/warp/)!
+Read more about the [Optimus Pipeline](https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/README) on the [WARP documentation site](https://broadinstitute.github.io/warp/)!
 
-### Optimus summary
-
-Optimus is a pipeline developed by the Data Coordination Platform (DCP) of the [Human Cell Atlas (HCA) Project](https://data.humancellatlas.org/) that supports processing of any 3' single-cell and single-nuclei expression data generated with the [10x Genomic v2 or v3 assay](https://www.10xgenomics.com/solutions/single-cell/). It is an alignment and transcriptome quantification pipeline that corrects cell barcodes, aligns reads to the genome, corrects Unique Molecular Identifiers (UMIs), generates an expression matrix in a UMI-aware manner, calculates summary metrics for genes and cells, detects empty droplets, returns read outputs in BAM format, and returns cell gene expression in numpy matrix and Loom file formats. 
+Optimus supports processing of any 3' single-cell and single-nuclei expression data generated with the [10x Genomic v2, v3, or v4 (GEM-X) assay](https://www.10xgenomics.com/solutions/single-cell/). It is an alignment and transcriptome quantification pipeline that corrects cell barcodes, aligns reads to the genome, corrects Unique Molecular Identifiers (UMIs), generates an expression matrix in a UMI-aware manner, calculates summary metrics for genes and cells, detects empty droplets, returns read outputs in BAM format, and returns cell gene expression in numpy matrix and h5ad file formats. 
 

--- a/pipelines/wdl/optimus/example_inputs/human_v4_TRU_example.json
+++ b/pipelines/wdl/optimus/example_inputs/human_v4_TRU_example.json
@@ -1,0 +1,20 @@
+{
+  "Optimus.r1_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_R1_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_R1_001.filtered.fastq.gz"
+  ],
+  "Optimus.r2_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_R2_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_R2_001.filtered.fastq.gz"
+  ],
+  "Optimus.i1_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_I1_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_I1_001.filtered.fastq.gz"
+  ],
+  "Optimus.tar_star_reference": "gs://gcp-public-data--broad-references/hg38/v0/star/star_2.7.9a_primary_gencode_human_v27.tar",
+  "Optimus.input_id": "pbmc_human_v4_TRU",
+  "Optimus.tenx_chemistry_version": 4,
+  "Optimus.tenx_chemistry_subversion": "v4_TRU",
+  "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/gencode.v27.primary_assembly.annotation.gtf",
+  "Optimus.cloud_provider": "gcp"
+}

--- a/pipelines/wdl/optimus/example_inputs/human_v4_example.json
+++ b/pipelines/wdl/optimus/example_inputs/human_v4_example.json
@@ -1,0 +1,20 @@
+{
+  "Optimus.r1_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_R1_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_R1_001.filtered.fastq.gz"
+  ],
+  "Optimus.r2_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_R2_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_R2_001.filtered.fastq.gz"
+  ],
+  "Optimus.i1_fastq": [
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L001_I1_001.filtered.fastq.gz",
+      "gs://broad-gotc-test-storage/Optimus/input/plumbing/chemistry_10X_V4/pbmc_10k_v4_chr21_genic/pbmc_10k_v4_S1_L002_I1_001.filtered.fastq.gz"
+  ],
+  "Optimus.tar_star_reference": "gs://gcp-public-data--broad-references/hg38/v0/star/star_2.7.9a_primary_gencode_human_v27.tar",
+  "Optimus.input_id": "pbmc_human_v4",
+  "Optimus.tenx_chemistry_version": 4,
+  "Optimus.tenx_chemistry_subversion": "v4",
+  "Optimus.annotations_gtf": "gs://gcp-public-data--broad-references/hg38/v0/gencode.v27.primary_assembly.annotation.gtf",
+  "Optimus.cloud_provider": "gcp"
+}

--- a/pipelines/wdl/paired_tag/PairedTag.changelog.md
+++ b/pipelines/wdl/paired_tag/PairedTag.changelog.md
@@ -1,3 +1,8 @@
+# 3.0.1
+2026-05-15 (Date of Last Commit)
+
+* Updated shared dependency CheckInputs.wdl to support 10x v4 (GEM-X) chemistry; no functional impact on PairedTag outputs
+
 # 3.0.0
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/paired_tag/PairedTag.wdl
+++ b/pipelines/wdl/paired_tag/PairedTag.wdl
@@ -8,7 +8,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow PairedTag {
 
-    String pipeline_version = "3.0.0"
+    String pipeline_version = "3.0.1"
 
     input {
         String input_id

--- a/pipelines/wdl/slideseq/SlideSeq.changelog.md
+++ b/pipelines/wdl/slideseq/SlideSeq.changelog.md
@@ -1,3 +1,8 @@
+# 3.6.7
+2026-05-15 (Date of Last Commit)
+
+* Updated shared dependency CheckInputs.wdl to support 10x v4 (GEM-X) chemistry; no functional impact on SlideSeq outputs
+
 # 3.6.6
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/slideseq/SlideSeq.wdl
+++ b/pipelines/wdl/slideseq/SlideSeq.wdl
@@ -25,7 +25,7 @@ import "../../../tasks/wdl/Utilities.wdl" as utils
 
 workflow SlideSeq {
 
-    String pipeline_version = "3.6.6"
+    String pipeline_version = "3.6.7"
 
     input {
         Array[File] r1_fastq

--- a/pipelines/wdl/slidetags/SlideTags.changelog.md
+++ b/pipelines/wdl/slidetags/SlideTags.changelog.md
@@ -1,3 +1,8 @@
+# 2.0.1
+2026-05-15 (Date of Last Commit)
+
+* Updated shared dependency CheckInputs.wdl to support 10x v4 (GEM-X) chemistry; no functional impact on SlideTags outputs
+
 # 2.0.0
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/slidetags/SlideTags.wdl
+++ b/pipelines/wdl/slidetags/SlideTags.wdl
@@ -6,7 +6,7 @@ import "../optimus/Optimus.wdl" as optimus
 
 workflow SlideTags {
 
-    String pipeline_version = "2.0.0"
+    String pipeline_version = "2.0.1"
 
     input {
 

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.changelog.md
@@ -1,3 +1,8 @@
+# 2.2.7
+2026-05-15 (Date of Last Commit)
+
+* Updated shared dependency CheckInputs.wdl to support 10x v4 (GEM-X) chemistry; no functional impact on MultiSampleSmartSeq2SingleNucleus outputs (only `checkInputArrays` is used from this task file)
+
 # 2.2.6
 2026-04-02 (Date of Last Commit)
 

--- a/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
+++ b/pipelines/wdl/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl
@@ -59,7 +59,7 @@ workflow MultiSampleSmartSeq2SingleNucleus {
   }
 
   # Version of this pipeline
-  String pipeline_version = "2.2.6"
+  String pipeline_version = "2.2.7"
 
   if (false) {
      String? none = "None"

--- a/tasks/wdl/CheckInputs.wdl
+++ b/tasks/wdl/CheckInputs.wdl
@@ -55,8 +55,6 @@ task checkInputArrays {
 
 task checkOptimusInput {
   input {
-    String cloud_provider
-    #String SAS_TOKEN
     File r1_fastq
     String counting_mode
     Boolean force_no_check
@@ -65,13 +63,14 @@ task checkOptimusInput {
     Int machine_mem_mb = 1000
     Int cpu = 1
     Int tenx_chemistry_version
-    String gcp_whitelist_v2
-    String gcp_whitelist_v3
-    String azure_whitelist_v2
-    String azure_whitelist_v3
+    String? tenx_chemistry_subversion
+    String whitelist_v2
+    String whitelist_v3
+    String whitelist_v4
+    String whitelist_v4_TRU
     Boolean ignore_r1_read_length
     String alpine_docker_path
-  }  
+  }
 
   meta {
     description: "checks optimus input values and fails the pipeline immediately"
@@ -114,37 +113,30 @@ task checkOptimusInput {
     # Check for chemistry version to produce read structure and whitelist
     if [[ ~{tenx_chemistry_version} == 2 ]]
       then
-      if [[ "~{cloud_provider}" == "gcp" ]]
-      then
-        WHITELIST="~{gcp_whitelist_v2}"
-      elif [[ "~{cloud_provider}" == "azure" ]]
-      then
-        WHITELIST="~{azure_whitelist_v2}"
-      else
-        pass="false"
-        echo "ERROR: Cloud provider must be either gcp or azure"
-      fi
+      WHITELIST="~{whitelist_v2}"
       echo "WHITELIST:" $WHITELIST
       echo $WHITELIST > whitelist.txt
       echo 16C10M > read_struct.txt
     elif [[ ~{tenx_chemistry_version} == 3 ]]
       then
-      if [[ "~{cloud_provider}" == "gcp" ]]
+      WHITELIST="~{whitelist_v3}"
+      echo "WHITELIST:" $WHITELIST
+      echo $WHITELIST > whitelist.txt
+      echo 16C12M > read_struct.txt
+    elif [[ ~{tenx_chemistry_version} == 4 ]]
       then
-        WHITELIST="~{gcp_whitelist_v3}"
-      elif [[ "~{cloud_provider}" == "azure" ]]
+      if [[ "~{tenx_chemistry_subversion}" == "v4_TRU" ]]
       then
-        WHITELIST="~{azure_whitelist_v3}"
+        WHITELIST="~{whitelist_v4_TRU}"
       else
-        pass="false"
-        echo "ERROR: Cloud provider must be either gcp or azure"
+        WHITELIST="~{whitelist_v4}"
       fi
       echo "WHITELIST:" $WHITELIST
       echo $WHITELIST > whitelist.txt
       echo 16C12M > read_struct.txt
     else
       pass="false"
-      echo "ERROR: Chemistry version must be either 2 or 3"
+      echo "ERROR: Chemistry version must be 2, 3, or 4"
     fi
     
     if [[ ~{tenx_chemistry_version} == 2 && $COUNT != 26 && ~{ignore_r1_read_length} == "false" ]]
@@ -155,6 +147,10 @@ task checkOptimusInput {
       then
       pass="false"
       echo "Read1 FASTQ does not match v3 chemistry; to override set ignore_r1_read_length to true"
+    elif [[ ~{tenx_chemistry_version} == 4 && $COUNT != 28 && ~{ignore_r1_read_length} == "false" ]]
+      then
+      pass="false"
+      echo "Read1 FASTQ does not match v4 chemistry; to override set ignore_r1_read_length to true"
     else
       pass="true"
     fi

--- a/website/docs/Pipelines/Optimus_Pipeline/README.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/README.md
@@ -73,7 +73,7 @@ Each 10x v2 and v3 3’ sequencing experiment generates triplets of FASTQ files 
 
 1. Forward reads (`r1_fastq`) containing the unique molecular identifier (UMI) and CB sequences
 2. Reverse reads (`r2_fastq`) containing the alignable genomic information from the mRNA transcript
-3. Optional index FASTQ (`i1_fastq`) containing the sample barcodes, when provided by the sequencing facility
+3. Index FASTQ (`i1_fastq`) containing the sample barcodes; optional for v2/v3 chemistry, **required for v4 (GEM-X) chemistry**
 
 
 :::tip Optimus is currently a single sample pipeline
@@ -88,9 +88,9 @@ The example configuration files also contain metadata for the reference files, d
 
 | Parameter name | Description | Optional attributes (when applicable) |
 | --- | --- | --- |
-| cloud_provider | String describing the cloud provider that should be used to run the workflow; value should be "gcp" or "azure". | String |
-| whitelist |  List of known CBs; the workflow automatically selects the [10x Genomics](https://www.10xgenomics.com/) whitelist that corresponds to the v2 or v3 chemistry based on the input `tenx_chemistry_version`. A custom whitelist can also be provided if the input data was generated with a chemistry different from 10x Genomics v2 or v3 (for example, v4). To use a custom whitelist, set the input `ignore_r1_read_length` to `true`. See the [Barcode whitelist options](#barcode-whitelist-options) table below for available whitelists. | N/A |
-| read_struct | String describing the structure of reads; the workflow automatically selects the [10x Genomics](https://www.10xgenomics.com/) read structure that corresponds to the v2 or v3 chemistry based on the input `tenx_chemistry_version`. A custom read structure can also be provided if the input data was generated with a chemistry different from 10x Genomics v2 or v3. To use a custom read structure, set the input `force_no_check` to "true". | N/A |
+| cloud_provider | String describing the cloud provider; default is "gcp". "azure" is accepted but all pipeline assets are hosted on GCP. | "gcp" (default) |
+| whitelist |  List of known CBs; the workflow automatically selects the [10x Genomics](https://www.10xgenomics.com/) whitelist that corresponds to the chemistry based on `tenx_chemistry_version` (and `tenx_chemistry_subversion` for v4). See the [Barcode whitelist options](#barcode-whitelist-options) table below for available whitelists. | N/A |
+| read_struct | String describing the structure of reads; automatically selected based on `tenx_chemistry_version` (`16C10M` for v2; `16C12M` for v3 and v4). Override by setting `force_no_check` to `true`. | N/A |
 | tar_star_reference | TAR file containing a species-specific reference genome and GTF; it is generated using the [BuildIndices workflow](https://github.com/broadinstitute/warp/tree/master/pipelines/wdl/build_indices/BuildIndices.wdl). | N/A |
 | input_id | Unique identifier describing the biological sample or replicate that corresponds with the FASTQ files; can be a human-readable name or UUID. | N/A |
 | gex_nhash_id | Optional string to identify the library aliquot; will be echoed in the output h5ad file in the adata.uns and the library-level metrics CSV; default is null (`""`) | N/A |
@@ -98,7 +98,8 @@ The example configuration files also contain metadata for the reference files, d
 | input_id_metadata_field | Optional string describing, when applicable, the metadata field containing the input_id. | N/A |
 | input_name_metadata_field | Optional string describing, when applicable, the metadata field containing the input_name. | N/A |
 | annotations_gtf | GTF containing gene annotations used for gene tagging (must match GTF in STAR reference). | N/A |
-| tenx_chemistry_version | Integer that specifies if data was generated with 10x v2 or v3 chemistry. v4 chemistry is supported via a [custom whitelist](#barcode-whitelist-options). Optimus validates v2/v3 chemistry by examining the UMIs and CBs in the first read 1 FASTQ file. If the chemistry does not match, the pipeline will fail. You can remove the check by setting `ignore_r1_read_length = true` in the input JSON. | 2 or 3 |
+| tenx_chemistry_version | Integer specifying the 10x chemistry. v2 uses a 10 bp UMI (26 bp R1), v3 and v4 use a 12 bp UMI (28 bp R1). Optimus validates the expected R1 length by default. You can override validation by setting `ignore_r1_read_length = true`. | 2, 3, or 4 |
+| tenx_chemistry_subversion | For v4 chemistry only: selects between the two v4 barcode whitelists. Use `"v4"` for kits run with Cell Ranger v8.0/v8.0.1; use `"v4_TRU"` for Cell Ranger v9.0 and later (default when unspecified). See [v4 chemistry documentation](./v4_chemistry.md) for details. | "v4" or "v4_TRU" |
 | mt_genes | Optional file containing mitochondrial gene names for a specific species. This is used for calculating gene metrics. | N/A |
 | soloMultiMappers | Optional string describing whether or not the Optimus (GEX) pipeline should run STARsolo with the `--soloMultiMappers` flag; default is "Uniform". | N/A |
 | counting_mode | String describing whether data is single-cell or single-nucleus. Single-cell mode counts reads aligned to the gene transcript, whereas single-nucleus counts whole transcript to account for nuclear pre-mRNA. | "sc_rna" or "sn_rna" |

--- a/website/docs/Pipelines/Optimus_Pipeline/v4_chemistry.md
+++ b/website/docs/Pipelines/Optimus_Pipeline/v4_chemistry.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 6
+slug: /Pipelines/Optimus_Pipeline/v4_chemistry
+---
+
+# 10x 3' v4 (GEM-X) Chemistry Support
+
+This page explains how to configure and run Optimus with 10x Genomics 3' v4 (GEM-X) chemistry, covering FASTQ inputs, reference files, barcode whitelist selection, and counting mode.
+
+## Overview
+
+Optimus natively supports 10x 3' v4 (GEM-X) chemistry by setting `tenx_chemistry_version = 4`. The v4 chemistry uses the same cell barcode and UMI lengths as v3:
+
+| Feature | v2 | v3 | v4 (GEM-X) |
+| --- | --- | --- | --- |
+| Cell barcode length | 16 bp | 16 bp | 16 bp |
+| UMI length | 10 bp | 12 bp | 12 bp |
+| R1 total length | 26 bp | 28 bp | 28 bp |
+| Whitelist (GCP) | `737K-august-2016.txt` | `3M-february-2018.txt` | `3M-3pgex-may-2023.txt` or `3M-3pgex-may-2023_TRU.txt` |
+
+## FASTQ Inputs
+
+Three FASTQ inputs are required for v4 chemistry. All lanes must be provided as arrays:
+
+| Input | Contents | Required for v4? |
+| --- | --- | --- |
+| `Optimus.r1_fastq` | R1 reads: cell barcode + UMI | Yes |
+| `Optimus.r2_fastq` | R2 reads: cDNA sequence | Yes |
+| `Optimus.i1_fastq` | I1 index reads: sample barcodes | **Yes — pipeline will fail if omitted** |
+
+## Reference Files
+
+The STAR reference tarball and GTF must be from matched builds. For a full list of available GCP-hosted references (human GRCh38, mouse GRCm39, and others), see the [BuildIndices example references](https://broadinstitute.github.io/warp/docs/Pipelines/BuildIndices_Pipeline/README#example-references).
+
+:::warning Match your reference and GTF
+Always use a STAR index and GTF from the same genome build and annotation release. Mismatched files will produce incorrect gene assignments.
+:::
+
+:::note Pseudogene handling
+WARP GENCODE-based references are not filtered to remove pseudogenes, unlike 10x Genomics Cell Ranger references. This can result in small count differences for multi-mapped pseudogene reads. See the [pseudogene handling note](./README.md#pseudogene-handling) for details.
+:::
+
+## Chemistry and Counting Mode
+
+Set `tenx_chemistry_version = 4` for all 10x v4 (GEM-X) data.
+
+For single-nucleus RNA-seq (the most common use case with v4), also set:
+
+```json
+"Optimus.counting_mode": "sn_rna"
+```
+
+`sn_rna` mode uses the `GeneFull_Ex50pAS` STARsolo feature, which counts reads aligned to whole transcripts (introns + exons) to account for nuclear pre-mRNA. For single-cell (not nucleus) v4 data, use `"sc_rna"` instead.
+
+## Barcode Whitelist Selection
+
+:::caution This choice affects cell calling
+The whitelist you select directly determines which barcodes are recognized as valid cells and affects comparability with Cell Ranger outputs. Use the correct version for your kit.
+:::
+
+Because 10x Genomics updated the v4 barcode list between Cell Ranger releases, Optimus exposes a `tenx_chemistry_subversion` input:
+
+| `tenx_chemistry_subversion` | Whitelist GCS path | Cell Ranger version | When to use |
+| --- | --- | --- | --- |
+| `"v4_TRU"` *(default when unspecified)* | `gs://gcp-public-data--broad-references/optimus_whitelists/3M-3pgex-may-2023_TRU.txt` | v9.0 and later | **Recommended for all new analyses** |
+| `"v4"` | `gs://gcp-public-data--broad-references/optimus_whitelists/3M-3pgex-may-2023.txt` | v8.0 and v8.0.1 | Only when backward compatibility with CR v8 outputs is required |
+
+For a complete list of all available whitelists, see the [Barcode whitelist options](./README.md#barcode-whitelist-options) table in the main Optimus documentation.
+
+## Example Inputs
+
+Downsampled plumbing test examples (human GRCh38, two lanes) are available in the repository:
+- [human_v4_TRU_example.json](https://github.com/broadinstitute/warp/blob/master/pipelines/wdl/optimus/example_inputs/human_v4_TRU_example.json) — Cell Ranger v9.0+ (recommended)
+- [human_v4_example.json](https://github.com/broadinstitute/warp/blob/master/pipelines/wdl/optimus/example_inputs/human_v4_example.json) — Cell Ranger v8.0/v8.0.1
+
+For single-nucleus data, add `"Optimus.counting_mode": "sn_rna"` to your input JSON. For Cell Ranger v8.0/v8.0.1 backward compatibility, change `tenx_chemistry_subversion` to `"v4"`.
+
+## Read Structure
+
+STARsolo is run with:
+
+```
+--soloCBstart 1 --soloCBlen 16
+--soloUMIstart 17 --soloUMIlen 12
+```
+
+R1 is expected to be 28 bp (16 bp CB + 12 bp UMI). The pipeline validates this length by default; set `ignore_r1_read_length = true` to skip validation if your R1 length differs.
+
+## Validation
+
+After running, verify that:
+- The `whitelist_input_used` output reflects the expected `3M-3pgex-may-2023*.txt` path.
+- STARsolo Summary.csv shows CB length 16 and UMI length 12.
+- Per-gene and per-cell Spearman correlations with Cell Ranger outputs are ≥ 0.97 (expected with matched references).


### PR DESCRIPTION
### Description

Update Optimus to have a tenx_chemistry option of 4 for V4 3' chemistry

There are two barcode whitelists, it now defaults to the V4_TRU version when 4 is selected but can also be specified as V4 for comparison to CellRanger 8 or earlier

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
