### PR TITLE
TSPS-1111 add in vcf manifest input option to sv imputation wdl

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -22,7 +22,7 @@ Optimus	 9.2.0	2026-07-10
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.6	2026-08-04 
+PreprocessPLsGVCF	 0.0.7	2026-08-11 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,7 +9,7 @@ Glimpse2LowPassImputation	 1.0.5	2026-08-09
 Glimpse2LowPassImputationBatch	 1.0.3	2026-08-01 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.14	2026-08-11 
+Glimpse2SVImputation	 0.0.15	2026-08-12 
 Glimpse2SVImputationBatch	 0.0.11	2026-08-09 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,7 +1,7 @@
 # 0.0.15
 2026-08-12 (Date of Last Commit)
 
-* Replace top-level FOFN inputs with a `gvcf_manifest` input that expects `gvcf_path`, `gvcf_index_path`, and `sample_id` columns.
+* Replace top-level FOFN inputs with a `gvcf_manifest` input that expects `gvcf_path`, `gvcf_index_path`, and `sample_id` columns to exist.
 * Batch samples from the manifest, while still converting array inputs into a manifest internally for compatibility.
 * Pass each manifest batch directly into `PreprocessPLsGVCF`, which now parses the manifest internally.
 * Use the sample count emitted by `PreprocessPLsGVCF` instead of counting manifest rows in the top-level workflow.

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,11 @@
+# 0.0.15
+2026-08-12 (Date of Last Commit)
+
+* Replace top-level FOFN inputs with a `gvcf_manifest` input that expects `gvcf_path`, `gvcf_index_path`, and `sample_id` columns.
+* Batch samples from the manifest, while still converting array inputs into a manifest internally for compatibility.
+* Pass each manifest batch directly into `PreprocessPLsGVCF`, which now parses the manifest internally.
+* Use the sample count emitted by `PreprocessPLsGVCF` instead of counting manifest rows in the top-level workflow.
+
 # 0.0.14
 2026-08-11 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,19 +5,16 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.14"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.6"
