### PR TITLE
TSPS-1108 move reheadering commands into its own task

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.0.4	2026-08-01
 Glimpse2LowPassImputationBatch	 1.0.3	2026-08-01 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.11	2026-08-05
-Glimpse2SVImputationBatch	 0.0.9	2026-08-05
+Glimpse2SVImputation	 0.0.11	2026-08-05 
+Glimpse2SVImputationBatch	 0.0.9	2026-08-05 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.0.4	2026-08-01
 Glimpse2LowPassImputationBatch	 1.0.3	2026-08-01 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.10	2026-08-04 
-Glimpse2SVImputationBatch	 0.0.8	2026-08-04 
+Glimpse2SVImputation	 0.0.11	2026-08-05
+Glimpse2SVImputationBatch	 0.0.9	2026-08-05
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.11
+2026-08-05 (Date of Last Commit)
+
+* update batch_pipeline_version
+
 # 0.0.10
 2026-08-04 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -4,9 +4,9 @@ import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.10"
+    String pipeline_version = "0.0.11"
     String preprocess_pls_gvcf_pipeline_version = "0.0.6"
-    String batch_pipeline_version = "0.0.8"
+    String batch_pipeline_version = "0.0.9"
 
     input {
         # inputs for Preprocessign wdl

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -29,6 +29,7 @@ workflow Glimpse2SVImputation {
         # inputs for Batch wdl
         Array[String] chromosomes
         File genetic_maps_tsv
+        File ref_dict
         File chunked_panel_json
 
         String extra_phase_args = "--impute-reference-only-variants --keep-monomorphic-ref-sites --Kpbwt 1000 --main 10 --burnin 5 --err-imp 1E-3"
@@ -63,6 +64,7 @@ workflow Glimpse2SVImputation {
             input_preprocessed_joint_vcf_idx = PreProcessGVCFs.preprocessed_pls_vcf_idx,
             chromosomes = chromosomes,
             genetic_maps_tsv = genetic_maps_tsv,
+            ref_dict = ref_dict,
             chunked_panel_json = chunked_panel_json,
             extra_phase_args = extra_phase_args,
             output_prefix = output_prefix,

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.9
+2026-08-05 (Date of Last Commit)
+
+* move re-headering commands from glimpsephase task to their own task
+* add UpdateVcfSequenceDictionary to new reheadering task to keep contig header consistent across runs
+
 # 0.0.8
 2026-08-04 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -70,7 +70,7 @@ workflow Glimpse2SVImputationBatch {
             input:
                 phased_vcfs = ChunkedGLIMPSE2Phase.phased_vcf,
                 phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_vcf_idx,
-                output_prefix = output_prefix + ".glimpse2.bubble",
+                output_prefix = output_prefix + "." + chromosome + ".glimpse2.bubble",
                 docker = glimpse2_docker
         }
 
@@ -102,7 +102,7 @@ workflow Glimpse2SVImputationBatch {
             input:
                 vcfs = PopAndMarginalizeCollisions.popped_vcf,
                 vcf_idxs = PopAndMarginalizeCollisions.popped_vcf_idx,
-                output_prefix = output_prefix + ".glimpse2.popped",
+                output_prefix = output_prefix + "." + chromosome + ".glimpse2.popped",
                 do_bcf = true,
                 do_sort = false,
                 extra_args = "--threads $(nproc) --naive",
@@ -114,7 +114,7 @@ workflow Glimpse2SVImputationBatch {
 
     output {
         Array[File] glimpse2_bubble_posteriors_vcf = GLIMPSE2Ligate.ligated_vcf
-        Array[File] glimpse2_bubble_posteriors_vcf_idx =GLIMPSE2Ligate.ligated_vcf_idx
+        Array[File] glimpse2_bubble_posteriors_vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx
         Array[File] glimpse2_popped_posteriors_vcf =ConcatPopAndMarginalizeCollisions.concatenated_vcf
         Array[File] glimpse2_popped_posteriors_vcf_idx = ConcatPopAndMarginalizeCollisions.concatenated_vcf_idx
     }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -14,6 +14,7 @@ workflow Glimpse2SVImputationBatch {
         Array[String] chromosomes
         File genetic_maps_tsv
         File chunked_panel_json
+        File ref_dict
 
         String? extra_phase_args
         # override for cpu used for glimpse phase task. Mostly used to set to 1 for determinism in testing, defaults to 4
@@ -73,11 +74,21 @@ workflow Glimpse2SVImputationBatch {
                 docker = glimpse2_docker
         }
 
+        # Update VCF header with reference dictionary
+        call UpdateHeader {
+            input:
+                bcf_to_reheader = GLIMPSE2Ligate.ligated_vcf,
+                bcf_to_get_header_from = input_preprocessed_joint_vcf,
+                ref_dict = ref_dict,
+                output_basename = output_prefix  + ".glimpse2.bubble.updated_header",
+                docker = glimpse2_docker
+        }
+
         scatter (k in range(length(pop_regions))) {
             call PopAndMarginalizeCollisions {
                 input:
-                    posteriors_vcf = GLIMPSE2Ligate.ligated_vcf,
-                    posteriors_vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx,
+                    posteriors_vcf = UpdateHeader.output_bcf,
+                    posteriors_vcf_idx = UpdateHeader.output_bcf_index,
                     panel_bubble_split_sites_only_vcf = panel_bubble_split_sites_only_vcf,
                     panel_bubble_split_sites_only_vcf_idx = panel_bubble_split_sites_only_vcf_idx,
                     panel_id_split_vcf_gz = panel_id_split_vcf_gz,
@@ -173,7 +184,7 @@ task GLIMPSE2Phase {
                 --input-gl ~{input_vcf} \
                 -R ~{panel_split_chunk_bin} \
                 ~{extra_phase_args} \
-                --output ~{output_prefix}.raw.bcf \
+                --output ~{output_prefix}.bcf \
                 --threads ~{threads} \
                 --seed ~{seed} \
                 --checkpoint-file-out checkpoint.bin"
@@ -193,13 +204,7 @@ task GLIMPSE2Phase {
             exit 1
         fi
 
-        # take input VCF header and add GLIMPSE INFO and FORMAT lines (GLIMPSE header only contains a single chromosome and breaks bcftools concat --naive)
-        bcftools view --no-version -h ~{input_vcf} | grep '^##' > input.header.txt
-        bcftools view --no-version -h ~{output_prefix}.raw.bcf | grep -E '^##INFO|^##FORMAT|^##NMAIN|^##FPLOIDY' > glimpse2.header.txt
-        bcftools view --no-version -h ~{input_vcf} | grep '^#CHROM' > input.columns.txt
-        cat input.header.txt glimpse2.header.txt input.columns.txt > header.txt
-        bcftools reheader -h header.txt ~{output_prefix}.raw.bcf -o ~{output_prefix}.bcf
-        bcftools index ~{output_prefix}.bcf
+        bcftools index -f ~{output_prefix}.bcf
     >>>
 
     output {
@@ -283,7 +288,6 @@ task GLIMPSE2Ligate {
     }
 }
 
-
 task PopAndMarginalizeCollisions {
     input {
         # all VCFs should be split to biallelic
@@ -339,5 +343,60 @@ task PopAndMarginalizeCollisions {
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
         noAddress: true
+    }
+}
+
+task UpdateHeader {
+    input {
+        File bcf_to_reheader
+        File bcf_to_get_header_from
+        File ref_dict
+        String output_basename
+
+        Int mem_gb = 2
+        Int cpu = 1
+        Int disk_size_gb = ceil(2.1 * size(bcf_to_reheader, "GiB") + 10)
+        Int max_retries = 1
+        String docker
+    }
+
+    parameter_meta {
+        bcf_to_get_header_from : {
+            localization_optional : true
+        }
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        export GCS_OAUTH_TOKEN=$(/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
+
+        # Set correct reference dictionary
+
+        # take input VCF header and add GLIMPSE INFO and FORMAT lines (GLIMPSE header only contains a single chromosome and breaks bcftools concat --naive)
+        bcftools view --no-version -h ~{bcf_to_get_header_from} | grep '^##' > input.header.txt
+        bcftools view --no-version -h ~{bcf_to_reheader} | grep -E '^##INFO|^##FORMAT|^##NMAIN|^##FPLOIDY' > glimpse2.header.txt
+        bcftools view --no-version -h ~{bcf_to_reheader} | grep '^#CHROM' > glimpse2.columns.txt
+        cat input.header.txt glimpse2.header.txt glimpse2.columns.txt > header.vcf
+
+        java -jar /picard.jar UpdateVcfSequenceDictionary -I header.vcf --SD ~{ref_dict} -O updated_header.vcf
+
+        bcftools reheader -h updated_header.vcf ~{bcf_to_reheader} -o ~{output_basename}.bcf
+        bcftools index ~{output_basename}.bcf
+    >>>
+
+    runtime {
+        docker: docker
+        disks: "local-disk " + disk_size_gb + " SSD"
+        memory: mem_gb + " GiB"
+        cpu: cpu
+        maxRetries: max_retries
+        preemptible: 3
+        noAddress: true
+    }
+
+    output {
+        File output_bcf = "~{output_basename}.bcf"
+        File output_bcf_index = "~{output_basename}.bcf.csi"
     }
 }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -70,7 +70,7 @@ workflow Glimpse2SVImputationBatch {
             input:
                 phased_vcfs = ChunkedGLIMPSE2Phase.phased_vcf,
                 phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_vcf_idx,
-                output_prefix = output_prefix + "." + chromosome + ".glimpse2.bubble",
+                output_prefix = output_prefix + ".glimpse2.bubble",
                 docker = glimpse2_docker
         }
 
@@ -80,7 +80,7 @@ workflow Glimpse2SVImputationBatch {
                 bcf_to_reheader = GLIMPSE2Ligate.ligated_vcf,
                 bcf_to_get_header_from = input_preprocessed_joint_vcf,
                 ref_dict = ref_dict,
-                output_basename = output_prefix  + ".glimpse2.bubble.updated_header",
+                output_basename = output_prefix +  "." + chromosome + ".glimpse2.bubble.updated_header",
                 docker = glimpse2_docker
         }
 
@@ -113,8 +113,8 @@ workflow Glimpse2SVImputationBatch {
     }
 
     output {
-        Array[File] glimpse2_bubble_posteriors_vcf = GLIMPSE2Ligate.ligated_vcf
-        Array[File] glimpse2_bubble_posteriors_vcf_idx = GLIMPSE2Ligate.ligated_vcf_idx
+        Array[File] glimpse2_bubble_posteriors_vcf = UpdateHeader.output_bcf
+        Array[File] glimpse2_bubble_posteriors_vcf_idx = UpdateHeader.output_bcf_index
         Array[File] glimpse2_popped_posteriors_vcf =ConcatPopAndMarginalizeCollisions.concatenated_vcf
         Array[File] glimpse2_popped_posteriors_vcf_idx = ConcatPopAndMarginalizeCollisions.concatenated_vcf_idx
     }

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.8"
+    String pipeline_version = "0.0.9"
     String concat_vcfs_pipeline_version = "0.0.3"
 
     input {


### PR DESCRIPTION
### Description

there a number of commands that are being run in teh glimpse phase task that dont need to be.  we are moving these commands to a separate task because they dont need many resources at all and the glimpse phase machine is the largest in the wdl.  This should help with cost

Submission on this branch:
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/552b6195-899d-4757-8f92-cc2af7dceffd

Verifying bubble output:
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/41ccdf06-0947-4919-bcfd-5a14cf8f1d18

Verifying popped output:
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/07b55d5e-3fc1-4571-aac8-762594a86fe9

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
