### PR TITLE
TSPS-972 New GLIMPSE2 build to fix input streaming

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,7 +5,7 @@ CramToUnmappedBams	 1.1.3	2024-08-02
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
 Glimpse2LowPassImputation	 0.0.22	2026-06-26 
-Glimpse2LowPassImputationBatch	 0.0.12	2026-06-26
+Glimpse2LowPassImputationBatch	 0.0.12	2026-06-26 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 0.0.6	2026-06-13 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,8 +4,8 @@ BuildIndices	 5.1.1	2026-05-20
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.21	2026-06-22 
-Glimpse2LowPassImputationBatch	 0.0.11	2026-06-22 
+Glimpse2LowPassImputation	 0.0.22	2026-06-26 
+Glimpse2LowPassImputationBatch	 0.0.12	2026-06-26
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 0.0.6	2026-06-13 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.22
+2026-06-26 (Date of Last Commit)
+
+* use updated GLIMPSE2 build to fix cloud input streaming
+
 # 0.0.21
 2026-06-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-d8f1ae5"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-d8f1ae5"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-75db1f9"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.21"
-    String batch_pipeline_version = "0.0.11"
+    String pipeline_version = "0.0.22"
+    String batch_pipeline_version = "0.0.12"
     String quota_consumed_version = "0.0.6"
     String input_qc_version = "1.0.4"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-75db1f9"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-with-bcftools-update-75db1f9"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.1.12
+2026-06-26 (Date of Last Commit)
+
+* use updated GLIMPSE2 build to fix cloud input streaming
+
 # 0.0.11
 2026-06-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,4 +1,4 @@
-# 0.1.12
+# 0.0.12
 2026-06-26 (Date of Last Commit)
 
 * use updated GLIMPSE2 build to fix cloud input streaming

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -30,7 +30,7 @@ workflow Glimpse2LowPassImputationBatch {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-75db1f9"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-with-bcftools-update-75db1f9"
     }
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -30,7 +30,7 @@ workflow Glimpse2LowPassImputationBatch {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-d8f1ae5"
     }
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.11"
+    String pipeline_version = "0.0.12"
 
     input {
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -30,7 +30,7 @@ workflow Glimpse2LowPassImputationBatch {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-d8f1ae5"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:morgan-test-retries-v2-75db1f9"
     }
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs


### PR DESCRIPTION
### Description

We want to use an updated GLIMPSE2 version that retries transient read errors during input (VCF, binary) streaming. See GLIMPSE2 PR: https://github.com/odelaneau/GLIMPSE/pull/300

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-972
Related warp-tools PR: (TO ADD)

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
