### PR TITLE
TSPS-1045 add sample batching and removed bubble vcf output

### DIFF
--- a/.github/workflows/test_sv_imputation.yml
+++ b/.github/workflows/test_sv_imputation.yml
@@ -10,6 +10,7 @@ on:
     ####################################
     paths:
       - 'pipelines/wdl/glimpse/sv_imputation/**'
+      - 'tasks/wdl/Glimpse2SVImputationTasks.wdl'
       - 'verification/VerifyGlimpse2SVImputation.wdl'
       - 'verification/test-wdls/TestGlimpse2SVImputation.wdl'
       - 'verification/VerifyTasks.wdl'

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -5,12 +5,12 @@ ConcatVcfs	 0.0.3	2026-07-21
 CramToUnmappedBams	 1.1.3	2024-08-02 
 ExomeGermlineSingleSample	 3.2.8	2026-07-31 
 ExomeReprocessing	 3.3.8	2026-07-31 
-Glimpse2LowPassImputation	 1.0.4	2026-08-01 
+Glimpse2LowPassImputation	 1.0.5	2026-08-09 
 Glimpse2LowPassImputationBatch	 1.0.3	2026-08-01 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.12	2026-08-06 
-Glimpse2SVImputationBatch	 0.0.10	2026-08-06 
+Glimpse2SVImputation	 0.0.13	2026-08-09 
+Glimpse2SVImputationBatch	 0.0.11	2026-08-09 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.changelog.md
@@ -1,3 +1,8 @@
+# 1.0.5
+2026-08-09 (Date of Last Commit)
+
+* update tasks to have `noAddress: true`
+
 # 1.0.4
 2026-08-01 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
