### PR TITLE
[TSPS-1110] Add optional INFO filter for SV Imputation pipeline

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,7 +9,7 @@ Glimpse2LowPassImputation	 1.0.5	2026-08-09
 Glimpse2LowPassImputationBatch	 1.0.3	2026-08-01 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.13	2026-08-09 
+Glimpse2SVImputation	 0.0.14	2026-08-11 
 Glimpse2SVImputationBatch	 0.0.11	2026-08-09 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.14
+2026-08-11 (Date of Last Commit)
+
+* Add optional `info_filter_for_inclusion` input; when set above 0.0, variants with INFO score below the threshold are excluded from the final per-chromosome popped output VCFs.
+
 # 0.0.13
 2026-08-09 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,7 +5,7 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.13"
+    String pipeline_version = "0.0.14"
     String preprocess_pls_gvcf_pipeline_version = "0.0.6"
     String batch_pipeline_version = "0.0.11"
 
@@ -41,6 +41,9 @@ workflow Glimpse2SVImputation {
 
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
+
+        # Optional filter: variants with INFO score below this threshold will be excluded from the final output VCFs
+        Float info_filter_for_inclusion = 0.0
 
         String glimpse2_docker = "us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771"
         String merge_docker = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
@@ -138,9 +141,20 @@ workflow Glimpse2SVImputation {
 
         File final_popped_contig_vcf = select_first([RecomputePoppedAfInfo.merged_imputed_vcf, popped_bcfs_for_contig[0]])
 
+        if (info_filter_for_inclusion > 0.0) {
+            call Glimpse2SVImputationTasks.FilterVcfByInfo as FilterPoppedContigByInfo {
+                input:
+                    vcf = final_popped_contig_vcf,
+                    info_threshold = info_filter_for_inclusion,
+                    output_prefix = output_prefix + "." + chromosomes[contig_idx] + ".glimpse2.popped.info_filtered"
+            }
+        }
+
+        File final_filtered_popped_contig_vcf = select_first([FilterPoppedContigByInfo.output_vcf, final_popped_contig_vcf])
+
         call Glimpse2SVImputationTasks.CreateVcfIndexAndMd5 as IndexFinalPoppedContig {
             input:
-                vcf_input = final_popped_contig_vcf,
+                vcf_input = final_filtered_popped_contig_vcf,
                 output_basename = output_prefix + "." + chromosomes[contig_idx],
                 gatk_docker = gatk_docker,
                 preemptible = 0

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22_info_filter.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22_info_filter.json
@@ -1,0 +1,28 @@
+{
+  "Glimpse2SVImputation.output_prefix": "3_samples_hgsvc_hprc_50_info_filter_plumbing_test",
+  "Glimpse2SVImputation.input_gvcfs": [
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21106.hard-filtered.vcf.gz",
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz",
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz"
+  ],
+  "Glimpse2SVImputation.input_gvcf_idxs": [
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21106.hard-filtered.vcf.gz.tbi",
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz.tbi",
+    "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz.tbi"
+  ],
+  "Glimpse2SVImputation.sample_ids": [
+    "NA21106",
+    "NA21110",
+    "NA21144"
+  ],
+  "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
+  "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
+  "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],
+  "Glimpse2SVImputation.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+  "Glimpse2SVImputation.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "Glimpse2SVImputation.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
+  "Glimpse2SVImputation.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
+  "Glimpse2SVImputation.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",
+  "Glimpse2SVImputation.info_filter_for_inclusion": 0.9,
+  "Glimpse2SVImputation.glimpse_phase_cpu_override": 1
+}

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -264,6 +264,39 @@ task CreateVcfIndexAndMd5 {
     }
 }
 
+task FilterVcfByInfo {
+    input {
+        File vcf
+        Float info_threshold
+        String output_prefix
+
+        String docker = "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
+        Int disk_size_gb = ceil(2.2 * size(vcf, "GiB") + 20)
+        Int mem_gb = 4
+        Int cpu = 1
+        Int preemptible = 3
+    }
+
+    command <<<
+        set -euo pipefail
+
+        bcftools filter -i 'INFO/INFO >= ~{info_threshold}' -O z -o ~{output_prefix}.vcf.gz ~{vcf}
+    >>>
+
+    runtime {
+        docker: docker
+        disks: "local-disk " + disk_size_gb + " HDD"
+        memory: mem_gb + " GiB"
+        cpu: cpu
+        preemptible: preemptible
+        noAddress: true
+    }
+
+    output {
+        File output_vcf = "~{output_prefix}.vcf.gz"
+    }
+}
+
 task SplitGvcfInputsIntoBatches {
     input {
         Array[String] input_gvcfs

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -41,6 +41,8 @@ workflow TestGlimpse2SVImputation {
         # inputs for PopAndMarginalizeCollisions
         File pop_glimpse2_panel_resources_json
 
+        Float? info_filter_for_inclusion
+
         String? glimpse2_docker
 
         # These values will be determined and injected into the inputs by the scala test framework
@@ -74,6 +76,7 @@ workflow TestGlimpse2SVImputation {
         extra_phase_args = extra_phase_args,
         glimpse_phase_cpu_override = glimpse_phase_cpu_override,
         pop_glimpse2_panel_resources_json = pop_glimpse2_panel_resources_json,
+        info_filter_for_inclusion = info_filter_for_inclusion,
         glimpse2_docker = glimpse2_docker,
     }
 


### PR DESCRIPTION
### Description

https://broadworkbench.atlassian.net/browse/TSPS-1110

Adds an optional INFO filter allowing the user to filter lower quality variants from the final output vcf.

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
