### PR TITLE
TSPS-1127 make all disk sizes dynamic and set bootDiskSizeGb to 0 for all tasks

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -8,20 +8,20 @@ Glimpse2LowPassImputation	 1.0.6	2026-08-12
 Glimpse2LowPassImputationBatch	 1.0.4	2026-08-12 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.18	2026-08-13 
-Glimpse2SVImputationBatch	 0.0.13	2026-08-13 
+Glimpse2SVImputation	 0.0.19	2026-08-17 
+Glimpse2SVImputationBatch	 0.0.14	2026-08-17 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.5	2026-08-13 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.6	2026-08-17 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.10	2026-08-13 
+PreprocessPLsGVCF	 0.0.11	2026-08-17 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -2,6 +2,7 @@
 2026-08-17 (Date of Last Commit)
 
 * make all task disk sizes dynamic and set bootDiskSizeGb to 0
+* update default sample_batch_size to 1000
 
 # 0.0.18
 2026-08-13 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.19
+2026-08-17 (Date of Last Commit)
+
+* make all task disk sizes dynamic and set bootDiskSizeGb to 0
+
 # 0.0.18
 2026-08-13 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -2,7 +2,7 @@
 2026-08-17 (Date of Last Commit)
 
 * make all task disk sizes dynamic and set bootDiskSizeGb to 0
