### PR TITLE
TSPS-1107 remove unused struct field

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,7 +9,7 @@ Glimpse2LowPassImputation	 1.0.3	2026-07-28
 Glimpse2LowPassImputationBatch	 1.0.2	2026-07-28 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.7	2026-07-30 
+Glimpse2SVImputation	 0.0.7	2026-07-30
 Glimpse2SVImputationBatch	 0.0.5	2026-07-23 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
@@ -22,7 +22,7 @@ Optimus	 9.2.0	2026-07-10
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.5	2026-07-30 
+PreprocessPLsGVCF	 0.0.5	2026-07-30
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.0.3	2026-07-28
 Glimpse2LowPassImputationBatch	 1.0.2	2026-07-28 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.7	2026-07-30
-Glimpse2SVImputationBatch	 0.0.5	2026-07-23 
+Glimpse2SVImputation	 0.0.8	2026-07-31 
+Glimpse2SVImputationBatch	 0.0.6	2026-07-31 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
@@ -22,7 +22,7 @@ Optimus	 9.2.0	2026-07-10
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.5	2026-07-30
+PreprocessPLsGVCF	 0.0.5	2026-07-30 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.8
+2026-07-31 (Date of Last Commit)
+
+* update batch_pipeline_version
+
 # 0.0.7
 2026-07-30 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,9 +4,9 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.7"
+    String pipeline_version = "0.0.8"
     String preprocess_pls_gvcf_pipeline_version = "0.0.5"
-    String batch_pipeline_version = "0.0.5"
+    String batch_pipeline_version = "0.0.6"
 
     input {
         # inputs for Preprocessign wdl

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.6
 2026-07-31 (Date of Last Commit)
 
-* removed unused field from ChunkedPanelChromosome struct
+* removed unused `chunks_tsv` field from `ChunkedPanelChromosome` struct
 
 # 0.0.5
 2026-07-23 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.6
+2026-07-31 (Date of Last Commit)
+
+* removed unused field from ChunkedPanelChromosome struct
+
 # 0.0.5
 2026-07-23 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.5"
+    String pipeline_version = "0.0.6"
     String concat_vcfs_pipeline_version = "0.0.3"
 
     input {
@@ -121,7 +121,6 @@ struct RuntimeAttr {
 }
 
 struct ChunkedPanelChromosome {
-    String chunks_tsv
     Array[String] input_regions
     Array[String] output_regions
     Array[String] panel_split_chunk_bins


### PR DESCRIPTION
### Description

The `chunks_tsv` field of the `ChunkedPanelChromosome` struct isnt used in the workflow at all so we can remove it.  If the json file contains the `chunks_tsv` cromwell will ignore it so no need to change the inputs.

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-1107

Successful submission on this branch (not running verification since this didnt touch anything about the workflow):  https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/dc5c569b-7e26-4676-a35d-c170d191b68d

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
