### PR TITLE
TSPS-1082 Low Pass WGS Imputation Input QC: add cram-crai basename check

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,9 +5,9 @@ ConcatVcfs	 0.0.1	2026-07-08
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 1.0.2	2026-07-17 
+Glimpse2LowPassImputation	 1.0.2	2026-07-20 
 Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
-Glimpse2LowPassImputationQC	 1.0.5	2026-07-17 
+Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.3	2026-07-16 
 Glimpse2SVImputationBatch	 0.0.2	2026-07-16 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,9 +5,9 @@ ConcatVcfs	 0.0.1	2026-07-08
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 1.0.1	2026-07-12 
+Glimpse2LowPassImputation	 1.0.2	2026-07-17 
 Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
-Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
+Glimpse2LowPassImputationQC	 1.0.5	2026-07-17 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.3	2026-07-16 
 Glimpse2SVImputationBatch	 0.0.2	2026-07-16 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.2
+2026-07-17 (Date of Last Commit)
+
+* Update Input QC workflow version
+
 # 1.0.1
 2026-07-12 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.2
-2026-07-17 (Date of Last Commit)
+2026-07-20 (Date of Last Commit)
 
 * Update Input QC workflow version
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,10 +4,10 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
     String batch_pipeline_version = "1.0.1"
     String quota_consumed_version = "1.0.0"
-    String input_qc_version = "1.0.4"
+    String input_qc_version = "1.0.5"
 
     input {
         # if multiple data types are provided, the workflow will prioritize cram/cram_indicies/sample_ids first, then cram manifest

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.5
+2026-07-17 (Date of Last Commit)
+
+* Add check for matching cram and crai basenames
+
 # 1.0.4
 2026-05-22 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.changelog.md
@@ -1,5 +1,5 @@
 # 1.0.5
-2026-07-17 (Date of Last Commit)
+2026-07-20 (Date of Last Commit)
 
 * Add check for matching cram and crai basenames
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -215,11 +215,11 @@ task ValidateCramsAndIndicesAndSampleIds {
         else:
             print("All CRAM files have the correct .cram extension.")
 
-        cram_indices_with_wrong_extension = [c for c in cram_indices if not c.endswith('.crai')]
+        cram_indices_with_wrong_extension = [c for c in cram_indices if not c.endswith('.cram.crai')]
         if cram_indices_with_wrong_extension:
-            qc_messages.append(create_error_message_with_item_list(f"Found {pluralize(len(cram_indices_with_wrong_extension), 'CRAM index file')} without a .crai extension", cram_indices_with_wrong_extension))
+            qc_messages.append(create_error_message_with_item_list(f"Found {pluralize(len(cram_indices_with_wrong_extension), 'CRAM index file')} without a .cram.crai extension", cram_indices_with_wrong_extension))
         else:
-            print("All CRAM index files have the correct .crai extension.")
+            print("All CRAM index files have the correct .cram.crai extension.")
 
         # Validate that cram paths are unique
         unique_crams = set(crams)
@@ -232,8 +232,8 @@ task ValidateCramsAndIndicesAndSampleIds {
         # Validate that each cram-crai pair has matching basenames
         mismatched_basename_pairs = []
         for cram, crai in zip(crams, cram_indices):
-            cram_basename = cram.split('/')[-1].replace('.cram', '')
-            crai_basename = crai.split('/')[-1].replace('.cram.crai', '')
+            cram_basename = cram.split('/')[-1].removesuffix('.cram')
+            crai_basename = crai.split('/')[-1].removesuffix('.cram.crai')
             if cram_basename != crai_basename:
                 mismatched_basename_pairs.append(f"{cram} and {crai}")
         if mismatched_basename_pairs:

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -229,6 +229,18 @@ task ValidateCramsAndIndicesAndSampleIds {
         else:
             print("CRAM paths are unique.")
 
+        # Validate that each cram-crai pair has matching basenames
+        mismatched_basename_pairs = []
+        for cram, crai in zip(crams, cram_indices):
+            cram_basename = cram.split('/')[-1].replace('.cram', '')
+            crai_basename = crai.split('/')[-1].replace('.crai', '')
+            if cram_basename != crai_basename:
+                mismatched_basename_pairs.append(f"{cram} and {crai}")
+        if mismatched_basename_pairs:
+            qc_messages.append(create_error_message_with_item_list(f"Found {pluralize(len(mismatched_basename_pairs), 'CRAM-CRAI pair')} with mismatched basenames", mismatched_basename_pairs))
+        else:
+            print("All CRAM-CRAI pairs have matching basenames.")
+
         # Ensure that all CRAM files are less than the maximum file size allowed
         max_cram_file_size_gb = ~{max_cram_file_size_gb}
         billing_project = "~{billing_project}"

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -233,7 +233,7 @@ task ValidateCramsAndIndicesAndSampleIds {
         mismatched_basename_pairs = []
         for cram, crai in zip(crams, cram_indices):
             cram_basename = cram.split('/')[-1].replace('.cram', '')
-            crai_basename = crai.split('/')[-1].replace('.crai', '')
+            crai_basename = crai.split('/')[-1].replace('.cram.crai', '')
             if cram_basename != crai_basename:
                 mismatched_basename_pairs.append(f"{cram} and {crai}")
         if mismatched_basename_pairs:

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/Glimpse2LowPassImputationQC.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow InputQC {
     # if this changes, update the input_qc_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "1.0.4"
+    String pipeline_version = "1.0.5"
 
     input {
         # service expects only cram_manifest even though main wdl can alternatively take input arrays

--- a/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_mismatched_crai_basename.json
+++ b/pipelines/wdl/glimpse/low_pass_imputation/input_qc/test_inputs/Plumbing/fail_manifest_mismatched_crai_basename.json
@@ -1,0 +1,10 @@
+{
+  "Glimpse2LowPassImputationQC.reference_panel_prefix": "gs://broad-dsde-methods-bge-resources-public/GlimpseImputation/ReferencePanels/1000G_HGDP_with_trio_information_old_chrX",
+  "Glimpse2LowPassImputationQC.contigs": ["chr1","chr2","chr3","chr4","chr5","chr6","chr7","chr8","chr9","chr10","chr11","chr12","chr13","chr14","chr15","chr16","chr17","chr18","chr19","chr20","chr21","chr22"],
+  "Glimpse2LowPassImputationQC.fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "Glimpse2LowPassImputationQC.fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+  "Glimpse2LowPassImputationQC.output_basename": "plumbing_test",
+  "Glimpse2LowPassImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "Glimpse2LowPassImputationQC.cram_manifest": "gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/manifests/fakeCramManifestMismatchedCraiBasename.tsv",
+  "Glimpse2LowPassImputationQC.billing_project_for_rp": "terra-f8e3de20"
+}


### PR DESCRIPTION
### Description

We expect users to submit cram-crai pairs that share a basename. If they don't, most likely the user has made a mistake. So we're adding this check to our InputQC wdl.

Test case output:
```
{ 
   "qc_messages": "Found 1 CRAM-CRAI pair with mismatched basenames: gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/fakeCram1.cram and gs://pd-test-storage-public/Glimpse2LowPassImputationQC/input/plumbing/crams/fakeCram2.cram.crai.", 
   "passes_qc": "false" 
}
```

Note we expect this new test case to fail because there's no truth data for it yet. Will create truth data once this PR is merged.

Also updated the crai required suffix from `.crai` to `.cram.crai` since we are effectively checking for that with the above check. This will likely cause a couple more tests to fail because the error message has changed.

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-1082

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [x] If you made a changelog update, did you update the pipeline version number?
