### PR TITLE
[TSPS-1063] Set noAddress to true for SV pipeline tasks

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 ArrayImputationQC	 1.3.0	2026-02-04 
 ArrayImputationQuotaConsumed	 1.1.0	2025-09-29 
 BuildIndices	 5.1.1	2026-05-20 
-ConcatVcfs	 0.0.3	2026-07-20 
+ConcatVcfs	 0.0.3	2026-07-21 
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
@@ -9,20 +9,20 @@ Glimpse2LowPassImputation	 1.0.1	2026-07-12
 Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.4	2026-07-17 
-Glimpse2SVImputationBatch	 0.0.4	2026-07-20 
+Glimpse2SVImputation	 0.0.5	2026-07-21 
+Glimpse2SVImputationBatch	 0.0.4	2026-07-21 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.3	2026-07-20 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.3	2026-07-21 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.4	2026-07-20 
+PreprocessPLsGVCF	 0.0.4	2026-07-21 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -1,7 +1,7 @@
 ArrayImputationQC	 1.3.0	2026-02-04 
 ArrayImputationQuotaConsumed	 1.1.0	2025-09-29 
 BuildIndices	 5.1.1	2026-05-20 
-ConcatVcfs	 0.0.2	2026-07-17 
+ConcatVcfs	 0.0.3	2026-07-20 
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
@@ -10,19 +10,19 @@ Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12
 Glimpse2LowPassImputationQC	 1.0.4	2026-05-22 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.4	2026-07-17 
-Glimpse2SVImputationBatch	 0.0.3	2026-07-17 
+Glimpse2SVImputationBatch	 0.0.4	2026-07-20 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.2	2026-07-17 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.3	2026-07-20 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.3	2026-07-17 
+PreprocessPLsGVCF	 0.0.4	2026-07-20 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-07-20 (Date of Last Commit)
+
+* Set noAddress to true in tasks
+
 # 0.0.2
 2026-07-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.3
-2026-07-20 (Date of Last Commit)
+2026-07-21 (Date of Last Commit)
 
-* Set noAddress to true in tasks
+* Set `noAddress` to true in tasks
 
 # 0.0.2
 2026-07-17 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/ConcatVcfs.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow ConcatVcfs {
     # if this changes, update the concat_vcfs_pipeline_version value in Glimpse2SVImputationBatch.wdl
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.3"
 
     input {
         Array[File] vcfs
@@ -153,5 +153,6 @@ task ConcatVcfs {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.5
+2026-07-21 (Date of Last Commit)
+
+* Updated both `preprocess_pls_gvcf_pipeline_version` and `batch_pipeline_version` to 0.0.4
+
 # 0.0.4
 2026-07-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,7 +4,7 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.4"
+    String pipeline_version = "0.0.5"
     String preprocess_pls_gvcf_pipeline_version = "0.0.4"
     String batch_pipeline_version = "0.0.4"
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,8 +5,8 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
     String pipeline_version = "0.0.4"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.3"
-    String batch_pipeline_version = "0.0.3"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.4"
+    String batch_pipeline_version = "0.0.4"
 
     input {
         # inputs for Preprocessign wdl

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.4
+2026-07-20 (Date of Last Commit)
+
+* Set noAddress to true in tasks
+
 # 0.0.3
 2026-07-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.4
-2026-07-20 (Date of Last Commit)
+2026-07-21 (Date of Last Commit)
 
-* Set noAddress to true in tasks
+* Set `noAddress` to true in tasks
 
 # 0.0.3
 2026-07-17 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,8 +4,8 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.3"
-    String concat_vcfs_pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.4"
+    String concat_vcfs_pipeline_version = "0.0.3"
 
     input {
         File input_preprocessed_joint_vcf
@@ -227,6 +227,7 @@ task GLIMPSE2Phase {
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
         checkpointFile:         "checkpoint.bin"
+        noAddress: true
     }
 }
 
@@ -277,6 +278,7 @@ task GLIMPSE2Ligate {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }
 
@@ -335,6 +337,7 @@ task PopAndMarginalizeCollisions {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }
 
@@ -381,5 +384,6 @@ task RemapSampleNames {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-07-20 (Date of Last Commit)
+
+* Set noAddress to true in tasks
+
 # 0.0.2
 2026-07-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.3
-2026-07-20 (Date of Last Commit)
+2026-07-21 (Date of Last Commit)
 
-* Set noAddress to true in tasks
+* Set `noAddress` to true in tasks
 
 # 0.0.2
 2026-07-17 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -4,7 +4,7 @@ version 1.0
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.3"
 
     input {
         Array[String]? vcfs_array
@@ -204,6 +204,7 @@ task CreateBatches {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }
 
@@ -367,6 +368,7 @@ task MergeVcfs {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }
 
@@ -417,5 +419,6 @@ task ConcatVcfs {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.4
+2026-07-20 (Date of Last Commit)
+
+* Set noAddress to true in tasks
+
 # 0.0.3
 2026-07-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.4
-2026-07-20 (Date of Last Commit)
+2026-07-21 (Date of Last Commit)
 
-* Set noAddress to true in tasks
+* Set `noAddress` to true in tasks
 
 # 0.0.3
 2026-07-17 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -4,8 +4,8 @@ import "./MultilevelHierarchicallyPasteVcfsStreaming.wdl" as MultilevelHierarchi
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.3"
-    String multi_level_paste_pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.4"
+    String multi_level_paste_pipeline_version = "0.0.3"
     input {
         File? input_gvcfs_fofn
         File? input_gvcf_idxs_fofn
@@ -132,6 +132,7 @@ task MapSampleNames {
         memory: "4 GB"
         disks: "local-disk 10 HDD"
         preemptible: 3
+        noAddress: true
     }
 }
 
@@ -197,5 +198,6 @@ task PreprocessPLs {
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+        noAddress: true
     }
 }


### PR DESCRIPTION
### Description

Jira - https://broadworkbench.atlassian.net/browse/TSPS-1063

This PR sets noAddress to true for all tasks in SV pipeline.

### Testing

Ran the wdl in test workspace and it succeeded - https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/9ccabe1c-8de2-4aea-8fbb-14256d4f6bd3

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
