### PR TITLE
TSPS-972 update glimpse docker image to version with vcf streamign fixes. 

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -4,10 +4,10 @@ BuildIndices	 5.1.1	2026-05-20
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 0.0.21	2026-06-22 
-Glimpse2LowPassImputationBatch	 0.0.11	2026-06-22 
+Glimpse2LowPassImputation	 1.0.0	2026-06-30 
+Glimpse2LowPassImputationBatch	 1.0.0	2026-06-30 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
-Glimpse2LowPassImputationQuotaConsumed	 0.0.6	2026-06-13 
+Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,10 @@
+# 1.0.0
+2026-06-30 (Date of Last Commit)
+
+* update glimpse docker image to encompass vcf streaming fixes
+* update batch subworkflow
+* update version for prod release
+
 # 0.0.21
 2026-06-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -3,7 +3,7 @@
 
 * update glimpse docker image to encompass vcf streaming fixes
 * update batch subworkflow
-* update version for prod release
+* update version for teaspoons prod release
 
 # 0.0.21
 2026-06-22 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,9 +4,9 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "0.0.21"
-    String batch_pipeline_version = "0.0.11"
-    String quota_consumed_version = "0.0.6"
+    String pipeline_version = "1.0.0"
+    String batch_pipeline_version = "1.0.0"
+    String quota_consumed_version = "1.0.0"
     String input_qc_version = "1.0.4"
 
     input {
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.0
 2026-06-30 (Date of Last Commit)
 
-* update version for prod release
+* update version for teaspoons prod release
 * update glimpse docker image to encompass vcf streaming fixes
 
 # 0.0.11

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,9 @@
+# 1.0.0
+2026-06-30 (Date of Last Commit)
+
+* update version for prod release
+* update glimpse docker image to encompass vcf streaming fixes
+
 # 0.0.11
 2026-06-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.11"
+    String pipeline_version = "1.0.0"
 
     input {
 
@@ -30,7 +30,7 @@ workflow Glimpse2LowPassImputationBatch {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248"
     }
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.0
+2026-06-30 (Date of Last Commit)
+
+* update version for prod release
+
 # 0.0.6
 2026-06-13 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.0
 2026-06-30 (Date of Last Commit)
 
-* update version for prod release
+* update version for teaspoons prod release
 
 # 0.0.6
 2026-06-13 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationQuotaConsumed.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow QuotaConsumed {
     # if this changes, update the quota_consumed_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "0.0.6"
+    String pipeline_version = "1.0.0"
 
     input {
         # service expects only cram_manifest even though main wdl can alternatively take input arrays


### PR DESCRIPTION


### Description

This PR updates pipeline version to 1.0.0 if not already at 1.x.x for our relesae to prod. It also updates the glimpse docker image to one that has the vcf streaming fixes for the issue we found while scale testing.

The image was created in https://github.com/broadinstitute/warp-tools/pull/202

JIRA ticket: https://broadworkbench.atlassian.net/browse/TSPS-972

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
