### PR TITLE
TSPS-1032 lower disk given to glimpse phase task

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,8 +5,8 @@ ConcatVcfs	 0.0.1	2026-07-08
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 1.0.0	2026-06-30 
-Glimpse2LowPassImputationBatch	 1.0.0	2026-06-30 
+Glimpse2LowPassImputation	 1.0.1	2026-07-12 
+Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.1	2026-07-08 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1
+2026-07-12 (Date of Last Commit)
+
+* update batch subworkflow
+
 # 1.0.0
 2026-06-30 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.1
 2026-07-12 (Date of Last Commit)
 
-* update batch subworkflow
+* update batch sub-workflow
 
 # 1.0.0
 2026-06-30 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "1.0.0"
-    String batch_pipeline_version = "1.0.0"
+    String pipeline_version = "1.0.1"
+    String batch_pipeline_version = "1.0.1"
     String quota_consumed_version = "1.0.0"
     String input_qc_version = "1.0.4"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,7 +1,7 @@
 # 1.0.1
 2026-07-12 (Date of Last Commit)
 
-* lower disk provide to glimpse phase task
+* lower disk provided to glimpse phase task
 
 # 1.0.0
 2026-06-30 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1
+2026-07-12 (Date of Last Commit)
+
+* lower disk provide to glimpse phase task
+
 # 1.0.0
 2026-06-30 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "1.0.0"
+    String pipeline_version = "1.0.1"
 
     input {
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -545,7 +545,7 @@ task GlimpsePhase {
 
         Int cpu = 4 # note that setting cpu > 1 will introduce non-determinism in GLIMPSE Phase due to multi-threading
         Int mem_gb = 16
-        Int disk_size_gb = ceil(0.3 * size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
+        Int disk_size_gb = ceil(0.5 * size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
         Int preemptible = 30
         Int max_retries = 3
         String docker

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -545,7 +545,7 @@ task GlimpsePhase {
 
         Int cpu = 4 # note that setting cpu > 1 will introduce non-determinism in GLIMPSE Phase due to multi-threading
         Int mem_gb = 16
-        Int disk_size_gb = ceil(2.2 * size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
+        Int disk_size_gb = ceil(0.3 * size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
         Int preemptible = 30
         Int max_retries = 3
         String docker


### PR DESCRIPTION
### Description

We never lowered the amount of disk we give glimpse phase now that we know it'll only stream vcfs.  recent tests have shown our disk usage is incredibly low for this task

https://docs.google.com/document/d/1RbE0-08WrZJQ3JyKZ7ZT_wBNxwqKfRDz6UGU2qE5apQ/edit?tab=t.0#heading=h.p057cc7urcyc

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
