### PR TITLE
TSPS-1106 get rid of sample_names_map_file input 

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,7 +9,7 @@ Glimpse2LowPassImputation	 1.0.3	2026-07-28
 Glimpse2LowPassImputationBatch	 1.0.2	2026-07-28 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.6	2026-07-23 
+Glimpse2SVImputation	 0.0.7	2026-07-30 
 Glimpse2SVImputationBatch	 0.0.5	2026-07-23 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
@@ -22,7 +22,7 @@ Optimus	 9.2.0	2026-07-10
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.4	2026-07-21 
+PreprocessPLsGVCF	 0.0.5	2026-07-30 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.7
 2026-07-30 (Date of Last Commit)
 
-* rename entity_ids input to sample_names
+* rename entity_ids input to sample_ids
 * remove sample_names_map_file input as preprocess no longer uses it
 
 # 0.0.6

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.7
+2026-07-30 (Date of Last Commit)
+
+* rename entity_ids input to sample_names
+* remove sample_names_map_fine input as preprocess no longer uses it
+
 # 0.0.6
 2026-07-23 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -2,7 +2,7 @@
 2026-07-30 (Date of Last Commit)
 
 * rename entity_ids input to sample_names
-* remove sample_names_map_fine input as preprocess no longer uses it
+* remove sample_names_map_file input as preprocess no longer uses it
 
 # 0.0.6
 2026-07-23 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -12,11 +12,11 @@ workflow Glimpse2SVImputation {
         # inputs for Preprocessign wdl
         File? input_gvcfs_fofn
         File? input_gvcf_idxs_fofn
-        File? sample_names_file          # order of sample names must match that of gVCFs
+        File? sample_ids_file          # order of sample ids must match that of gVCFs
 
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? sample_names
+        Array[String]? sample_ids
 
         String output_prefix
 
@@ -46,10 +46,10 @@ workflow Glimpse2SVImputation {
         input:
         input_gvcfs_fofn = input_gvcfs_fofn,
         input_gvcf_idxs_fofn = input_gvcf_idxs_fofn,
-        sample_names_file = sample_names_file,
+        sample_ids_file = sample_ids_file,
         input_gvcfs = input_gvcfs,
         input_gvcf_idxs = input_gvcf_idxs,
-        sample_names = sample_names,
+        sample_ids = sample_ids,
         preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
         preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
         extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -16,9 +16,7 @@ workflow Glimpse2SVImputation {
 
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? entity_ids
-        File? sample_names_map_file           # TSV map of entity_id (research_id) to id2 for AoU DRAGEN gVCFs;
-                                              # Terra struggles with id2 as they are parsed as mixed strings/numbers
+        Array[String]? sample_names
 
         String output_prefix
 
@@ -51,8 +49,7 @@ workflow Glimpse2SVImputation {
         sample_names_file = sample_names_file,
         input_gvcfs = input_gvcfs,
         input_gvcf_idxs = input_gvcf_idxs,
-        entity_ids = entity_ids,
-        sample_names_map_file = sample_names_map_file,
+        sample_names = sample_names,
         preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
         preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
         extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,8 +4,8 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.6"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.4"
+    String pipeline_version = "0.0.7"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.5"
     String batch_pipeline_version = "0.0.5"
 
     input {

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.5
+2026-07-30 (Date of Last Commit)
+
+* remove sample_map_file input and associated logic/task to simplify the worklow a little
+
 # 0.0.4
 2026-07-21 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.5
 2026-07-30 (Date of Last Commit)
 
-* remove sample_map_file input and associated logic/task to simplify the worklow a little
+* remove sample_names_map_file input and associated logic/task to simplify the workflow a little
 
 # 0.0.4
 2026-07-21 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -4,7 +4,7 @@ import "./MultilevelHierarchicallyPasteVcfsStreaming.wdl" as MultilevelHierarchi
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.4"
+    String pipeline_version = "0.0.5"
     String multi_level_paste_pipeline_version = "0.0.3"
     input {
         File? input_gvcfs_fofn

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -9,11 +9,11 @@ workflow PreprocessPLsGVCF {
     input {
         File? input_gvcfs_fofn
         File? input_gvcf_idxs_fofn
-        File? sample_names_file          # order of sample names must match that of gVCFs
+        File? sample_ids_file          # order of sample names must match that of gVCFs
 
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? sample_names
+        Array[String]? sample_ids
 
         # inputs for PreprocessPLs
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
@@ -33,10 +33,10 @@ workflow PreprocessPLsGVCF {
     }
     Array[File] input_gvcf_idxs_ = select_first([input_gvcf_idxs, parsed_gvcf_idxs])
 
-    if (defined(sample_names_file)) {
-        Array[String] parsed_sample_names = read_lines(select_first([sample_names_file]))
+    if (defined(sample_ids_file)) {
+        Array[String] parsed_sample_ids = read_lines(select_first([sample_ids_file]))
     }
-    Array[String] sample_names_ = select_first([sample_names, parsed_sample_names])
+    Array[String] sample_ids_ = select_first([sample_ids, parsed_sample_ids])
 
     scatter (j in range(length(input_gvcfs_))) {
         call PreprocessPLs as PreprocessPLsGVCF {
@@ -46,8 +46,8 @@ workflow PreprocessPLsGVCF {
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-                sample_names = [sample_names_[j]],
-                output_prefix = ".sample-" + j + "." + sample_names_[j] + ".preprocessedPLs",
+                sample_names = [sample_ids_[j]],
+                output_prefix = ".sample-" + j + "." + sample_ids_[j] + ".preprocessedPLs",
                 extra_args = extract_bubble_likelihoods_extra_args
         }
     }

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -13,9 +13,7 @@ workflow PreprocessPLsGVCF {
 
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? entity_ids
-        File? sample_names_map_file           # TSV map of entity_id (research_id) to id2 for AoU DRAGEN gVCFs;
-        # Terra struggles with id2 as they are parsed as mixed strings/numbers
+        Array[String]? sample_names
 
         # inputs for PreprocessPLs
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
@@ -38,17 +36,7 @@ workflow PreprocessPLsGVCF {
     if (defined(sample_names_file)) {
         Array[String] parsed_sample_names = read_lines(select_first([sample_names_file]))
     }
-
-    # Replaced map scatter with a bash task call
-    if (defined(entity_ids) && defined(sample_names_map_file)) {
-        call MapSampleNames {
-            input:
-                entity_ids = select_first([entity_ids]),
-                sample_names_map_file = select_first([sample_names_map_file])
-        }
-    }
-
-    Array[String] sample_names_ = select_first([MapSampleNames.mapped_sample_names, parsed_sample_names])
+    Array[String] sample_names_ = select_first([sample_names, parsed_sample_names])
 
     scatter (j in range(length(input_gvcfs_))) {
         call PreprocessPLs as PreprocessPLsGVCF {
@@ -93,47 +81,6 @@ struct RuntimeAttr {
     Int? preemptible_tries
     Int? max_retries
     String? docker
-}
-
-task MapSampleNames {
-    input {
-        Array[String] entity_ids
-        File sample_names_map_file
-    }
-
-    command <<<
-        set -euo pipefail
-
-        # Use awk to load the TSV map into memory, then translate the entity IDs array in order
-        awk 'BEGIN {FS="\t"; OFS="\t"}
-        NR==FNR {
-            # First pass: read the map file into an array
-            map[$1] = $2;
-            next
-        }
-        {
-            # Second pass: read the entity_ids file
-            if ($1 in map) {
-                print map[$1]
-            } else {
-                print "Error: ID " $1 " not found in map file" > "/dev/stderr"
-                exit 1
-            }
-        }' ~{sample_names_map_file} ~{write_lines(entity_ids)} > mapped_names.txt
-    >>>
-
-    output {
-        Array[String] mapped_sample_names = read_lines("mapped_names.txt")
-    }
-
-    runtime {
-        docker: "ubuntu:22.04"
-        cpu: 1
-        memory: "4 GB"
-        disks: "local-disk 10 HDD"
-        preemptible: 3
-        noAddress: true
-    }
 }
 
 task PreprocessPLs {


### PR DESCRIPTION
### Description

There was some logic in the wdl that was really necessary for allowing a remapping file.  Instead we should just use the input sample name array/fofn that the user is already passing in for that.

Imputation run on this branch
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/259c3d85-2777-44ba-bce2-09c2db9cb91d

Comparison of bubble output
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/5de178c5-3adb-4f04-961d-fc3e82b74dfc


Comparison of popped output
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/014e1c34-df45-43de-954f-8dd9a3e0af74

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