-* update default sample_batch_size to 1000
+* update default value of sample_batch_size to 1000
 
 # 0.0.18
 2026-08-13 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -15,7 +15,7 @@ workflow Glimpse2SVImputation {
         Array[File]? input_gvcf_idxs
         Array[String]? sample_ids
         File? gvcf_manifest
-        Int sample_batch_size = 500
+        Int sample_batch_size = 1000
 
         String output_prefix
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,9 +5,9 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.18"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.10"
-    String batch_pipeline_version = "0.0.13"
+    String pipeline_version = "0.0.19"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.11"
+    String batch_pipeline_version = "0.0.14"
 
     input {
         # if both array inputs and gvcf_manifest are provided, array inputs take precedence

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.14
+2026-08-17 (Date of Last Commit)
+
+* make all task disk sizes dynamic and set bootDiskSizeGb to 0
+
 # 0.0.13
 2026-08-13 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -298,7 +298,7 @@ task PopAndMarginalizeCollisions {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_gb = ceil(3*size(posteriors_vcf)) + ceil(size([panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB")) + 10
+    Int disk_gb = ceil(3*size(posteriors_vcf, "GB")) + ceil(size([panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB")) + 10
 
     command <<<
         set -euox pipefail

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.13"
+    String pipeline_version = "0.0.14"
 
     input {
         File input_preprocessed_joint_vcf

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -167,7 +167,7 @@ task GLIMPSE2Phase {
         }
     }
 
-    Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 30)
+    Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 40)
 
     command <<<
         set -euxo pipefail
@@ -211,7 +211,7 @@ task GLIMPSE2Phase {
         cpu_cores:          threads,
         mem_gb:             16,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  30,
         max_retries:        3,
@@ -242,7 +242,7 @@ task GLIMPSE2Ligate {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size_gb = 2 * ceil(size(phased_vcfs, "GB")) + 10
+    Int disk_size_gb = ceil(2.1*size(phased_vcfs, "GB")) + 10
 
     command <<<
         set -euox pipefail
@@ -263,7 +263,7 @@ task GLIMPSE2Ligate {
         cpu_cores:          2,
         mem_gb:             18,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  0,
         max_retries:        1,
@@ -298,7 +298,7 @@ task PopAndMarginalizeCollisions {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_gb = 10 + 3 * ceil(size([posteriors_vcf, panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB"))
+    Int disk_gb = ceil(3*size(posteriors_vcf)) + ceil(size([panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB")) + 10
 
     command <<<
         set -euox pipefail
@@ -319,9 +319,9 @@ task PopAndMarginalizeCollisions {
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          2,
-        mem_gb:             6,
+        mem_gb:             8,
         disk_gb:            disk_gb,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
@@ -349,7 +349,7 @@ task UpdateHeader {
 
         Int mem_gb = 2
         Int cpu = 1
-        Int disk_size_gb = ceil(2.1 * size(bcf_to_reheader, "GiB") + 10)
+        Int disk_size_gb = ceil(2.1 * size(bcf_to_reheader, "GiB")) + 10
         Int max_retries = 1
         String docker
     }
@@ -382,6 +382,7 @@ task UpdateHeader {
     runtime {
         docker: docker
         disks: "local-disk " + disk_size_gb + " SSD"
+        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         maxRetries: max_retries

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.6
+2026-08-17 (Date of Last Commit)
+
+* make all task disk sizes dynamic and set bootDiskSizeGb to 0
+
 # 0.0.5
 2026-08-13 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.5"
+    String pipeline_version = "0.0.6"
 
     input {
         Array[String]? vcfs_array

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -189,9 +189,9 @@ task CreateBatches {
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          1,
-        mem_gb:             4,
+        mem_gb:             2,
         disk_gb:            10,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         disk_type:          "HDD",
         preemptible_tries:  2,
         max_retries:        1,
@@ -226,7 +226,7 @@ task MergeVcfs {
     }
 
     # Dynamically sizes disk if localizing, defaults to 50GB if streaming
-    Int disk_gb = if length(vcfs_localize) > 0 then 10 + 2 * ceil(size(vcfs_localize, "GiB")) else 50
+    Int disk_gb = if length(vcfs_localize) > 0 then ceil(2.1*size(vcfs_localize, "GiB")) + 10 else ceil(1.1*size(vcfs_localize, "GiB")) + 10
 
     command <<<
         set -euox pipefail
@@ -339,7 +339,7 @@ task MergeVcfs {
         cpu_cores:          2,
         mem_gb:             4,
         disk_gb:            disk_gb,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.11
+2026-08-17 (Date of Last Commit)
+
+* make all task disk sizes dynamic and set bootDiskSizeGb to 0
+
 # 0.0.10
 2026-08-13 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -5,8 +5,8 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.10"
-    String multi_level_paste_pipeline_version = "0.0.5"
+    String pipeline_version = "0.0.11"
+    String multi_level_paste_pipeline_version = "0.0.6"
     input {
         File input_gvcf_manifest
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -85,7 +85,7 @@ task PreprocessPLs {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size_gb = 10 + 2 * ceil(size([input_vcf, panel_bubble_split_sites_only_vcf], "GB"))
+    Int disk_size_gb = ceil(2*size([input_vcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
 
     File sample_names_list = write_lines(sample_names)
 
@@ -116,7 +116,7 @@ task PreprocessPLs {
         cpu_cores:          1,
         mem_gb:             2,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       10,
+        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  4,
         max_retries:        1,

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -75,6 +75,7 @@ task MergeSampleChunksVcfsWithPaste {
     runtime {
         docker: "us.gcr.io/broad-dsde-methods/bcftools_bgzip:beagle_imputation_v1.0.0"
         disks: "local-disk " + disk_size_gb + " HDD"
+        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -117,6 +118,7 @@ task ExtractAnnotations {
     runtime {
         docker: docker_extract_annotations
         disks: "local-disk " + disk_size_gb + " HDD"
+        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -210,6 +212,7 @@ EOF
     runtime {
         docker: docker_merge
         disks: "local-disk " + disk_size_gb + " HDD"
+        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -251,6 +254,7 @@ task CreateVcfIndexAndMd5 {
     runtime {
         docker: gatk_docker
         disks: "local-disk ${disk_size_gb} SSD"
+        bootDiskSizeGb: 0
         memory: "${memory_mb} MiB"
         cpu: cpu
         preemptible: preemptible
@@ -286,6 +290,7 @@ task FilterVcfByInfo {
     runtime {
         docker: docker
         disks: "local-disk " + disk_size_gb + " HDD"
+        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -340,6 +345,7 @@ task SplitVcfManifestIntoBatches {
         docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
         cpu: 1
         disks: "local-disk 10 HDD"
+        bootDiskSizeGb: 0
         memory: "1 GiB"
         preemptible: 3
         noAddress: true
@@ -387,6 +393,7 @@ task ConvertInputArraysToManifest {
         cpu: 1
         memory: "1 GiB"
         disks: "local-disk 10 HDD"
+        bootDiskSizeGb: 0
         preemptible: 3
         noAddress: true
     }
@@ -430,8 +437,9 @@ task ParseVcfManifestIntoArrays {
     runtime {
         docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
         cpu: 1
-        memory: "4 GiB"
+        memory: "1 GiB"
         disks: "local-disk 10 HDD"
+        bootDiskSizeGb: 0
         preemptible: 3
         noAddress: true
     }
@@ -472,7 +480,7 @@ task ConcatBcfs {
         cpu: 1
         memory: "4 GiB"
         disks: "local-disk " + disk_gb + " SSD"
-        bootDiskSizeGb: 10
+        bootDiskSizeGb: 0
         preemptible: 3
         maxRetries: 0
         docker: "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"


### PR DESCRIPTION
### Description

We want to make sure all of tasks have dynamic disk sizing

We also are testing whether we can set bootDiskSizeGb to 0.

Non call cached submission with these changes - https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/a37941e9-eb48-4ab9-981a-9596f88b1565

jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-1127

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