+++ b/pipelines/wdl/glimpse/low_pass_imputation/Glimpse2LowPassImputation.wdl
@@ -4,7 +4,7 @@ import "./Glimpse2LowPassImputationBatch.wdl" as Glimpse2LowPassImputationBatch
 import "../../../../tasks/wdl/Glimpse2LowPassImputationTasks.wdl" as Glimpse2LowPassImputationTasks
 
 workflow Glimpse2LowPassImputation {
-    String pipeline_version = "1.0.4"
+    String pipeline_version = "1.0.5"
     String batch_pipeline_version = "1.0.3"
     String quota_consumed_version = "1.0.0"
     String input_qc_version = "1.0.5"

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,12 @@
+# 0.0.13
+2026-08-09 (Date of Last Commit)
+
+* Add array-input sample batching for `input_gvcfs`, `input_gvcf_idxs`, and `sample_ids`.
+* Support FOFN input path (`input_gvcfs_fofn`, `input_gvcf_idxs_fofn`, `sample_ids_file`) as a single batch.
+* Run `PreprocessPLsGVCF` and `Glimpse2SVImputationBatch` per sample batch.
+* Merge per-chromosome popped outputs across batches and recompute cohort-level `AF` and `INFO`.
+* Emit only `glimpse2_popped_posteriors_vcf` outputs from the top-level workflow.
+
 # 0.0.12
 2026-08-06 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -2,11 +2,12 @@ version 1.0
 
 import "./PreprocessPLsGVCF.wdl" as PreprocessPLsGVCF
 import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
+import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.12"
+    String pipeline_version = "0.0.13"
     String preprocess_pls_gvcf_pipeline_version = "0.0.6"
-    String batch_pipeline_version = "0.0.10"
+    String batch_pipeline_version = "0.0.11"
 
     input {
         # inputs for Preprocessign wdl
@@ -17,6 +18,7 @@ workflow Glimpse2SVImputation {
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
         Array[String]? sample_ids
+        Int sample_batch_size = 500
 
         String output_prefix
 
@@ -41,44 +43,144 @@ workflow Glimpse2SVImputation {
         File pop_glimpse2_panel_resources_json
 
         String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771"
+        String merge_docker = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
+        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
     }
 
-    call PreprocessPLsGVCF.PreprocessPLsGVCF as PreProcessGVCFs {
-        input:
-        input_gvcfs_fofn = input_gvcfs_fofn,
-        input_gvcf_idxs_fofn = input_gvcf_idxs_fofn,
-        sample_ids_file = sample_ids_file,
-        input_gvcfs = input_gvcfs,
-        input_gvcf_idxs = input_gvcf_idxs,
-        sample_ids = sample_ids,
-        preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
-        preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-        extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,
-        paste_regions = paste_regions
+    # Determine which input path is being used
+    Boolean using_arrays = defined(input_gvcfs) && defined(input_gvcf_idxs) && defined(sample_ids)
+    Boolean using_fofns = defined(input_gvcfs_fofn) && defined(input_gvcf_idxs_fofn) && defined(sample_ids_file)
 
+    # If using FOFNs, wrap them as single-batch inputs; if using arrays, batch them
+    if (using_arrays) {
+        call Glimpse2SVImputationTasks.SplitGvcfInputsIntoBatches {
+            input:
+                input_gvcfs = select_first([input_gvcfs]),
+                input_gvcf_idxs = select_first([input_gvcf_idxs]),
+                sample_ids = select_first([sample_ids]),
+                batch_size = sample_batch_size
+        }
     }
 
-    call Glimpse2SVImputationBatch.Glimpse2SVImputationBatch {
-        input:
-            input_preprocessed_joint_vcf = PreProcessGVCFs.preprocessed_pls_vcf,
-            input_preprocessed_joint_vcf_idx = PreProcessGVCFs.preprocessed_pls_vcf_idx,
-            chromosomes = chromosomes,
-            genetic_maps_tsv = genetic_maps_tsv,
-            ref_dict = ref_dict,
-            chunked_panel_json = chunked_panel_json,
-            extra_phase_args = extra_phase_args,
-            output_prefix = output_prefix,
-            pop_glimpse2_panel_resources_json = pop_glimpse2_panel_resources_json,
-            glimpse2_docker = glimpse2_docker,
-            glimpse_phase_cpu_override = glimpse_phase_cpu_override
+    if (using_fofns) {
+        call WrapFofnsAsSingleBatch {
+            input:
+                input_gvcfs_fofn = select_first([input_gvcfs_fofn]),
+                input_gvcf_idxs_fofn = select_first([input_gvcf_idxs_fofn]),
+                sample_ids_file = select_first([sample_ids_file])
+        }
+    }
+
+    Array[File] gvcf_fofn_batches = select_first([SplitGvcfInputsIntoBatches.gvcf_fofn_batches, WrapFofnsAsSingleBatch.gvcf_fofn_batch])
+    Array[File] gvcf_idx_fofn_batches = select_first([SplitGvcfInputsIntoBatches.gvcf_idx_fofn_batches, WrapFofnsAsSingleBatch.gvcf_idx_fofn_batch])
+    Array[File] sample_ids_batches = select_first([SplitGvcfInputsIntoBatches.sample_ids_batches, WrapFofnsAsSingleBatch.sample_ids_batch])
+
+    scatter (batch_idx in range(length(gvcf_fofn_batches))) {
+        Int batch_num_samples = length(read_lines(sample_ids_batches[batch_idx]))
+
+        call PreprocessPLsGVCF.PreprocessPLsGVCF as PreProcessGVCFsBatch {
+            input:
+                input_gvcfs_fofn = gvcf_fofn_batches[batch_idx],
+                input_gvcf_idxs_fofn = gvcf_idx_fofn_batches[batch_idx],
+                sample_ids_file = sample_ids_batches[batch_idx],
+                preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
+                preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
+                extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,
+                paste_regions = paste_regions
+        }
+
+        call Glimpse2SVImputationBatch.Glimpse2SVImputationBatch as RunBatch {
+            input:
+                input_preprocessed_joint_vcf = PreProcessGVCFsBatch.preprocessed_pls_vcf,
+                input_preprocessed_joint_vcf_idx = PreProcessGVCFsBatch.preprocessed_pls_vcf_idx,
+                chromosomes = chromosomes,
+                genetic_maps_tsv = genetic_maps_tsv,
+                ref_dict = ref_dict,
+                chunked_panel_json = chunked_panel_json,
+                extra_phase_args = extra_phase_args,
+                output_prefix = output_prefix + ".batch_" + batch_idx,
+                pop_glimpse2_panel_resources_json = pop_glimpse2_panel_resources_json,
+                glimpse2_docker = glimpse2_docker,
+                glimpse_phase_cpu_override = glimpse_phase_cpu_override
+        }
+    }
+
+    scatter (contig_idx in range(length(chromosomes))) {
+        Array[File] popped_bcfs_for_contig = transpose(RunBatch.glimpse2_popped_posteriors_vcf)[contig_idx]
+        Array[File] popped_bcf_idxs_for_contig = transpose(RunBatch.glimpse2_popped_posteriors_vcf_idx)[contig_idx]
+
+        if (length(gvcf_fofn_batches) > 1) {
+            scatter (batch_annot_idx in range(length(popped_bcfs_for_contig))) {
+                call Glimpse2SVImputationTasks.ExtractAnnotations as ExtractPoppedAnnotations {
+                    input:
+                        imputed_vcf = popped_bcfs_for_contig[batch_annot_idx],
+                        imputed_vcf_index = popped_bcf_idxs_for_contig[batch_annot_idx],
+                        batch_index = batch_annot_idx,
+                        docker_extract_annotations = gatk_docker
+                }
+            }
+
+            call Glimpse2SVImputationTasks.MergeSampleChunksVcfsWithPaste as MergePoppedContigVcfs {
+                input:
+                    input_vcfs = popped_bcfs_for_contig,
+                    output_vcf_basename = output_prefix + "." + chromosomes[contig_idx] + ".glimpse2.popped.merged"
+            }
+
+            call Glimpse2SVImputationTasks.RecomputeAndAnnotate as RecomputePoppedAfInfo {
+                input:
+                    merged_vcf = MergePoppedContigVcfs.output_vcf,
+                    annotations = ExtractPoppedAnnotations.annotations,
+                    num_samples = batch_num_samples,
+                    output_basename = output_prefix + "." + chromosomes[contig_idx] + ".glimpse2.popped.merged.reannotated",
+                    docker_merge = merge_docker
+            }
+        }
+
+        File final_popped_contig_vcf = select_first([RecomputePoppedAfInfo.merged_imputed_vcf, popped_bcfs_for_contig[0]])
+
+        call Glimpse2SVImputationTasks.CreateVcfIndexAndMd5 as IndexFinalPoppedContig {
+            input:
+                vcf_input = final_popped_contig_vcf,
+                output_basename = output_prefix + "." + chromosomes[contig_idx],
+                gatk_docker = gatk_docker,
+                preemptible = 0
+        }
     }
 
     output {
-        Array[File] glimpse2_bubble_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf
-        Array[File] glimpse2_bubble_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_bubble_posteriors_vcf_idx
-        Array[File] glimpse2_popped_posteriors_vcf = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf
-        Array[File] glimpse2_popped_posteriors_vcf_idx = Glimpse2SVImputationBatch.glimpse2_popped_posteriors_vcf_idx
+        Array[File] glimpse2_popped_posteriors_vcf = IndexFinalPoppedContig.output_vcf
+        Array[File] glimpse2_popped_posteriors_vcf_idx = IndexFinalPoppedContig.output_vcf_index
     }
 }
 
+task WrapFofnsAsSingleBatch {
+    input {
+        File input_gvcfs_fofn
+        File input_gvcf_idxs_fofn
+        File sample_ids_file
+    }
 
+    command <<<
+        set -euo pipefail
+
+        # Copy FOFNs and sample IDs file as single-batch files with standardized naming
+        cp ~{input_gvcfs_fofn} gvcf_batch_0000.fofn
+        cp ~{input_gvcf_idxs_fofn} gvcf_idx_batch_0000.fofn
+        cp ~{sample_ids_file} sample_ids_batch_0000.txt
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        cpu: 1
+        memory: "1 GiB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        noAddress: true
+    }
+
+    output {
+        Array[File] gvcf_fofn_batch = glob("gvcf_batch_0000.fofn")
+        Array[File] gvcf_idx_fofn_batch = glob("gvcf_idx_batch_0000.fofn")
+        Array[File] sample_ids_batch = glob("sample_ids_batch_0000.txt")
+    }
+}

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.11
+2026-08-09 (Date of Last Commit)
+
+* increase Glimpse2Phase task disk size by 20GB
+
 # 0.0.10
 2026-08-06 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "./ConcatVcfs.wdl" as ConcatVcfs
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.10"
+    String pipeline_version = "0.0.11"
     String concat_vcfs_pipeline_version = "0.0.3"
 
     input {
@@ -173,7 +173,7 @@ task GLIMPSE2Phase {
         }
     }
 
-    Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 10)
+    Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 30)
 
     command <<<
         set -euxo pipefail

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/6_samples_hgsvc_hprc_50_chr19-22_batched.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/6_samples_hgsvc_hprc_50_chr19-22_batched.json
@@ -1,0 +1,37 @@
+{
+    "Glimpse2SVImputation.output_prefix": "6_samples_hgsvc_hprc_50_batched_plumbing_test",
+    "Glimpse2SVImputation.input_gvcfs": [
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21106.hard-filtered.vcf.gz",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00405.haplotypeCalls.er.raw.vcf.gz",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00408.haplotypeCalls.er.raw.vcf.gz",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00418.haplotypeCalls.er.raw.vcf.gz"
+    ],
+    "Glimpse2SVImputation.input_gvcf_idxs": [
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21106.hard-filtered.vcf.gz.tbi",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz.tbi",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz.tbi",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00405.haplotypeCalls.er.raw.vcf.gz.tbi",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00408.haplotypeCalls.er.raw.vcf.gz.tbi",
+        "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00418.haplotypeCalls.er.raw.vcf.gz.tbi"
+    ],
+    "Glimpse2SVImputation.sample_ids": [
+        "NA21106", 
+        "NA21110",
+        "NA21144",
+        "HG00405",
+        "HG00408",
+        "HG00418"
+    ],
+    "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
+    "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
+    "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],
+    "Glimpse2SVImputation.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+    "Glimpse2SVImputation.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+    "Glimpse2SVImputation.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
+    "Glimpse2SVImputation.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
+    "Glimpse2SVImputation.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",
+    "Glimpse2SVImputation.glimpse_phase_cpu_override": 1,
+    "Glimpse2SVImputation.sample_batch_size": 3
+}

--- a/tasks/wdl/Glimpse2LowPassImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2LowPassImputationTasks.wdl
@@ -107,6 +107,7 @@ task ExtractAnnotations {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        noAddress: true
     }
 
     output {
@@ -132,6 +133,8 @@ task RecomputeAndAnnotate {
     }
 
     command <<<
+        set -euo pipefail
+
         cat <<EOF > script.py
 import pandas as pd
 import numpy as np
@@ -197,6 +200,7 @@ EOF
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        noAddress: true
     }
 
     output {
@@ -239,6 +243,7 @@ task MergeQCMetrics {
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
+        noAddress: true
     }
 }
 

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -1,0 +1,332 @@
+version 1.0
+
+task MergeSampleChunksVcfsWithPaste {
+    input {
+        Array[File] input_vcfs
+        String output_vcf_basename
+
+        Int disk_size_gb = ceil(2.2 * size(input_vcfs, "GiB") + 50)
+        Int mem_gb = 8
+        Int cpu = 4
+        Int preemptible = 0
+    }
+
+    command <<<
+        set -euo pipefail
+
+        vcfs=(~{sep=" " input_vcfs})
+
+        mkfifo fifo_0
+        mkfifo fifo_to_paste_0
+
+        i=1
+
+        fifos_to_paste=()
+        md5sums=()
+        # Keep only meta header lines here. The #CHROM line is merged in the paste stream.
+        bcftools view -h --no-version ${vcfs[0]} | awk '!/^#CHROM/' > header.vcf
+        n_lines=$(wc -l header.vcf | cut -d' ' -f1)
+
+        mkfifo fifo_to_md5_0
+
+        # Stream starting at #CHROM so sample-name columns are merged across batches.
+        bcftools view --no-version ${vcfs[0]} > fifo_0 &
+        tail +$((n_lines)) fifo_0 | tee fifo_to_md5_0 > fifo_to_paste_0 &
+        tail -n +2 fifo_to_md5_0 | cut -f1-5,9 | md5sum > md5sum_0 &
+
+        for vcf in "${vcfs[@]:1}"; do
+        fifo_name="fifo_$i"
+        mkfifo "$fifo_name"
+
+        fifo_name_to_md5="fifo_to_md5_$i"
+        mkfifo "$fifo_name_to_md5"
+
+        fifo_name_to_paste="fifo_to_paste_$i"
+        mkfifo "$fifo_name_to_paste"
+        fifos_to_paste+=("$fifo_name_to_paste")
+
+        file_name_md5sum="md5sum_$i"
+        md5sums+=("$file_name_md5sum")
+        n_lines=$(bcftools view -h --no-version $vcf | awk '!/^#CHROM/' | wc -l | cut -d' ' -f1)
+
+        bcftools view --no-version $vcf > "$fifo_name" &
+        tail +$((n_lines)) "$fifo_name" | tee "$fifo_name_to_md5" | cut -f 10- > "$fifo_name_to_paste" &
+        tail -n +2 "$fifo_name_to_md5" | cut -f1-5,9 | md5sum > "$file_name_md5sum" &
+
+        ((i++))
+        done
+
+        mkfifo fifo_to_cat
+
+        paste fifo_to_paste_0 "${fifos_to_paste[@]}" | tee fifo_to_cat | awk 'NR % 5000000 == 0' | cut -f 1-5 &
+
+        cat header.vcf fifo_to_cat | bgzip -o ~{output_vcf_basename}.vcf.gz
+
+        for md5sum_file in "${md5sums[@]}"; do
+        diff <(cat md5sum_0) <(cat $md5sum_file) >> /dev/null || (echo "Fields 1-5,9 do not match for $md5sum_file" && exit 1)
+        done
+
+        for fifo in fifo_*; do
+        rm $fifo
+        done
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/bcftools_bgzip:beagle_imputation_v1.0.0"
+        disks: "local-disk " + disk_size_gb + " HDD"
+        memory: mem_gb + " GiB"
+        cpu: cpu
+        preemptible: preemptible
+        maxRetries: 1
+        noAddress: true
+    }
+
+    output {
+        File output_vcf = "~{output_vcf_basename}.vcf.gz"
+    }
+}
+
+task ExtractAnnotations {
+    input {
+        File imputed_vcf
+        File imputed_vcf_index
+        Int batch_index
+
+        String docker_extract_annotations
+        Int disk_size_gb = ceil(2 * size(imputed_vcf, "GiB") + 50)
+        Int mem_gb = 2
+        Int cpu = 1
+        Int preemptible = 1
+    }
+
+    command <<<
+        set -euo pipefail
+
+        # Ensure index is localized so bcftools can use it for random access if needed
+        ls ~{imputed_vcf_index} > /dev/null
+
+        printf 'CHROM\tPOS\tREF\tALT\tAF\tINFO\n' > annotations_batch_~{batch_index}.tsv
+        bcftools query \
+        -f '%CHROM\t%POS\t%REF\t%ALT\t%INFO/AF\t%INFO/INFO\n' \
+        ~{imputed_vcf} >> annotations_batch_~{batch_index}.tsv
+
+        bgzip annotations_batch_~{batch_index}.tsv
+    >>>
+
+    runtime {
+        docker: docker_extract_annotations
+        disks: "local-disk " + disk_size_gb + " HDD"
+        memory: mem_gb + " GiB"
+        cpu: cpu
+        preemptible: preemptible
+        noAddress: true
+    }
+
+    output {
+        File annotations = "annotations_batch_~{batch_index}.tsv.gz"
+    }
+}
+
+task RecomputeAndAnnotate {
+    input {
+        File merged_vcf
+        Array[File] annotations
+
+        Array[Int] num_samples
+
+        String output_basename
+
+        String docker_merge
+        Int disk_size_gb = ceil(2.2 * size(merged_vcf, "GiB") + size(annotations, "GiB") + 50)
+        Int mem_gb = 6
+        Int cpu = 1
+        Int preemptible = 0
+        Int chunk_size = 100000
+    }
+
+    command <<<
+        set -euo pipefail
+
+        cat <<EOF > script.py
+import pandas as pd
+import numpy as np
+
+input_filenames = ['~{sep="', '" annotations}']
+num_samples = [~{sep=", " num_samples}]
+if len(num_samples) != len(input_filenames):
+    raise RuntimeError('The number of input annotations does not match the number of input number of samples.')
+
+total_samples = sum(num_samples)
+num_batches = len(input_filenames)
+chunk_size = ~{chunk_size}
+
+# Stream all annotation files in parallel chunks rather than loading everything into memory at once.
+# This keeps memory usage proportional to chunk_size * num_batches rather than total_sites * num_batches.
+readers = [pd.read_csv(f, sep='\t', chunksize=chunk_size) for f in input_filenames]
+
+with open('aggregated_annotations.tsv', 'w') as out:
+    for chunks in zip(*readers):
+        # Validate that all batches have identical sites for this chunk
+        ref_loci = chunks[0][['CHROM', 'POS', 'REF', 'ALT']].reset_index(drop=True)
+        for i, chunk in enumerate(chunks[1:], 1):
+            if not ref_loci.equals(chunk[['CHROM', 'POS', 'REF', 'ALT']].reset_index(drop=True)):
+                raise RuntimeError(f'Sites in chunk do not match between batch 0 and batch {i}. '
+                                   f'First mismatch at: {ref_loci[~ref_loci.eq(chunk[["CHROM","POS","REF","ALT"]].reset_index(drop=True)).all(axis=1)].head(1).to_dict("records")}')
+
+        # Vectorized weighted AF across batches
+        agg_af = sum(chunks[i]['AF'].values * num_samples[i] for i in range(num_batches)) / total_samples
+
+        # Vectorized weighted INFO across batches
+        numerator = sum(
+            (1 - chunks[i]['INFO'].values) * 2 * num_samples[i] * chunks[i]['AF'].values * (1 - chunks[i]['AF'].values)
+            for i in range(num_batches)
+        )
+        denominator = 2 * total_samples * agg_af * (1 - agg_af)
+        # INFO is defined as 1 for monomorphic sites (AF == 0 or AF == 1)
+        polymorphic = (agg_af != 0) & (agg_af != 1)
+        agg_info = np.where(polymorphic, 1 - np.divide(numerator, denominator, where=polymorphic, out=np.zeros_like(denominator)), 1.0)
+
+        def round_to_n_sig_figs(x, n):
+            if x == 0:
+                return 0.0
+            return round(float(x), n - 1 - int(np.floor(np.log10(abs(x)))))
+
+        result = ref_loci.copy()
+        # Cap INFO and AF values at 3 sig-figs to avoid blowing up the output file size w/ overprecision
+        result['AF'] = np.vectorize(round_to_n_sig_figs)(agg_af, 3)
+        result['INFO'] = np.vectorize(round_to_n_sig_figs)(agg_info, 3)
+        result.to_csv(out, sep='\t', header=False, index=False)
+
+EOF
+        python3 script.py
+
+        bgzip aggregated_annotations.tsv
+        tabix -s1 -b2 -e2 aggregated_annotations.tsv.gz
+
+        bcftools annotate -a aggregated_annotations.tsv.gz -c CHROM,POS,REF,ALT,AF,INFO -O z -o ~{output_basename}.vcf.gz ~{merged_vcf}
+    >>>
+
+    runtime {
+        docker: docker_merge
+        disks: "local-disk " + disk_size_gb + " HDD"
+        memory: mem_gb + " GiB"
+        cpu: cpu
+        preemptible: preemptible
+        noAddress: true
+    }
+
+    output {
+        File merged_imputed_vcf = "~{output_basename}.vcf.gz"
+        File aggregated_annotations = "aggregated_annotations.tsv.gz"
+    }
+}
+
+task CreateVcfIndexAndMd5 {
+    input {
+        File vcf_input
+        String output_basename
+
+        Int disk_size_gb = ceil(2.1*size(vcf_input, "GiB")) + 10
+        Int cpu = 1
+        Int memory_mb = 6000
+        String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        Int preemptible = 3
+    }
+
+    command <<<
+        set -euo pipefail
+
+        if [[ "~{vcf_input}" == *.bcf ]]; then
+            # Normalize BCF input to a bgzipped VCF for downstream compatibility.
+            bcftools view -O z -o ~{output_basename}.vcf.gz ~{vcf_input}
+        else
+            ln -sf ~{vcf_input} ~{output_basename}.vcf.gz
+        fi
+
+        bcftools index -t ~{output_basename}.vcf.gz
+
+        md5sum ~{output_basename}.vcf.gz | awk '{ print $1 }' > ~{output_basename}.md5sum
+    >>>
+    runtime {
+        docker: gatk_docker
+        disks: "local-disk ${disk_size_gb} SSD"
+        memory: "${memory_mb} MiB"
+        cpu: cpu
+        preemptible: preemptible
+        maxRetries: 1
+        noAddress: true
+    }
+    output {
+        File output_vcf = "~{output_basename}.vcf.gz"
+        File output_vcf_index = "~{output_basename}.vcf.gz.tbi"
+        File output_vcf_md5sum = "~{output_basename}.md5sum"
+    }
+}
+
+task SplitGvcfInputsIntoBatches {
+    input {
+        Array[String] input_gvcfs
+        Array[String] input_gvcf_idxs
+        Array[String] sample_ids
+        Int batch_size
+    }
+
+    command <<<
+        set -euo pipefail
+
+        cat <<EOF > script.py
+import sys
+
+gvcfs = ['~{sep="', '" input_gvcfs}']
+gvcf_idxs = ['~{sep="', '" input_gvcf_idxs}']
+sample_ids = ['~{sep="', '" sample_ids}']
+batch_size = ~{batch_size}
+
+if not (len(gvcfs) == len(gvcf_idxs) == len(sample_ids)):
+    print(
+        f"input_gvcfs ({len(gvcfs)}), input_gvcf_idxs ({len(gvcf_idxs)}), and sample_ids ({len(sample_ids)}) must have identical lengths.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if batch_size < 1:
+    print(f"batch_size must be > 0, got {batch_size}", file=sys.stderr)
+    sys.exit(1)
+
+batch_num = 0
+for i in range(0, len(gvcfs), batch_size):
+    gvcf_chunk = gvcfs[i : i + batch_size]
+    gvcf_idx_chunk = gvcf_idxs[i : i + batch_size]
+    sample_id_chunk = sample_ids[i : i + batch_size]
+
+    with open(f"gvcf_batch_{batch_num:04d}.fofn", "w") as gvcf_out:
+        gvcf_out.write("\n".join(gvcf_chunk) + "\n")
+
+    with open(f"gvcf_idx_batch_{batch_num:04d}.fofn", "w") as idx_out:
+        idx_out.write("\n".join(gvcf_idx_chunk) + "\n")
+
+    with open(f"sample_ids_batch_{batch_num:04d}.txt", "w") as sample_out:
+        sample_out.write("\n".join(sample_id_chunk) + "\n")
+
+    batch_num += 1
+EOF
+        python3 script.py
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        cpu: 1
+        memory: "1 GiB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        noAddress: true
+    }
+
+    output {
+        Array[File] gvcf_fofn_batches = glob("gvcf_batch_*.fofn")
+        Array[File] gvcf_idx_fofn_batches = glob("gvcf_idx_batch_*.fofn")
+        Array[File] sample_ids_batches = glob("sample_ids_batch_*.txt")
+    }
+}
+