+    String pipeline_version = "0.0.15"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.7"
     String batch_pipeline_version = "0.0.11"
 
     input {
-        # inputs for Preprocessign wdl
-        File? input_gvcfs_fofn
-        File? input_gvcf_idxs_fofn
-        File? sample_ids_file          # order of sample ids must match that of gVCFs
-
+        # if both array inputs and gvcf_manifest are provided, array inputs take precedence
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
         Array[String]? sample_ids
+        File? gvcf_manifest
         Int sample_batch_size = 500
 
         String output_prefix
@@ -50,42 +47,30 @@ workflow Glimpse2SVImputation {
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
     }
 
-    # Determine which input path is being used
     Boolean using_arrays = defined(input_gvcfs) && defined(input_gvcf_idxs) && defined(sample_ids)
-    Boolean using_fofns = defined(input_gvcfs_fofn) && defined(input_gvcf_idxs_fofn) && defined(sample_ids_file)
 
-    # If using FOFNs, wrap them as single-batch inputs; if using arrays, batch them
     if (using_arrays) {
-        call Glimpse2SVImputationTasks.SplitGvcfInputsIntoBatches {
+        call Glimpse2SVImputationTasks.ConvertInputArraysToManifest {
             input:
-                input_gvcfs = select_first([input_gvcfs]),
-                input_gvcf_idxs = select_first([input_gvcf_idxs]),
-                sample_ids = select_first([sample_ids]),
-                batch_size = sample_batch_size
+                gvcf_paths = select_first([input_gvcfs]),
+                gvcf_index_paths = select_first([input_gvcf_idxs]),
+                sample_ids = select_first([sample_ids])
         }
     }
 
-    if (using_fofns) {
-        call WrapFofnsAsSingleBatch {
-            input:
-                input_gvcfs_fofn = select_first([input_gvcfs_fofn]),
-                input_gvcf_idxs_fofn = select_first([input_gvcf_idxs_fofn]),
-                sample_ids_file = select_first([sample_ids_file])
-        }
+    # if neither the full array input set nor gvcf_manifest is provided the workflow will fail at runtime
+    File gvcf_manifest_to_use = select_first([ConvertInputArraysToManifest.output_manifest, gvcf_manifest])
+
+    call Glimpse2SVImputationTasks.SplitVcfManifestIntoBatches as SplitIntoSampleBatches {
+        input:
+            batch_size = sample_batch_size,
+            gvcf_manifest = gvcf_manifest_to_use
     }
 
-    Array[File] gvcf_fofn_batches = select_first([SplitGvcfInputsIntoBatches.gvcf_fofn_batches, WrapFofnsAsSingleBatch.gvcf_fofn_batch])
-    Array[File] gvcf_idx_fofn_batches = select_first([SplitGvcfInputsIntoBatches.gvcf_idx_fofn_batches, WrapFofnsAsSingleBatch.gvcf_idx_fofn_batch])
-    Array[File] sample_ids_batches = select_first([SplitGvcfInputsIntoBatches.sample_ids_batches, WrapFofnsAsSingleBatch.sample_ids_batch])
-
-    scatter (batch_idx in range(length(gvcf_fofn_batches))) {
-        Int batch_num_samples = length(read_lines(sample_ids_batches[batch_idx]))
-
+    scatter (batch_idx in range(length(SplitIntoSampleBatches.gvcf_manifest_batches))) {
         call PreprocessPLsGVCF.PreprocessPLsGVCF as PreProcessGVCFsBatch {
             input:
-                input_gvcfs_fofn = gvcf_fofn_batches[batch_idx],
-                input_gvcf_idxs_fofn = gvcf_idx_fofn_batches[batch_idx],
-                sample_ids_file = sample_ids_batches[batch_idx],
+                input_gvcf_manifest = SplitIntoSampleBatches.gvcf_manifest_batches[batch_idx],
                 preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 preprocess_panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
                 extract_bubble_likelihoods_extra_args = extract_bubble_likelihoods_extra_args,
@@ -112,7 +97,7 @@ workflow Glimpse2SVImputation {
         Array[File] popped_bcfs_for_contig = transpose(RunBatch.glimpse2_popped_posteriors_vcf)[contig_idx]
         Array[File] popped_bcf_idxs_for_contig = transpose(RunBatch.glimpse2_popped_posteriors_vcf_idx)[contig_idx]
 
-        if (length(gvcf_fofn_batches) > 1) {
+        if (length(SplitIntoSampleBatches.gvcf_manifest_batches) > 1) {
             scatter (batch_annot_idx in range(length(popped_bcfs_for_contig))) {
                 call Glimpse2SVImputationTasks.ExtractAnnotations as ExtractPoppedAnnotations {
                     input:
@@ -133,7 +118,7 @@ workflow Glimpse2SVImputation {
                 input:
                     merged_vcf = MergePoppedContigVcfs.output_vcf,
                     annotations = ExtractPoppedAnnotations.annotations,
-                    num_samples = batch_num_samples,
+                    num_samples = PreProcessGVCFsBatch.num_samples,
                     output_basename = output_prefix + "." + chromosomes[contig_idx] + ".glimpse2.popped.merged.reannotated",
                     docker_merge = merge_docker
             }
@@ -167,34 +152,3 @@ workflow Glimpse2SVImputation {
     }
 }
 
-task WrapFofnsAsSingleBatch {
-    input {
-        File input_gvcfs_fofn
-        File input_gvcf_idxs_fofn
-        File sample_ids_file
-    }
-
-    command <<<
-        set -euo pipefail
-
-        # Copy FOFNs and sample IDs file as single-batch files with standardized naming
-        cp ~{input_gvcfs_fofn} gvcf_batch_0000.fofn
-        cp ~{input_gvcf_idxs_fofn} gvcf_idx_batch_0000.fofn
-        cp ~{sample_ids_file} sample_ids_batch_0000.txt
-    >>>
-
-    runtime {
-        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
-        cpu: 1
-        memory: "1 GiB"
-        disks: "local-disk 10 HDD"
-        preemptible: 3
-        noAddress: true
-    }
-
-    output {
-        Array[File] gvcf_fofn_batch = glob("gvcf_batch_0000.fofn")
-        Array[File] gvcf_idx_fofn_batch = glob("gvcf_idx_batch_0000.fofn")
-        Array[File] sample_ids_batch = glob("sample_ids_batch_0000.txt")
-    }
-}

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.7
+2026-08-11 (Date of Last Commit)
+
+* Replace per-sample array and FOFN inputs with a single `gvcf_manifest` input that is then parsed inside the workflow.
+* Emit the parsed sample count so callers can use it directly without re-counting manifest rows.
+
 # 0.0.6
 2026-08-04 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -1,19 +1,14 @@
 version 1.0
 
 import "./MultilevelHierarchicallyPasteVcfsStreaming.wdl" as MultilevelHierarchicallyPasteVcfsStreaming
+import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.6"
+    String pipeline_version = "0.0.7"
     String multi_level_paste_pipeline_version = "0.0.3"
     input {
-        File? input_gvcfs_fofn
-        File? input_gvcf_idxs_fofn
-        File? sample_ids_file          # order of sample names must match that of gVCFs
-
-        Array[File]? input_gvcfs
-        Array[File]? input_gvcf_idxs
-        Array[String]? sample_ids
+        File input_gvcf_manifest
 
         # inputs for PreprocessPLs
         File preprocess_panel_bubble_split_sites_only_vcf       # can be subset of panel, e.g., simple bubble alleles only
@@ -23,31 +18,21 @@ workflow PreprocessPLsGVCF {
         Array[String] paste_regions
     }
 
-    if (defined(input_gvcfs_fofn)) {
-        Array[File] parsed_gvcfs = read_lines(select_first([input_gvcfs_fofn]))
+    call Glimpse2SVImputationTasks.ParseVcfManifestIntoArrays as ParseInputManifest {
+        input:
+            gvcf_manifest = input_gvcf_manifest
     }
-    Array[File] input_gvcfs_ = select_first([input_gvcfs, parsed_gvcfs])
 
-    if (defined(input_gvcf_idxs_fofn)) {
-        Array[File] parsed_gvcf_idxs = read_lines(select_first([input_gvcf_idxs_fofn]))
-    }
-    Array[File] input_gvcf_idxs_ = select_first([input_gvcf_idxs, parsed_gvcf_idxs])
-
-    if (defined(sample_ids_file)) {
-        Array[String] parsed_sample_ids = read_lines(select_first([sample_ids_file]))
-    }
-    Array[String] sample_ids_ = select_first([sample_ids, parsed_sample_ids])
-
-    scatter (j in range(length(input_gvcfs_))) {
+    scatter (j in range(length(ParseInputManifest.input_gvcfs))) {
         call PreprocessPLs as PreprocessPLsGVCF {
             input:
-                input_vcf = input_gvcfs_[j],
-                input_vcf_idx = input_gvcf_idxs_[j],
+                input_vcf = ParseInputManifest.input_gvcfs[j],
+                input_vcf_idx = ParseInputManifest.input_gvcf_idxs[j],
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-                sample_names = [sample_ids_[j]],
-                output_prefix = "sample-" + j + "." + sample_ids_[j] + ".preprocessedPLs",
+                sample_names = [ParseInputManifest.sample_ids[j]],
+                output_prefix = "sample-" + j + "." + ParseInputManifest.sample_ids[j] + ".preprocessedPLs",
                 extra_args = extract_bubble_likelihoods_extra_args
         }
     }
@@ -69,6 +54,7 @@ workflow PreprocessPLsGVCF {
     output {
         File preprocessed_pls_vcf = PastePreprocessPLsGVCFs.merged_vcf
         File preprocessed_pls_vcf_idx = PastePreprocessPLsGVCFs.merged_vcf_idx
+        Int num_samples = length(ParseInputManifest.sample_ids)
     }
 }
 

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_manifest_hgsvc_hprc_50_chr19-22.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_manifest_hgsvc_hprc_50_chr19-22.json
@@ -1,0 +1,13 @@
+{
+    "Glimpse2SVImputation.output_prefix": "3_samples_manifest_hgsvc_hprc_50_plumbing_test",
+    "Glimpse2SVImputation.gvcf_manifest": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/manifests/3_sample_manifest.tsv",
+    "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
+    "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
+    "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],
+    "Glimpse2SVImputation.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+    "Glimpse2SVImputation.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+    "Glimpse2SVImputation.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
+    "Glimpse2SVImputation.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
+    "Glimpse2SVImputation.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",
+    "Glimpse2SVImputation.glimpse_phase_cpu_override": 1
+}

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -297,53 +297,133 @@ task FilterVcfByInfo {
     }
 }
 
-task SplitGvcfInputsIntoBatches {
+task SplitVcfManifestIntoBatches {
     input {
-        Array[String] input_gvcfs
-        Array[String] input_gvcf_idxs
-        Array[String] sample_ids
         Int batch_size
+        File gvcf_manifest
+    }
+
+    command <<<
+        cat <<EOF > script.py
+        import sys
+        import pandas as pd
+
+        batch_size = ~{batch_size}
+
+        df = pd.read_csv("~{gvcf_manifest}", sep='\t')
+
+        required_cols = ['sample_id', 'gvcf_path', 'gvcf_index_path']
+        missing_cols = [col for col in required_cols if col not in df.columns]
+        if missing_cols:
+            print(f"Missing required columns in the VCF manifest: {', '.join(missing_cols)}.", file=sys.stderr)
+            sys.exit(1)
+
+        if df[required_cols].isnull().any().any():
+            print("The VCF manifest contains empty values in required columns.", file=sys.stderr)
+            sys.exit(1)
+
+        if len(df) == 0:
+            print("The VCF manifest must contain at least one row.", file=sys.stderr)
+            sys.exit(1)
+
+        chunk_num = 0
+        for i in range(0, len(df), batch_size):
+            df_chunk = df[i : i + batch_size]
+            df_chunk.to_csv(f"chunk_{chunk_num:04d}.tsv", sep='\t', index=False)
+            chunk_num += 1
+
+        EOF
+        python3 script.py
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        cpu: 1
+        disks: "local-disk 10 HDD"
+        memory: "1 GiB"
+        preemptible: 3
+        noAddress: true
+    }
+
+    output {
+        Array[File] gvcf_manifest_batches = glob("chunk_*")
+    }
+}
+
+task ConvertInputArraysToManifest {
+    input {
+        Array[String] sample_ids
+        Array[String] gvcf_paths
+        Array[String] gvcf_index_paths
+        String output_filename = "manifest.tsv"
+    }
+
+    command <<<
+        set -euo pipefail
+
+        python3 << 'EOF'
+        import sys
+
+        sample_ids = ['~{sep="', '" sample_ids}']
+        gvcf_paths = ['~{sep="', '" gvcf_paths}']
+        gvcf_index_paths = ['~{sep="', '" gvcf_index_paths}']
+
+        if not (len(sample_ids) == len(gvcf_paths) == len(gvcf_index_paths)):
+            print(
+                f"ERROR: Input arrays have different lengths: sample_ids={len(sample_ids)}, gvcf_paths={len(gvcf_paths)}, gvcf_index_paths={len(gvcf_index_paths)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        with open('~{output_filename}', 'w') as f:
+            f.write("sample_id\tgvcf_path\tgvcf_index_path\n")
+            for sample_id, gvcf_path, gvcf_index_path in zip(sample_ids, gvcf_paths, gvcf_index_paths):
+                f.write(f"{sample_id}\t{gvcf_path}\t{gvcf_index_path}\n")
+        EOF
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        cpu: 1
+        memory: "1 GiB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        noAddress: true
+    }
+
+    output {
+        File output_manifest = "~{output_filename}"
+    }
+}
+
+task ParseVcfManifestIntoArrays {
+    input {
+        File gvcf_manifest
     }
 
     command <<<
         set -euo pipefail
 
         cat <<EOF > script.py
-import sys
+        import sys
+        import pandas as pd
 
-gvcfs = ['~{sep="', '" input_gvcfs}']
-gvcf_idxs = ['~{sep="', '" input_gvcf_idxs}']
-sample_ids = ['~{sep="', '" sample_ids}']
-batch_size = ~{batch_size}
+        df = pd.read_csv("~{gvcf_manifest}", sep='\t')
 
-if not (len(gvcfs) == len(gvcf_idxs) == len(sample_ids)):
-    print(
-        f"input_gvcfs ({len(gvcfs)}), input_gvcf_idxs ({len(gvcf_idxs)}), and sample_ids ({len(sample_ids)}) must have identical lengths.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+        required_cols = ['sample_id', 'gvcf_path', 'gvcf_index_path']
+        missing_cols = [col for col in required_cols if col not in df.columns]
+        if missing_cols:
+            print(f"Missing required columns in the VCF manifest: {', '.join(missing_cols)}.", file=sys.stderr)
+            sys.exit(1)
 
-if batch_size < 1:
-    print(f"batch_size must be > 0, got {batch_size}", file=sys.stderr)
-    sys.exit(1)
+        if df[required_cols].isnull().any().any():
+            print("The VCF manifest contains empty values in required columns.", file=sys.stderr)
+            sys.exit(1)
 
-batch_num = 0
-for i in range(0, len(gvcfs), batch_size):
-    gvcf_chunk = gvcfs[i : i + batch_size]
-    gvcf_idx_chunk = gvcf_idxs[i : i + batch_size]
-    sample_id_chunk = sample_ids[i : i + batch_size]
-
-    with open(f"gvcf_batch_{batch_num:04d}.fofn", "w") as gvcf_out:
-        gvcf_out.write("\n".join(gvcf_chunk) + "\n")
-
-    with open(f"gvcf_idx_batch_{batch_num:04d}.fofn", "w") as idx_out:
-        idx_out.write("\n".join(gvcf_idx_chunk) + "\n")
-
-    with open(f"sample_ids_batch_{batch_num:04d}.txt", "w") as sample_out:
-        sample_out.write("\n".join(sample_id_chunk) + "\n")
-
-    batch_num += 1
-EOF
+        df['gvcf_path'].to_csv('gvcf_paths.txt', index=False, header=False)
+        df['gvcf_index_path'].to_csv('gvcf_index_paths.txt', index=False, header=False)
+        df['sample_id'].to_csv('sample_ids.txt', index=False, header=False)
+        EOF
         python3 script.py
     >>>
 
@@ -357,9 +437,9 @@ EOF
     }
 
     output {
-        Array[File] gvcf_fofn_batches = glob("gvcf_batch_*.fofn")
-        Array[File] gvcf_idx_fofn_batches = glob("gvcf_idx_batch_*.fofn")
-        Array[File] sample_ids_batches = glob("sample_ids_batch_*.txt")
+        Array[File] input_gvcfs = read_lines("gvcf_paths.txt")
+        Array[File] input_gvcf_idxs = read_lines("gvcf_index_paths.txt")
+        Array[String] sample_ids = read_lines("sample_ids.txt")
     }
 }
 

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -8,14 +8,10 @@ import "../../tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl" as Copy
 workflow TestGlimpse2SVImputation {
 
     input {
-        # inputs for Preprocessing wdl
-        File? input_gvcfs_fofn
-        File? input_gvcf_idxs_fofn
-        File? sample_ids_file          # order of sample ids must match that of gVCFs
-
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
         Array[String]? sample_ids
+        File? gvcf_manifest
 
         Int sample_batch_size = 500
 
@@ -57,12 +53,10 @@ workflow TestGlimpse2SVImputation {
 
     call Glimpse2SVImputation.Glimpse2SVImputation {
       input:
-        input_gvcfs_fofn = input_gvcfs_fofn,
-        input_gvcf_idxs_fofn = input_gvcf_idxs_fofn,
-        sample_ids_file = sample_ids_file,
         input_gvcfs = input_gvcfs,
         input_gvcf_idxs = input_gvcf_idxs,
         sample_ids = sample_ids,
+        gvcf_manifest = gvcf_manifest,
         sample_batch_size = sample_batch_size,
         output_prefix = output_prefix,
         preprocess_panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,


### PR DESCRIPTION
### Description

Users will be submitting a manifest style tsv file to TSPS when launching the sv imputation pipeline.  This PR adds that input type as an option.  The manifest is expected to have the columns `gvcf_path`, `gvcf_index_path`, `sample_id`.  

The pr also removes the fofn style inputs as that can easily be replaced by a manifest file now.  Batching now happens at the manifest level so if arrays of strings are passed in as input to the workflow, they will be converted to a manifest style file and then that file will be batched and passed to subsequent steps in the pipeline.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
