### PR TITLE
TSPS-1103 / TSPS-1109 Allow for multiple chromosomes to be processed in one workflow call

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.0.2	2026-07-20
 Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.5	2026-07-21 
-Glimpse2SVImputationBatch	 0.0.4	2026-07-21 
+Glimpse2SVImputation	 0.0.6	2026-07-23 
+Glimpse2SVImputationBatch	 0.0.5	2026-07-23 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.6
+2026-07-23 (Date of Last Commit)
+
+* Update workflow to process array of chromosomes instead of just one
+* remove now unused remapping input
+
 # 0.0.5
 2026-07-21 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,9 +4,9 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.5"
+    String pipeline_version = "0.0.6"
     String preprocess_pls_gvcf_pipeline_version = "0.0.4"
-    String batch_pipeline_version = "0.0.4"
+    String batch_pipeline_version = "0.0.5"
 
     input {
         # inputs for Preprocessign wdl

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -29,9 +29,7 @@ workflow Glimpse2SVImputation {
         Array[String] paste_regions
 
         # inputs for Batch wdl
-        File? remap_sample_names_file    # TSV with old_name new_name mappings
-
-        String chromosome
+        Array[String] chromosomes
         File genetic_maps_tsv
         File chunked_panel_json
 
@@ -66,8 +64,7 @@ workflow Glimpse2SVImputation {
         input:
             input_preprocessed_joint_vcf = PreProcessGVCFs.preprocessed_pls_vcf,
             input_preprocessed_joint_vcf_idx = PreProcessGVCFs.preprocessed_pls_vcf_idx,
-            remap_sample_names_file = remap_sample_names_file,
-            chromosome = chromosome,
+            chromosomes = chromosomes,
             genetic_maps_tsv = genetic_maps_tsv,
             chunked_panel_json = chunked_panel_json,
             extra_phase_args = extra_phase_args,
@@ -78,10 +75,10 @@ workflow Glimpse2SVImputation {
     }
 
     output {
-        File glimpse2_bubble_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf
-        File glimpse2_bubble_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf_idx
-        File glimpse2_popped_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf
-        File glimpse2_popped_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf_idx
+        Array[File] glimpse2_bubble_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf
+        Array[File] glimpse2_bubble_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf_idx
+        Array[File] glimpse2_popped_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf
+        Array[File] glimpse2_popped_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf_idx
     }
 }
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -2,7 +2,7 @@
 2026-07-23 (Date of Last Commit)
 
 * Update workflow to process array of chromosomes instead of just one
-* remove unused remapping steps/tasks/input that were at the end of the workflow
+* remove unused remapping calls/task/input that were at the end of the workflow
 
 # 0.0.4
 2026-07-21 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.5
+2026-07-23 (Date of Last Commit)
+
+* Update workflow to process array of chromosomes instead of just one
+* remove unused remapping steps/tasks/input that were at the end of the workflow
+
 # 0.0.4
 2026-07-21 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -11,9 +11,7 @@ workflow Glimpse2SVImputationBatch {
         File input_preprocessed_joint_vcf
         File input_preprocessed_joint_vcf_idx
 
-        File? remap_sample_names_file    # TSV with old_name new_name mappings
-
-        String chromosome
+        Array[String] chromosomes
         File genetic_maps_tsv
         File chunked_panel_json
 
@@ -30,100 +28,84 @@ workflow Glimpse2SVImputationBatch {
     }
 
     Map[String, String] genetic_maps_dict = read_map(genetic_maps_tsv)
-    String genetic_map = genetic_maps_dict[chromosome]
-
-    Map[String, ChunkedPanelChromosome] chunked_panel = read_json(chunked_panel_json)
-    Array[String] input_regions = chunked_panel[chromosome].input_regions
-    Array[String] output_regions = chunked_panel[chromosome].output_regions
-    Array[File] panel_split_chunk_bins = chunked_panel[chromosome].panel_split_chunk_bins
-
     Map[String, PopAndMarginalizePanelResourcesChromosome] pop_glimpse2_panel_resources = read_json(pop_glimpse2_panel_resources_json)
-    File panel_bubble_split_sites_only_vcf = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf
-    File panel_bubble_split_sites_only_vcf_idx = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf_idx
-    File panel_id_split_vcf_gz = pop_glimpse2_panel_resources[chromosome].panel_id_split_vcf_gz
-    File panel_id_split_vcf_gz_tbi = pop_glimpse2_panel_resources[chromosome].panel_id_split_vcf_gz_tbi
-    Array[String] pop_regions = select_first([pop_glimpse2_panel_resources[chromosome].pop_regions, output_regions])
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs
     # to tasks that are inside nested scatters, so we need to define a non-optional variable that we can use to pass the
     # value down to the GlimpsePhase task. If not defined, Cromwell fails the workflow
     Int defined_glimpse_phase_cpu_override = select_first([glimpse_phase_cpu_override, 4])
 
-    scatter (k in range(length(output_regions))) {
-        call GLIMPSE2Phase as ChunkedGLIMPSE2Phase {
-            input:
-                input_vcf = input_preprocessed_joint_vcf,
-                input_vcf_idx = input_preprocessed_joint_vcf_idx,
-                panel_split_chunk_bin = panel_split_chunk_bins[k],
-                input_region = input_regions[k],
-                output_region = output_regions[k],
-                genetic_map = genetic_map,
-                output_prefix = output_prefix + ".shard-" + k + ".glimpse2.phased",
-                extra_phase_args = extra_phase_args,
-                docker = glimpse2_docker,
-                threads = defined_glimpse_phase_cpu_override
-        }
-    }
+    scatter (chromosome in chromosomes) {
+        String genetic_map = genetic_maps_dict[chromosome]
 
-    call GLIMPSE2Ligate {
-        input:
-            phased_vcfs = ChunkedGLIMPSE2Phase.phased_vcf,
-            phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_vcf_idx,
-            output_prefix = output_prefix + ".glimpse2.bubble",
-            docker = glimpse2_docker
-    }
+        Map[String, ChunkedPanelChromosome] chunked_panel = read_json(chunked_panel_json)
+        Array[String] input_regions = chunked_panel[chromosome].input_regions
+        Array[String] output_regions = chunked_panel[chromosome].output_regions
+        Array[File] panel_split_chunk_bins = chunked_panel[chromosome].panel_split_chunk_bins
 
-    scatter (k in range(length(pop_regions))) {
-        call PopAndMarginalizeCollisions {
-            input:
-                posteriors_vcf = GLIMPSE2Ligate.ligated_vcf,
-                posteriors_vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx,
-                panel_bubble_split_sites_only_vcf = panel_bubble_split_sites_only_vcf,
-                panel_bubble_split_sites_only_vcf_idx = panel_bubble_split_sites_only_vcf_idx,
-                panel_id_split_vcf_gz = panel_id_split_vcf_gz,
-                panel_id_split_vcf_gz_tbi = panel_id_split_vcf_gz_tbi,
-                region = pop_regions[k],
-                output_prefix = output_prefix + ".glimpse2.popped"
-        }
-    }
+        File panel_bubble_split_sites_only_vcf = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf
+        File panel_bubble_split_sites_only_vcf_idx = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf_idx
+        File panel_id_split_vcf_gz = pop_glimpse2_panel_resources[chromosome].panel_id_split_vcf_gz
+        File panel_id_split_vcf_gz_tbi = pop_glimpse2_panel_resources[chromosome].panel_id_split_vcf_gz_tbi
+        Array[String] pop_regions = select_first([pop_glimpse2_panel_resources[chromosome].pop_regions, output_regions])
 
-    call ConcatVcfs.ConcatVcfs as ConcatPopAndMarginalizeCollisions {
-        input:
-            vcfs = PopAndMarginalizeCollisions.popped_vcf,
-            vcf_idxs = PopAndMarginalizeCollisions.popped_vcf_idx,
-            output_prefix = output_prefix + ".glimpse2.popped",
-            do_bcf = true,
-            do_sort = false,
-            extra_args = "--threads $(nproc) --naive",
-            regions = [],
-            do_sort_shard = false,
-            extra_args_shard = ""
-    }
-
-    # Conditionally trigger remapping tasks
-    if (defined(remap_sample_names_file)) {
-        call RemapSampleNames as RemapBubblePosteriors {
-            input:
-                vcf = GLIMPSE2Ligate.ligated_vcf,
-                vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx,
-                remap_file = select_first([remap_sample_names_file]),
-                output_prefix = output_prefix + ".glimpse2.bubble"
+        scatter (k in range(length(output_regions))) {
+            call GLIMPSE2Phase as ChunkedGLIMPSE2Phase {
+                input:
+                    input_vcf = input_preprocessed_joint_vcf,
+                    input_vcf_idx = input_preprocessed_joint_vcf_idx,
+                    panel_split_chunk_bin = panel_split_chunk_bins[k],
+                    input_region = input_regions[k],
+                    output_region = output_regions[k],
+                    genetic_map = genetic_map,
+                    output_prefix = output_prefix + ".shard-" + k + ".glimpse2.phased",
+                    extra_phase_args = extra_phase_args,
+                    docker = glimpse2_docker,
+                    threads = defined_glimpse_phase_cpu_override
+            }
         }
 
-        call RemapSampleNames as RemapPoppedPosteriors {
+        call GLIMPSE2Ligate {
             input:
-                vcf = ConcatPopAndMarginalizeCollisions.concatenated_vcf,
-                vcf_idx = ConcatPopAndMarginalizeCollisions.concatenated_vcf_idx,
-                remap_file = select_first([remap_sample_names_file]),
-                output_prefix = output_prefix + ".glimpse2.popped"
+                phased_vcfs = ChunkedGLIMPSE2Phase.phased_vcf,
+                phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_vcf_idx,
+                output_prefix = output_prefix + ".glimpse2.bubble",
+                docker = glimpse2_docker
+        }
+
+        scatter (k in range(length(pop_regions))) {
+            call PopAndMarginalizeCollisions {
+                input:
+                    posteriors_vcf = GLIMPSE2Ligate.ligated_vcf,
+                    posteriors_vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx,
+                    panel_bubble_split_sites_only_vcf = panel_bubble_split_sites_only_vcf,
+                    panel_bubble_split_sites_only_vcf_idx = panel_bubble_split_sites_only_vcf_idx,
+                    panel_id_split_vcf_gz = panel_id_split_vcf_gz,
+                    panel_id_split_vcf_gz_tbi = panel_id_split_vcf_gz_tbi,
+                    region = pop_regions[k],
+                    output_prefix = output_prefix + ".glimpse2.popped"
+            }
+        }
+
+        call ConcatVcfs.ConcatVcfs as ConcatPopAndMarginalizeCollisions {
+            input:
+                vcfs = PopAndMarginalizeCollisions.popped_vcf,
+                vcf_idxs = PopAndMarginalizeCollisions.popped_vcf_idx,
+                output_prefix = output_prefix + ".glimpse2.popped",
+                do_bcf = true,
+                do_sort = false,
+                extra_args = "--threads $(nproc) --naive",
+                regions = [],
+                do_sort_shard = false,
+                extra_args_shard = ""
         }
     }
 
     output {
-        File glimpse2_bubble_posteriors_vcf = select_first([RemapBubblePosteriors.output_vcf, GLIMPSE2Ligate.ligated_vcf])
-        File glimpse2_bubble_posteriors_vcf_idx = select_first([RemapBubblePosteriors.output_vcf_idx, GLIMPSE2Ligate.ligated_vcf_idx])
-        File glimpse2_popped_posteriors_vcf = select_first([RemapPoppedPosteriors.output_vcf, ConcatPopAndMarginalizeCollisions.concatenated_vcf])
-        File glimpse2_popped_posteriors_vcf_idx = select_first([RemapPoppedPosteriors.output_vcf_idx, ConcatPopAndMarginalizeCollisions.concatenated_vcf_idx])
+        Array[File] glimpse2_bubble_posteriors_vcf = GLIMPSE2Ligate.ligated_vcf
+        Array[File] glimpse2_bubble_posteriors_vcf_idx =GLIMPSE2Ligate.ligated_vcf_idx
+        Array[File] glimpse2_popped_posteriors_vcf =ConcatPopAndMarginalizeCollisions.concatenated_vcf
+        Array[File] glimpse2_popped_posteriors_vcf_idx = ConcatPopAndMarginalizeCollisions.concatenated_vcf_idx
     }
 }
 
@@ -327,53 +309,6 @@ task PopAndMarginalizeCollisions {
         preemptible_tries:  2,
         max_retries:        1,
         docker:             "us.gcr.io/broad-gotc-prod/sv-imputation-rust-tools:1.0.0-5dc0f19-1784328222"
-    }
-    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-    runtime {
-        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
-        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + if select_first([runtime_attr.use_ssd, default_attr.use_ssd]) then " SSD" else " HDD"
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
-        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
-        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
-        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
-        noAddress: true
-    }
-}
-
-task RemapSampleNames {
-    input {
-        File vcf
-        File vcf_idx
-        File remap_file
-        String output_prefix
-
-        RuntimeAttr? runtime_attr_override
-    }
-
-    Int disk_size_gb = 10 + 2 * ceil(size(vcf, "GB"))
-
-    command <<<
-        set -euxo pipefail
-
-        bcftools reheader --samples ~{remap_file} ~{vcf} -o ~{output_prefix}.bcf
-        bcftools index ~{output_prefix}.bcf
-    >>>
-
-    output {
-        File output_vcf = "~{output_prefix}.bcf"
-        File output_vcf_idx = "~{output_prefix}.bcf.csi"
-    }
-
-    RuntimeAttr default_attr = object {
-        cpu_cores:          2,
-        mem_gb:             4,
-        disk_gb:            disk_size_gb,
-        boot_disk_gb:       10,
-        use_ssd:            true,
-        preemptible_tries:  2,
-        max_retries:        1,
-        docker:             "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.4"
+    String pipeline_version = "0.0.5"
     String concat_vcfs_pipeline_version = "0.0.3"
 
     input {


### PR DESCRIPTION
### Description
Because of how the initial version of this workflow was copied to warp, the batch workflow only processed oen chromosome.  This PR changes it so the batch workflow can process multiple chromosomes in one call.

This pr also removes unused remapping calls/task/input and makes those changes through to the parent workflow

Submission run with these changes processing multiple inputs
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/ec25b079-371c-4895-a374-aba0a19c80b6



Jira tickets:
https://broadworkbench.atlassian.net/browse/TSPS-1103
https://broadworkbench.atlassian.net/browse/TSPS-1109

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
