### PR TITLE
TSPS-1039 SV imputation test fix: add ref_dict input

### DIFF
--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22.json
@@ -19,6 +19,7 @@
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
     "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],
     "Glimpse2SVImputation.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+    "Glimpse2SVImputation.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
     "Glimpse2SVImputation.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
     "Glimpse2SVImputation.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
     "Glimpse2SVImputation.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Scientific/3_samples_hgsvc_hprc_50_chr19-22.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Scientific/3_samples_hgsvc_hprc_50_chr19-22.json
@@ -19,6 +19,7 @@
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
     "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],
     "Glimpse2SVImputation.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+    "Glimpse2SVImputation.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
     "Glimpse2SVImputation.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
     "Glimpse2SVImputation.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
     "Glimpse2SVImputation.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -28,6 +28,7 @@ workflow TestGlimpse2SVImputation {
         # inputs for Batch wdl
         Array[String] chromosomes
         File genetic_maps_tsv
+        File ref_dict
         File chunked_panel_json
 
         String? extra_phase_args
@@ -66,6 +67,7 @@ workflow TestGlimpse2SVImputation {
         chromosomes = chromosomes,
         genetic_maps_tsv = genetic_maps_tsv,
         chunked_panel_json = chunked_panel_json,
+        ref_dict = ref_dict,
         extra_phase_args = extra_phase_args,
         glimpse_phase_cpu_override = glimpse_phase_cpu_override,
         pop_glimpse2_panel_resources_json = pop_glimpse2_panel_resources_json,


### PR DESCRIPTION
### Description


A [recent PR](https://github.com/broadinstitute/warp/pull/1909) added tests for the SV Imputation wdl, but right before it was merged, a new input (ref_dict) [was added](https://github.com/broadinstitute/warp/pull/1905) to the wdl and wasn't factored into the tests. Here we wire that new input in. 



### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
