### PR TITLE
TSPS-796 add seed input to glimpse phase task

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,8 +4,8 @@ BuildIndices	 5.1.1	2026-05-20
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.18	2026-05-27 
-Glimpse2LowPassImputationBatch	 0.0.8	2026-05-27 
+Glimpse2LowPassImputation	 0.0.19	2026-06-03 
+Glimpse2LowPassImputationBatch	 0.0.9	2026-06-03 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 0.0.5	2026-05-22 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.19
+2026-06-03 (Date of Last Commit)
+
+* add seed input to glimpse phase task
+
 # 0.0.18
 2026-05-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.18"
-    String batch_pipeline_version = "0.0.8"
+    String pipeline_version = "0.0.19"
+    String batch_pipeline_version = "0.0.9"
     String quota_consumed_version = "0.0.5"
     String input_qc_version = "1.0.4"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.9
+2026-06-03 (Date of Last Commit)
+
+* add seed input to glimpse phase task
+
 # 0.0.8
 2026-05-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.8"
+    String pipeline_version = "0.0.9"
 
     input {
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -390,6 +390,7 @@ task GlimpsePhase {
         Int? n_burnin
         Int? n_main
         Int? effective_population_size
+        Int seed = 15052011
 
         Int cpu = 4 # note that setting cpu > 1 will introduce non-determinism in GLIMPSE Phase due to multi-threading
         Int mem_gb = 16
@@ -446,6 +447,7 @@ task GlimpsePhase {
         --reference ~{reference_chunk} \
         --output phase_output.bcf \
         --threads ~{cpu} \
+        --seed ~{seed} \
         ~{if impute_reference_only_variants then "--impute-reference-only-variants" else ""} ~{if call_indels then "--call-indels" else ""} \
         ~{"--burnin " + n_burnin} ~{"--main " + n_main} \
         ~{"--ne " + effective_population_size} \


### PR DESCRIPTION
### Description
We should be passing in a seed value to the glimpse phase task.  The current defautl value should be the same as the [glimpse2phase default](https://odelaneau.github.io/GLIMPSE/docs/documentation/phase/) so I dont expect any differences in the warp test outputs. 

jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-796

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