--- a/verification/VerifyGlimpse2SVImputation.wdl
+++ b/verification/VerifyGlimpse2SVImputation.wdl
@@ -20,10 +20,6 @@ import "../verification/VerifyTasks.wdl" as Tasks
 
 workflow VerifyGlimpse2SVImputation {
   input {
-    # bubble posteriors vcf, one per chromosome
-    Array[File] truth_bubble_posteriors_vcf
-    Array[File] test_bubble_posteriors_vcf
-
     # popped posteriors vcf, one per chromosome
     Array[File] truth_popped_posteriors_vcf
     Array[File] test_popped_posteriors_vcf
@@ -31,13 +27,6 @@ workflow VerifyGlimpse2SVImputation {
     Boolean? done
   }
 
-  scatter (idx in range(length(truth_bubble_posteriors_vcf))) {
-    call Tasks.CompareVcfs as CompareBubblePosteriorsVcfs {
-      input:
-        file1 = truth_bubble_posteriors_vcf[idx],
-        file2 = test_bubble_posteriors_vcf[idx]
-    }
-  }
 
   scatter (idx in range(length(truth_popped_posteriors_vcf))) {
     call Tasks.CompareVcfs as ComparePoppedPosteriorsVcfs {

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -17,6 +17,8 @@ workflow TestGlimpse2SVImputation {
         Array[File]? input_gvcf_idxs
         Array[String]? sample_ids
 
+        Int sample_batch_size = 500
+
         String output_prefix
 
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
@@ -59,6 +61,7 @@ workflow TestGlimpse2SVImputation {
         input_gvcfs = input_gvcfs,
         input_gvcf_idxs = input_gvcf_idxs,
         sample_ids = sample_ids,
+        sample_batch_size = sample_batch_size,
         output_prefix = output_prefix,
         preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
         preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -75,10 +75,8 @@ workflow TestGlimpse2SVImputation {
     }
 
 
-    # Collect all of the pipeline outputs into single Array[String]
+    # Collect all pipeline outputs into a single Array[String]
     Array[String] pipeline_outputs = flatten([
-                                    Glimpse2SVImputation.glimpse2_bubble_posteriors_vcf,
-                                    Glimpse2SVImputation.glimpse2_bubble_posteriors_vcf_idx,
                                     Glimpse2SVImputation.glimpse2_popped_posteriors_vcf,
                                     Glimpse2SVImputation.glimpse2_popped_posteriors_vcf_idx
     ])
@@ -101,12 +99,6 @@ workflow TestGlimpse2SVImputation {
 
     # This is achieved by passing each desired file/array[files] to GetValidationInputs
     if (!update_truth){
-        call Utilities.GetValidationInputs as GetBubblePosteriorsVcfs {
-          input:
-            input_files = Glimpse2SVImputation.glimpse2_bubble_posteriors_vcf,
-            results_path = results_path,
-            truth_path = truth_path
-        }
         call Utilities.GetValidationInputs as GetPoppedPosteriorsVcfs {
           input:
             input_files = Glimpse2SVImputation.glimpse2_popped_posteriors_vcf,
@@ -116,8 +108,6 @@ workflow TestGlimpse2SVImputation {
 
       call VerifyGlimpse2SVImputation.VerifyGlimpse2SVImputation as Verify {
         input:
-          truth_bubble_posteriors_vcf = GetBubblePosteriorsVcfs.truth_files,
-          test_bubble_posteriors_vcf = GetBubblePosteriorsVcfs.results_files,
           truth_popped_posteriors_vcf = GetPoppedPosteriorsVcfs.truth_files,
           test_popped_posteriors_vcf = GetPoppedPosteriorsVcfs.results_files,
           done = CopyToTestResults.done


### PR DESCRIPTION
### Description

in order to make the sv imputation pipeline scale, we want to be able to batch the inputs.  This allows us to better optimize each task in each batch better and lower the overall cost.

The PR also changes the output of the pipeline to a vcf file from a bcf file

document going through the evaluation of these batch changes - https://docs.google.com/document/d/1CAkXO-JBhN9usAraFT2UC-vozTwP-xSYI8awJywluOE/edit?tab=t.0

Jira ticket:  https://broadworkbench.atlassian.net/browse/TSPS-1045 and https://broadworkbench.atlassian.net/browse/TSPS-1114

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
