### PR TITLE
TSPS-1024 TSPS-1129 Make 50002 OOM less likely

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,8 +5,8 @@ ConcatVcfs	 0.0.3	2026-07-21
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.7	2026-01-21 
 ExomeReprocessing	 3.3.7	2026-01-21 
-Glimpse2LowPassImputation	 1.0.2	2026-07-20 
-Glimpse2LowPassImputationBatch	 1.0.1	2026-07-12 
+Glimpse2LowPassImputation	 1.0.3	2026-07-28 
+Glimpse2LowPassImputationBatch	 1.0.2	2026-07-28 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.6	2026-07-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.3
+2026-07-28 (Date of Last Commit)
+
+* update docker image used for glimpse. This will include runtime optimizations
+
 # 1.0.2
 2026-07-20 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -2,6 +2,7 @@
 2026-07-28 (Date of Last Commit)
 
 * update docker image used for glimpse. This will include runtime optimizations
+* change deafult sample batch size to 500
 
 # 1.0.2
 2026-07-20 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -2,7 +2,7 @@
 2026-07-28 (Date of Last Commit)
 
 * update docker image used for glimpse. This will include runtime optimizations
-* change deafult sample batch size to 500
+* change default sample batch size to 500
 
 # 1.0.2
 2026-07-20 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:for-scale-test-8671138"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -42,7 +42,7 @@ workflow Glimpse2LowPassImputation {
         Int? glimpse_phase_cpu_override
 
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:for-scale-test-8671138"
+        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
     }
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -5,7 +5,7 @@ import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2Low
 
 workflow Glimpse2LowPassImputation {
     String pipeline_version = "1.0.3"
-    String batch_pipeline_version = "1.0.3"
+    String batch_pipeline_version = "1.0.2"
     String quota_consumed_version = "1.0.0"
     String input_qc_version = "1.0.5"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -36,7 +36,7 @@ workflow Glimpse2LowPassImputation {
         Int calling_batch_size = 100
 
         # batch size used by this gateway workflow to split very large sample lists
-        Int sample_batch_size = 1000
+        Int sample_batch_size = 500
 
         # override for cpu used for glimpse phase task. Mostly used to set to 1 for determinism in testing, defaults to 4
         Int? glimpse_phase_cpu_override

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,8 +4,8 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "1.0.2"
-    String batch_pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.3"
+    String batch_pipeline_version = "1.0.3"
     String quota_consumed_version = "1.0.0"
     String input_qc_version = "1.0.5"
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.changelog.md
@@ -1,3 +1,9 @@
+# 1.0.2
+2026-07-28 (Date of Last Commit)
+
+* increase disk provided to glimpse phase task
+* remove glimpse docker image default value
+
 # 1.0.1
 2026-07-12 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -29,8 +29,8 @@ workflow Glimpse2LowPassImputationBatch {
         # override for cpu used for glimpse phase task. Mostly used to set to 1 for determinism in testing
         Int? glimpse_phase_cpu_override
 
-        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.0.0"
-        String glimpse_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248"
+        String gatk_docker
+        String glimpse_docker
     }
 
     # we need to define this here so that it can be used in nested scatters below. Cromwell doesn't understand optional inputs

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -545,7 +545,7 @@ task GlimpsePhase {
 
         Int cpu = 4 # note that setting cpu > 1 will introduce non-determinism in GLIMPSE Phase due to multi-threading
         Int mem_gb = 16
-        Int disk_size_gb = ceil(0.5 * size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
+        Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(reference_chunk, "GiB") + 10)
         Int preemptible = 30
         Int max_retries = 3
         String docker

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputationBatch.wdl
@@ -6,7 +6,7 @@ version 1.0
 
 workflow Glimpse2LowPassImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2LowPassImputation.wdl
-    String pipeline_version = "1.0.1"
+    String pipeline_version = "1.0.2"
 
     input {
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -41,7 +41,7 @@ workflow Glimpse2SVImputation {
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
 
-        String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"    # enables checkpointing, but note this contains bcftools/htslib 1.16!
+        String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:for-scale-test-8671138"    # enables checkpointing, but note this contains bcftools/htslib 1.16!
     }
 
     call PreprocessPLsGVCF.PreprocessPLsGVCF as PreProcessGVCFs {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -41,7 +41,7 @@ workflow Glimpse2SVImputation {
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
 
-        String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:for-scale-test-8671138"    # enables checkpointing, but note this contains bcftools/htslib 1.16!
+        String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818"    # enables checkpointing, but note this contains bcftools/htslib 1.16!
     }
 
     call PreprocessPLsGVCF.PreprocessPLsGVCF as PreProcessGVCFs {


### PR DESCRIPTION
### Description

We ran into a number of issues when scale testing / our friends and family testing with OOM tasks causing 50002s and not being retried with more memory which caused a high percentage of our workflows to fail.  These change will make the 50002s less likely to happen.

We also saw some out of disk failures after reducing the disk in the previous version so bumping that up to a higher number

JIRA tickets:
https://broadworkbench.atlassian.net/browse/TSPS-1129
https://broadworkbench.atlassian.net/browse/TSPS-1024

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
