### PR TITLE
[TSPS-1062] SV imputation pipeline docker images update

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 ArrayImputationQC	 1.3.0	2026-02-04 
 ArrayImputationQuotaConsumed	 1.1.0	2025-09-29 
 BuildIndices	 5.1.1	2026-05-20 
-ConcatVcfs	 0.0.1	2026-07-08 
+ConcatVcfs	 0.0.2	2026-07-17 
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
@@ -9,20 +9,20 @@ Glimpse2LowPassImputation	 1.0.1	2026-07-12
 Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.3	2026-07-16 
-Glimpse2SVImputationBatch	 0.0.2	2026-07-16 
+Glimpse2SVImputation	 0.0.4	2026-07-17 
+Glimpse2SVImputationBatch	 0.0.3	2026-07-17 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.1	2026-07-08 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.2	2026-07-17 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.2	2026-07-14 
+PreprocessPLsGVCF	 0.0.3	2026-07-17 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.2
+2026-07-17 (Date of Last Commit)
+
+* Updated docker image for ConcatVcfs task to use the official bcftools-vcftools image
+
 # 0.0.1
 2026-07-08 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow ConcatVcfs {
     # if this changes, update the concat_vcfs_pipeline_version value in Glimpse2SVImputationBatch.wdl
-    String pipeline_version = "0.0.1"
+    String pipeline_version = "0.0.2"
 
     input {
         Array[File] vcfs

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
@@ -142,7 +142,7 @@ task ConcatVcfs {
         disk_type:          "SSD",
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsp-lrma/lr-gcloud-samtools:0.1.23"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
@@ -142,7 +142,7 @@ task ConcatVcfs {
         disk_type:          "SSD",
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.4
+2026-07-17 (Date of Last Commit)
+
+* * Updated tasks to use the official bcftools-vcftools and sv-imputation-rust-tools docker images
+* sv-imputation-rust-tools contains the 3 rust binaries and tasks have been updated accordingly
+  to use the binaries from this image instead of building them in the pipeline
+
 # 0.0.3
 2026-07-16 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -42,9 +42,6 @@ workflow Glimpse2SVImputation {
 
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
-        File? pop_glimpse2_script               # heavily modified version of convert-to-biallelic.py
-        File? pop_glimpse2_cargo_toml
-        File? pop_glimpse2_binary
 
         String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"    # enables checkpointing, but note this contains bcftools/htslib 1.16!
     }
@@ -76,9 +73,6 @@ workflow Glimpse2SVImputation {
             extra_phase_args = extra_phase_args,
             output_prefix = output_prefix,
             pop_glimpse2_panel_resources_json = pop_glimpse2_panel_resources_json,
-            pop_glimpse2_script = pop_glimpse2_script,
-            pop_glimpse2_cargo_toml = pop_glimpse2_cargo_toml,
-            pop_glimpse2_binary = pop_glimpse2_binary,
             glimpse2_docker = glimpse2_docker,
             glimpse_phase_cpu_override = glimpse_phase_cpu_override
     }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,9 +4,9 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.3"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.2"
-    String batch_pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.4"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.3"
+    String batch_pipeline_version = "0.0.3"
 
     input {
         # inputs for Preprocessign wdl

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -24,12 +24,8 @@ workflow Glimpse2SVImputation {
 
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
         File preprocess_panel_bubble_split_sites_only_vcf_idx
-        File? extract_bubble_likelihoods_script
-        File? extract_bubble_likelihoods_cargo_toml
-        File? extract_bubble_likelihoods_binary
         String? extract_bubble_likelihoods_extra_args
 
-        File paste_vcfs_binary
         Array[String] paste_regions
 
         # inputs for Batch wdl
@@ -64,11 +60,7 @@ workflow Glimpse2SVImputation {
         sample_names_map_file = sample_names_map_file,
         preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
         preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-        extract_bubble_likelihoods_script = extract_bubble_likelihoods_script,
-        extract_bubble_likelihoods_cargo_toml = extract_bubble_likelihoods_cargo_toml,
-        extract_bubble_likelihoods_binary = extract_bubble_likelihoods_binary,
         extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,
-        paste_vcfs_binary = paste_vcfs_binary,
         paste_regions = paste_regions
 
     }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.3
+2026-07-17 (Date of Last Commit)
+
+* Updated tasks to use the official bcftools-vcftools and sv-imputation-rust-tools docker images
+* sv-imputation-rust-tools contains the 3 rust binaries and tasks have been updated accordingly 
+to use the binaries from this image instead of building them in the pipeline
+
 # 0.0.2
 2026-07-16 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -25,9 +25,6 @@ workflow Glimpse2SVImputationBatch {
 
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
-        File? pop_glimpse2_script               # heavily modified version of convert-to-biallelic.py
-        File? pop_glimpse2_cargo_toml
-        File? pop_glimpse2_binary
 
         String glimpse2_docker
     }
@@ -85,9 +82,6 @@ workflow Glimpse2SVImputationBatch {
                 panel_bubble_split_sites_only_vcf_idx = panel_bubble_split_sites_only_vcf_idx,
                 panel_id_split_vcf_gz = panel_id_split_vcf_gz,
                 panel_id_split_vcf_gz_tbi = panel_id_split_vcf_gz_tbi,
-                pop_glimpse2_script = pop_glimpse2_script,
-                cargo_toml = pop_glimpse2_cargo_toml,
-                pop_glimpse2_binary = pop_glimpse2_binary,
                 region = pop_regions[k],
                 output_prefix = output_prefix + ".glimpse2.popped"
         }
@@ -297,10 +291,6 @@ task PopAndMarginalizeCollisions {
         File panel_id_split_vcf_gz           # panel popping script currently requires vcf.gz, so we also use that here
         File panel_id_split_vcf_gz_tbi
 
-        File? pop_glimpse2_script             # modified version of convert-to-biallelic.py translated to Rust
-        File? cargo_toml
-        File? pop_glimpse2_binary
-
         String region
         String output_prefix
 
@@ -312,24 +302,11 @@ task PopAndMarginalizeCollisions {
     command <<<
         set -euox pipefail
 
-        if [ -n "~{pop_glimpse2_binary}" ]; then
-            POP_BIN="~{pop_glimpse2_binary}"
-            chmod +x $POP_BIN
-        else
-            mkdir -p pop-glimpse2/src/bin
-            cp ~{pop_glimpse2_script} pop-glimpse2/src/bin/pop-glimpse2.rs
-            cp ~{cargo_toml} pop-glimpse2
-            cd pop-glimpse2
-            cargo build --release
-            cd ..
-            POP_BIN="./pop-glimpse2/target/release/pop-glimpse2"
-        fi
-
         # this now only works for pop-glimpse2-joint-opt.rs;
         # the sort may also be extraneous, but we keep it in to guard against getting out of sync with the popped panel
         bcftools view -r ~{region} --regions-overlap 0 ~{panel_bubble_split_sites_only_vcf} -Oz -o panel.bubble.split.sites.shard.vcf.gz
         bcftools view -r ~{region} --regions-overlap 0 ~{posteriors_vcf} | \
-            $POP_BIN ~{panel_id_split_vcf_gz} panel.bubble.split.sites.shard.vcf.gz | \
+            /usr/local/bin/pop-glimpse2 ~{panel_id_split_vcf_gz} panel.bubble.split.sites.shard.vcf.gz | \
             bcftools sort --max-mem=2G -W -Ob -o ~{output_prefix}.bcf
     >>>
 
@@ -347,7 +324,7 @@ task PopAndMarginalizeCollisions {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsde-methods/slee/lrma-aou2-panel-creation-rust:v1"
+        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,8 +4,8 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.2"
-    String concat_vcfs_pipeline_version = "0.0.1"
+    String pipeline_version = "0.0.3"
+    String concat_vcfs_pipeline_version = "0.0.2"
 
     input {
         File input_preprocessed_joint_vcf

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -393,7 +393,7 @@ task RemapSampleNames {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsp-lrma/lr-gcloud-samtools:0.1.23"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -324,7 +324,7 @@ task PopAndMarginalizeCollisions {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
+        docker:             "us.gcr.io/broad-gotc-prod/sv-imputation-rust-tools:1.0.0-5dc0f19-1784328222"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -370,7 +370,7 @@ task RemapSampleNames {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.2
+2026-07-17 (Date of Last Commit)
+
+* Updated tasks to use the official bcftools-vcftools and sv-imputation-rust-tools docker images
+* sv-imputation-rust-tools contains the 3 rust binaries and tasks have been updated accordingly
+  to use the binaries from this image instead of building them in the pipeline
+
 # 0.0.1
 2026-07-08 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -198,7 +198,7 @@ task CreateBatches {
         disk_type:          "HDD",
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsp-lrma/lr-gcloud-samtools:0.1.23"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -431,7 +431,7 @@ task ConcatVcfs {
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,
-        docker:             "us.gcr.io/broad-dsp-lrma/lr-gcloud-samtools:0.1.23"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -4,7 +4,7 @@ version 1.0
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.1"
+    String pipeline_version = "0.0.2"
 
     input {
         Array[String]? vcfs_array

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -193,7 +193,7 @@ task CreateBatches {
         disk_type:          "HDD",
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -356,7 +356,7 @@ task MergeVcfs {
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,
-        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
+        docker:             "us.gcr.io/broad-gotc-prod/sv-imputation-rust-tools:1.0.0-5dc0f19-1784328222"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -406,7 +406,7 @@ task ConcatVcfs {
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,
-        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:sps_sv_docker_images"
+        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -17,7 +17,6 @@ workflow MultilevelHierarchicallyMergeVcfs {
         Array[Int] timeouts_min  # Timeouts in minutes per level. Set to 0 to disable. e.g., [720, 720]
         String output_prefix
 
-        File paste_vcfs_binary
         String extra_merge_args = "--threads $(nproc) --info ID,RAF --format GT,DS,GP"
 
         String extra_concat_args = "--threads $(nproc) --naive"
@@ -51,7 +50,6 @@ workflow MultilevelHierarchicallyMergeVcfs {
                     timeout_min = timeouts_min[0],
                     region = region,
                     output_prefix = region_prefix + ".L0-" + i,
-                    paste_vcfs_binary = paste_vcfs_binary,
                     extra_args = "-r " + region + " " + extra_merge_args
             }
         }
@@ -80,7 +78,6 @@ workflow MultilevelHierarchicallyMergeVcfs {
                         timeout_min = timeouts_min[1],
                         region = region,
                         output_prefix = region_prefix + ".L1-" + i,
-                        paste_vcfs_binary = paste_vcfs_binary,
                         extra_args = "-r " + region + " " + extra_merge_args
                 }
             }
@@ -110,7 +107,6 @@ workflow MultilevelHierarchicallyMergeVcfs {
                         timeout_min = timeouts_min[2],
                         region = region,
                         output_prefix = region_prefix + ".L2-" + i,
-                        paste_vcfs_binary = paste_vcfs_binary,
                         extra_args = "-r " + region + " " + extra_merge_args
                 }
             }
@@ -131,7 +127,6 @@ workflow MultilevelHierarchicallyMergeVcfs {
                     timeout_min = 0,
                     region = region,
                     output_prefix = region_prefix + ".final",
-                    paste_vcfs_binary = paste_vcfs_binary,
                     extra_args = "-r " + region + " " + extra_merge_args
             }
         }
@@ -223,10 +218,6 @@ task MergeVcfs {
         String? region
         String output_prefix
         String? extra_args
-
-        File? cargo_toml
-        File? paste_vcfs_script
-        File? paste_vcfs_binary
 
         RuntimeAttr? runtime_attr_override
     }
@@ -337,27 +328,11 @@ task MergeVcfs {
         ) &
         HEARTBEAT_PID=$!
 
-        if [ -n "~{paste_vcfs_binary}" ]; then
-            PASTE_BIN="~{paste_vcfs_binary}"
-            chmod +x $PASTE_BIN
-        else
-            # ==========================================
-            # ON-THE-FLY RUST COMPILATION
-            # ==========================================
-            mkdir -p paste-vcfs/src
-            mv ~{cargo_toml} paste-vcfs/Cargo.toml
-            mv ~{paste_vcfs_script} paste-vcfs/src/main.rs
-            cd paste-vcfs
-            CARGO_BUILD_JOBS=$(nproc) cargo build --release
-            cd ..
-            PASTE_BIN="./paste-vcfs/target/release/paste-vcfs"
-        fi
-
         # ==========================================
         # EXECUTE CUSTOM MERGE
         # ==========================================
         # Execute the compiled tool, pasting positional inputs straight from our list
-        $PASTE_BIN \
+        /usr/local/bin/paste-vcfs \
             ~{extra_args} \
             -o ~{output_prefix}.bcf \
             $(cat merge_list.txt)
@@ -381,7 +356,7 @@ task MergeVcfs {
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,
-        docker:             "us.gcr.io/broad-dsde-methods/slee/lrma-aou2-panel-creation-rust:v1"
+        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.3
 2026-07-17 (Date of Last Commit)
 
-* Updated tasks to use the official sv-imputation-rust-tools docker images
+* Updated tasks to use the official sv-imputation-rust-tools docker image
 * sv-imputation-rust-tools contains the 3 rust binaries and tasks have been updated accordingly
   to use the binaries from this image instead of building them in the pipeline
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.3
+2026-07-17 (Date of Last Commit)
+
+* Updated tasks to use the official sv-imputation-rust-tools docker images
+* sv-imputation-rust-tools contains the 3 rust binaries and tasks have been updated accordingly
+  to use the binaries from this image instead of building them in the pipeline
+
 # 0.0.2
 2026-07-14 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -4,8 +4,8 @@ import "./MultilevelHierarchicallyPasteVcfsStreaming.wdl" as MultilevelHierarchi
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.2"
-    String multi_level_paste_pipeline_version = "0.0.1"
+    String pipeline_version = "0.0.3"
+    String multi_level_paste_pipeline_version = "0.0.2"
     input {
         File? input_gvcfs_fofn
         File? input_gvcf_idxs_fofn

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -186,7 +186,7 @@ task PreprocessPLs {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
+        docker:             "us.gcr.io/broad-gotc-prod/sv-imputation-rust-tools:1.0.0-5dc0f19-1784328222"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -20,12 +20,8 @@ workflow PreprocessPLsGVCF {
         # inputs for PreprocessPLs
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
         File preprocess_panel_bubble_split_sites_only_vcf_idx
-        File? extract_bubble_likelihoods_script
-        File? extract_bubble_likelihoods_cargo_toml
-        File? extract_bubble_likelihoods_binary
         String? extract_bubble_likelihoods_extra_args
 
-        File paste_vcfs_binary
         Array[String] paste_regions
     }
 
@@ -64,9 +60,6 @@ workflow PreprocessPLsGVCF {
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
                 sample_names = [sample_names_[j]],
                 output_prefix = ".sample-" + j + "." + sample_names_[j] + ".preprocessedPLs",
-                extract_bubble_likelihoods_script = extract_bubble_likelihoods_script,
-                cargo_toml = extract_bubble_likelihoods_cargo_toml,
-                extract_bubble_likelihoods_binary = extract_bubble_likelihoods_binary,
                 extra_args = extract_bubble_likelihoods_extra_args
         }
     }
@@ -81,7 +74,6 @@ workflow PreprocessPLsGVCF {
             do_localization = [true, true],
             timeouts_min = [0, 0],
             output_prefix = "preprocessedPLs.merged",
-            paste_vcfs_binary = paste_vcfs_binary,
             extra_merge_args = "--threads $(nproc) --format GT,PL",
             extra_concat_args = "--threads $(nproc) --naive"
     }
@@ -154,9 +146,6 @@ task PreprocessPLs {
         Array[String] sample_names
         String output_prefix
 
-        File? extract_bubble_likelihoods_script
-        File? cargo_toml
-        File? extract_bubble_likelihoods_binary
         String? extra_args = "--window 15000 --cap-pl 30 --scale-pl 5.0 --threads $(nproc)"
 
         RuntimeAttr? runtime_attr_override
@@ -169,20 +158,7 @@ task PreprocessPLs {
     command <<<
         set -euxo pipefail
 
-        if [ -n "~{extract_bubble_likelihoods_binary}" ]; then
-            EXTRACT_BIN="~{extract_bubble_likelihoods_binary}"
-            chmod +x $EXTRACT_BIN
-        else
-            mkdir -p extract-bubble-PLs/src
-            cp ~{extract_bubble_likelihoods_script} extract-bubble-PLs/src/main.rs
-            cp ~{cargo_toml} extract-bubble-PLs
-            cd extract-bubble-PLs
-            cargo build --release
-            cd ..
-            EXTRACT_BIN="./extract-bubble-PLs/target/release/extract-bubble-PLs"
-        fi
-
-        $EXTRACT_BIN ~{mode} \
+        /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
             ~{input_vcf}##idx##~{input_vcf_idx} \
             ~{output_prefix}.bcf \
@@ -210,7 +186,7 @@ task PreprocessPLs {
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-dsde-methods/slee/lrma-aou2-panel-creation-rust:v1"
+        docker:             "us.gcr.io/broad-dsde-methods/sshah/sv_rust_tools:1.0.0-5dc0f19-1784242277"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {


### PR DESCRIPTION
### Description

Jira - https://broadworkbench.atlassian.net/browse/TSPS-1062

This PR updates the tasks to use the below docker images:
- us.gcr.io/broad-gotc-prod/sv-imputation-rust-tools
- us.gcr.io/broad-gotc-prod/bcftools-vcftools

The rust-tools docker image is generated from this [warp-tools PR](https://github.com/broadinstitute/warp-tools/pull/205). Once this PR merges the official images for both above images will be generated and used in this PR.

### Testing

Manually tested the pipeline changes.

Successful test submission - https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/357fbc98-29c1-46b2-9293-1cc3bc00d0bb

Ran CompareBcfs workflow on the output and there were no output differences.
Comparison for `glimpse2_bubble_posteriors_vcf` bcf  - https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/8655be89-5127-4f9f-b768-c9822edbbc1c

Comparison for `glimpse2_popped_posteriors_vcf ` - https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/49a8a108-310a-49c1-b5da-a17f99c7cb38

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [x] If you made a changelog update, did you update the pipeline version number?
