### PR TITLE
TSPS-913 FIX: Update scientific test data

### DIFF
--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Scientific/pass_manifest.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Scientific/pass_manifest.json
@@ -5,6 +5,6 @@
   "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "Glimpse2LowPassImputationQC.output_basename": "scientific_test_same_as_plumbing_though",
   "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/fakeCramManifestGoodAccess.tsv",
+  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/cramManifestPassQC.tsv",
   "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"
 }


### PR DESCRIPTION
### Description

In https://github.com/broadinstitute/warp/pull/1841 we forgot to update the scientific test data along with the plumbing data. 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
