### PR TITLE
remove coverage metrcis from glimpse imputation pipeline

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,8 +4,8 @@ BuildIndices	 5.1.1	2026-05-20
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.17	2026-05-22 
-Glimpse2LowPassImputationBatch	 0.0.7	2026-05-22 
+Glimpse2LowPassImputation	 0.0.18	2026-05-27 
+Glimpse2LowPassImputationBatch	 0.0.8	2026-05-27 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 0.0.5	2026-05-22 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.18
+2026-05-27 (Date of Last Commit)
+
+* remove coverage metrics from glimpse phase task
+
 # 0.0.17
 2026-05-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.17"
-    String batch_pipeline_version = "0.0.7"
+    String pipeline_version = "0.0.18"
+    String batch_pipeline_version = "0.0.8"
     String quota_consumed_version = "0.0.5"
     String input_qc_version = "1.0.4"
 
@@ -173,15 +173,6 @@ workflow Glimpse2LowPassImputation {
 
     Array[File] contig_variant_vcfs = UpdateHeaderVariants.output_vcf
     Array[File] contig_hom_ref_vcfs = UpdateHeaderHomRefOnly.output_vcf
-    Array[File] batch_coverage_metrics = select_all(RunBatch.coverage_metrics)
-
-    if (length(batch_coverage_metrics) > 0) {
-        call Glimpse2LowPassImputationTasks.MergeCoverageMetrics as MergeBatchCoverageMetrics {
-            input:
-                coverage_metrics = batch_coverage_metrics,
-                output_basename = output_basename
-        }
-    }
 
     call Glimpse2LowPassImputationTasks.GatherVcfsNoIndex {
         input:
@@ -227,6 +218,5 @@ workflow Glimpse2LowPassImputation {
         File imputed_hom_ref_sites_only_vcf_md5 = CreateVcfIndexAndMd5HomRefOnly.output_vcf_md5sum
 
         File qc_metrics = CollectQCMetrics.qc_metrics
-        File? coverage_metrics = MergeBatchCoverageMetrics.merged_coverage_metrics
     }
 }

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.8
+2026-05-27 (Date of Last Commit)
+
+* remove coverage metrics from glimpse phase task
+
 # 0.0.7
 2026-05-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.7"
+    String pipeline_version = "0.0.8"
 
     input {
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -128,22 +128,11 @@ workflow Glimpse2LowPassImputationBatch {
                 output_basename = output_basename,
                 docker = glimpse_docker
         }
-        Array[File] contig_coverage_metrics = select_all(GlimpsePhase.coverage_metrics)
-    }
-
-    Array[File] genome_coverage_metrics = flatten(contig_coverage_metrics)
-    if (length(genome_coverage_metrics) > 0) {
-        call CombineCoverageMetrics {
-            input:
-                cov_metrics = genome_coverage_metrics,
-                output_basename = output_basename
-        }
     }
 
     output {
         Array[File] imputed_contig_ligated_vcfs = GlimpseLigate.imputed_vcf
         Array[File] imputed_contig_ligated_vcf_indices = GlimpseLigate.imputed_vcf_index
-        File? coverage_metrics = CombineCoverageMetrics.coverage_metrics
     }
 }
 
@@ -497,7 +486,6 @@ task GlimpsePhase {
     output {
         File imputed_vcf = "phase_output.bcf"
         File imputed_vcf_index = "phase_output.bcf.csi"
-        File? coverage_metrics = "phase_output_stats_coverage.txt.gz"
     }
 }
 
@@ -540,50 +528,5 @@ task GlimpseLigate {
     output {
         File imputed_vcf = "~{output_basename}.imputed.vcf.gz"
         File imputed_vcf_index = "~{output_basename}.imputed.vcf.gz.tbi"
-    }
-}
-
-task CombineCoverageMetrics
-{
-    input {
-        Array[File] cov_metrics
-        String output_basename
-    }
-
-    command <<<
-        set -euo pipefail
-
-        cov_files=( ~{sep=" " cov_metrics} )
-
-        for i in "${!cov_files[@]}"; do
-            if [ $i -eq 0 ]; then
-                n_skip=1
-                echo 'Chunk' > chunk_col.txt
-            else
-                n_skip=2
-            fi
-            # glimpse coverage metrics are formatted to be human readable in a command line, not machine readable or consistent.  ie, number of tabs
-            # are variable between columns depending on length of sample names, odd things like that.  We want these to be machine readable tables,
-            # so need to fix this.
-            zcat ${cov_files[$i]} | tail -n +$((n_skip + 1)) | sed s/%//g | sed s/"No data"/"No data pct"/g | sed s/\\t\\t/\\t/g >> cov_file.txt
-            n_lines_cov=$(< cov_file.txt wc -l)
-            n_lines_chunk=$(< chunk_col.txt wc -l)
-            n_lines_out=$((n_lines_cov-n_lines_chunk))
-            echo 'n_lines_out=' ${n_lines_out}
-            echo ${cov_files[$i]}
-            { yes ${i} || :; } | head -n ${n_lines_out} >> chunk_col.txt
-        done
-
-        paste chunk_col.txt cov_file.txt > ~{output_basename}.coverage_metrics.txt
-
-    >>>
-
-    runtime {
-        docker: "us.gcr.io/broad-dsde-methods/ubuntu:20.04"
-        noAddress: true
-    }
-
-    output {
-        File coverage_metrics="~{output_basename}.coverage_metrics.txt"
     }
 }

--- a/tasks/wdl/Glimpse2LowPassImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2LowPassImputationTasks.wdl
@@ -242,51 +242,6 @@ task MergeQCMetrics {
     }
 }
 
-task MergeCoverageMetrics {
-    input {
-        Array[File] coverage_metrics
-        String docker = "us.gcr.io/broad-dsde-methods/python-data-slim:1.1"
-        String output_basename
-
-        Int disk_size_gb = ceil(2.2 * size(coverage_metrics, "GiB") + 50)
-        Int mem_gb = 4
-        Int cpu = 2
-        Int preemptible = 1
-    }
-
-    command <<<
-        set -xeuo pipefail
-
-
-        python3 <<EOF
-        import pandas as pd
-        from collections import defaultdict
-        coverage_metrics = ['~{sep="', '" coverage_metrics}']
-        all_types = defaultdict(lambda: str)
-        all_types.update({"Chunk":int, "ID":int})
-        merged_coverage_metrics_array = [pd.read_csv(coverage_metric, sep='\t', dtype=all_types) for coverage_metric in coverage_metrics]
-        id_offset = 0
-        for cov_metric in merged_coverage_metrics_array:
-            cov_metric.ID += id_offset
-            id_offset = cov_metric.ID.max() + 1
-        merged_coverage_metrics = pd.concat(merged_coverage_metrics_array).sort_values(['Chunk','ID'])
-        merged_coverage_metrics.to_csv('~{output_basename}.coverage_metrics.txt', sep='\t', index=False)
-        EOF
-    >>>
-
-    output {
-        File merged_coverage_metrics = "~{output_basename}.coverage_metrics.txt"
-    }
-
-    runtime {
-        docker: docker
-        disks: "local-disk " + disk_size_gb + " HDD"
-        memory: mem_gb + " GiB"
-        cpu: cpu
-        preemptible: preemptible
-    }
-}
-
 task FilterVcfByInfo {
     input {
         File vcf


### PR DESCRIPTION
### Description

These metrics arent ever populated and we dont use them in the service so get rid of them

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
