### PR TITLE
[TSPS-1147] Remove sample_ids input from SV pipeline

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,13 +9,13 @@ Glimpse2LowPassImputationBatch	 1.0.4	2026-08-12
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
 Glimpse2SVImputation	 0.0.22	2026-08-20 
-Glimpse2SVImputationBatch	 0.0.16	2026-08-18 
+Glimpse2SVImputationBatch	 0.0.17	2026-08-20 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.7	2026-08-17 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.8	2026-08-20 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 

--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -8,7 +8,7 @@ Glimpse2LowPassImputation	 1.0.6	2026-08-12
 Glimpse2LowPassImputationBatch	 1.0.4	2026-08-12 
 Glimpse2LowPassImputationQC	 1.0.5	2026-07-20 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.0	2026-06-30 
-Glimpse2SVImputation	 0.0.21	2026-08-18 
+Glimpse2SVImputation	 0.0.22	2026-08-20 
 Glimpse2SVImputationBatch	 0.0.16	2026-08-18 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 
@@ -21,7 +21,7 @@ Optimus	 9.2.0	2026-07-10
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
 Pipeline Name	Version	Date of Last Commit
-PreprocessPLsGVCF	 0.0.12	2026-08-17 
+PreprocessPLsGVCF	 0.0.13	2026-08-20 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.22
+2026-08-20 (Date of Last Commit)
+
+* Remove `sample_ids` input from workflow. The sample name will now be obtained from GVCF file
+* Update `preprocess_pls_gvcf_pipeline_version` to 0.0.13
+* Remove `sample_ids` from `ConvertInputArraysToManifest` task
+
 # 0.0.21
 2026-08-18 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -7,7 +7,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 workflow Glimpse2SVImputation {
     String pipeline_version = "0.0.22"
     String preprocess_pls_gvcf_pipeline_version = "0.0.13"
-    String batch_pipeline_version = "0.0.16"
+    String batch_pipeline_version = "0.0.17"
 
     input {
         # if both array inputs and gvcf_manifest are provided, array inputs take precedence

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -13,7 +13,6 @@ workflow Glimpse2SVImputation {
         # if both array inputs and gvcf_manifest are provided, array inputs take precedence
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? sample_ids
         File? gvcf_manifest
         Int sample_batch_size = 1000
 
@@ -50,14 +49,13 @@ workflow Glimpse2SVImputation {
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
     }
 
-    Boolean using_arrays = defined(input_gvcfs) && defined(input_gvcf_idxs) && defined(sample_ids)
+    Boolean using_arrays = defined(input_gvcfs) && defined(input_gvcf_idxs)
 
     if (using_arrays) {
         call Glimpse2SVImputationTasks.ConvertInputArraysToManifest {
             input:
                 gvcf_paths = select_first([input_gvcfs]),
-                gvcf_index_paths = select_first([input_gvcf_idxs]),
-                sample_ids = select_first([sample_ids])
+                gvcf_index_paths = select_first([input_gvcf_idxs])
         }
     }
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,8 +5,8 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.21"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.12"
+    String pipeline_version = "0.0.22"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.13"
     String batch_pipeline_version = "0.0.16"
 
     input {

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.17
+2026-08-20 (Date of Last Commit)
+
+* Updated Glimpse2SVImputationTasks dependency (sample_ids no longer required as a input)
+
 # 0.0.16
 2026-08-18 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.16"
+    String pipeline_version = "0.0.17"
 
     input {
         File input_preprocessed_joint_vcf

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.8
+2026-08-20 (Date of Last Commit)
+
+* Updated Glimpse2SVImputationTasks dependency (sample_ids no longer required as a input)
+
 # 0.0.7
 2026-08-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.7"
+    String pipeline_version = "0.0.8"
 
     input {
         Array[String]? vcfs_array

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.13
+2026-08-20 (Date of Last Commit)
+
+* Remove `sample_names` input from `PreprocessPLs` task. The sample name will now be obtained from GVCF file
+
 # 0.0.12
 2026-08-17 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -2,6 +2,7 @@
 2026-08-20 (Date of Last Commit)
 
 * Remove `sample_names` input from `PreprocessPLs` task. The sample name will now be obtained from GVCF file
+* * Update `multi_level_paste_pipeline_version` to 0.0.8
 
 # 0.0.12
 2026-08-17 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -89,33 +89,27 @@ task PreprocessPLs {
     command <<<
         set -euxo pipefail
 
-        # Extract sample name from GVCF header
-        sample_name=$(bcftools query -l ~{input_vcf})
-
-        # Write sample name to file for extract-bubble-PLs tool and output naming
-        echo "$sample_name" > sample_name.txt
-
-        # Create final output prefix combining index and sample name
-        final_output_prefix="~{output_prefix}.${sample_name}.preprocessedPLs"
+        # Extract sample name from GVCF header and write to file for extract-bubble-PLs tool
+        bcftools query -l ~{input_vcf} > sample_name.txt
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
             ~{input_vcf}##idx##~{input_vcf_idx} \
-            ${final_output_prefix}.bcf \
+            ~{output_prefix}.bcf \
             ~{"--region " + output_region} \
             --samples sample_name.txt \
             --threads ~{cpu} \
             ~{extra_args}
 
-        bcftools index ${final_output_prefix}.bcf
+        bcftools index ~{output_prefix}.bcf
 
         echo "Number of bubble alleles extracted..."
-        bcftools index -n ${final_output_prefix}.bcf
+        bcftools index -n ~{output_prefix}.bcf
     >>>
 
     output {
-        File preprocessed_pls_vcf = "~{output_prefix}.~{read_string('sample_name.txt')}.preprocessedPLs.bcf"
-        File preprocessed_pls_vcf_idx = "~{output_prefix}.~{read_string('sample_name.txt')}.preprocessedPLs.bcf.csi"
+        File preprocessed_pls_vcf = "~{output_prefix}.bcf"
+        File preprocessed_pls_vcf_idx = "~{output_prefix}.bcf.csi"
     }
 
     #########################

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -31,8 +31,7 @@ workflow PreprocessPLsGVCF {
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-                sample_names = [ParseInputManifest.sample_ids[j]],
-                output_prefix = "sample-" + j + "." + ParseInputManifest.sample_ids[j] + ".preprocessedPLs",
+                output_prefix = "sample-" + j + ".preprocessedPLs",
                 extra_args = extract_bubble_likelihoods_extra_args
         }
     }
@@ -54,7 +53,7 @@ workflow PreprocessPLsGVCF {
     output {
         File preprocessed_pls_vcf = PastePreprocessPLsGVCFs.merged_vcf
         File preprocessed_pls_vcf_idx = PastePreprocessPLsGVCFs.merged_vcf_idx
-        Int num_samples = length(ParseInputManifest.sample_ids)
+        Int num_samples = length(ParseInputManifest.input_gvcfs)
     }
 }
 
@@ -77,7 +76,6 @@ task PreprocessPLs {
         File panel_bubble_split_sites_only_vcf
         File panel_bubble_split_sites_only_vcf_idx
         String? output_region
-        Array[String] sample_names
         String output_prefix
 
         String? extra_args = "--window 15000 --cap-pl 30 --scale-pl 5.0"
@@ -88,17 +86,35 @@ task PreprocessPLs {
 
     Int disk_size_gb = ceil(2*size([input_vcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
 
-    File sample_names_list = write_lines(sample_names)
-
     command <<<
         set -euxo pipefail
+
+        # Extract sample name from GVCF header and validate there is exactly one sample
+        bcftools query -l ~{input_vcf} > sample_names.txt
+        # Count non-empty lines (grep -c returns count even without trailing newline)
+        num_samples=$(grep -c . sample_names.txt || echo "0")
+
+        if [ "$num_samples" -ne 1 ]; then
+            echo "ERROR: GVCF must contain exactly one sample, but found $num_samples samples in ~{input_vcf}" >&2
+            if [ "$num_samples" -eq 0 ]; then
+                echo "No samples found in the GVCF header" >&2
+            else
+                echo "Samples found:" >&2
+                cat sample_names.txt >&2
+            fi
+            exit 1
+        fi
+
+        sample_name=$(cat sample_names.txt)
+        echo "Processing sample: $sample_name"
+        mv sample_names.txt sample_name.txt
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
             ~{input_vcf}##idx##~{input_vcf_idx} \
             ~{output_prefix}.bcf \
             ~{"--region " + output_region} \
-            --samples ~{sample_names_list} \
+            --samples sample_name.txt \
             --threads ~{cpu} \
             ~{extra_args}
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -89,17 +89,8 @@ task PreprocessPLs {
     command <<<
         set -euxo pipefail
 
-        # Extract sample name from GVCF header and validate there is exactly one sample
+        # Extract sample name from GVCF header
         bcftools query -l ~{input_vcf} > sample_name.txt
-        # Count non-empty lines (grep -c returns count even without trailing newline)
-        num_samples=$(grep -c . sample_name.txt || echo "0")
-
-        if [ "$num_samples" -ne 1 ]; then
-            echo "ERROR: GVCF must contain exactly one sample, but found $num_samples samples in ~{input_vcf}" >&2
-            exit 1
-        fi
-
-        echo "Processing sample: $(cat sample_name.txt)"
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -90,24 +90,17 @@ task PreprocessPLs {
         set -euxo pipefail
 
         # Extract sample name from GVCF header and validate there is exactly one sample
-        bcftools query -l ~{input_vcf} > sample_names.txt
+        bcftools query -l ~{input_vcf} > sample_name.txt
         # Count non-empty lines (grep -c returns count even without trailing newline)
-        num_samples=$(grep -c . sample_names.txt || echo "0")
+        num_samples=$(grep -c . sample_name.txt || echo "0")
 
         if [ "$num_samples" -ne 1 ]; then
             echo "ERROR: GVCF must contain exactly one sample, but found $num_samples samples in ~{input_vcf}" >&2
-            if [ "$num_samples" -eq 0 ]; then
-                echo "No samples found in the GVCF header" >&2
-            else
-                echo "Samples found:" >&2
-                cat sample_names.txt >&2
-            fi
+            [ "$num_samples" -eq 0 ] && echo "No samples found in the GVCF header" >&2 || cat sample_name.txt >&2
             exit 1
         fi
 
-        sample_name=$(cat sample_names.txt)
-        echo "Processing sample: $sample_name"
-        mv sample_names.txt sample_name.txt
+        echo "Processing sample: $(cat sample_name.txt)"
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -5,7 +5,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.12"
+    String pipeline_version = "0.0.13"
     String multi_level_paste_pipeline_version = "0.0.7"
     input {
         File input_gvcf_manifest

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -114,9 +114,8 @@ task PreprocessPLs {
     >>>
 
     output {
-        String sample_name = read_string("sample_name.txt")
-        File preprocessed_pls_vcf = "~{output_prefix}.~{sample_name}.preprocessedPLs.bcf"
-        File preprocessed_pls_vcf_idx = "~{output_prefix}.~{sample_name}.preprocessedPLs.bcf.csi"
+        File preprocessed_pls_vcf = "~{output_prefix}.~{read_string('sample_name.txt')}.preprocessedPLs.bcf"
+        File preprocessed_pls_vcf_idx = "~{output_prefix}.~{read_string('sample_name.txt')}.preprocessedPLs.bcf.csi"
     }
 
     #########################

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -31,7 +31,7 @@ workflow PreprocessPLsGVCF {
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
-                output_prefix = "sample-" + j + ".preprocessedPLs",
+                output_prefix = "sample-" + j,
                 extra_args = extract_bubble_likelihoods_extra_args
         }
     }
@@ -90,26 +90,33 @@ task PreprocessPLs {
         set -euxo pipefail
 
         # Extract sample name from GVCF header
-        bcftools query -l ~{input_vcf} > sample_name.txt
+        sample_name=$(bcftools query -l ~{input_vcf})
+
+        # Write sample name to file for extract-bubble-PLs tool and output naming
+        echo "$sample_name" > sample_name.txt
+
+        # Create final output prefix combining index and sample name
+        final_output_prefix="~{output_prefix}.${sample_name}.preprocessedPLs"
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
             ~{input_vcf}##idx##~{input_vcf_idx} \
-            ~{output_prefix}.bcf \
+            ${final_output_prefix}.bcf \
             ~{"--region " + output_region} \
             --samples sample_name.txt \
             --threads ~{cpu} \
             ~{extra_args}
 
-        bcftools index ~{output_prefix}.bcf
+        bcftools index ${final_output_prefix}.bcf
 
         echo "Number of bubble alleles extracted..."
-        bcftools index -n ~{output_prefix}.bcf
+        bcftools index -n ${final_output_prefix}.bcf
     >>>
 
     output {
-        File preprocessed_pls_vcf = "~{output_prefix}.bcf"
-        File preprocessed_pls_vcf_idx = "~{output_prefix}.bcf.csi"
+        String sample_name = read_string("sample_name.txt")
+        File preprocessed_pls_vcf = "~{output_prefix}.~{sample_name}.preprocessedPLs.bcf"
+        File preprocessed_pls_vcf_idx = "~{output_prefix}.~{sample_name}.preprocessedPLs.bcf.csi"
     }
 
     #########################

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -96,7 +96,6 @@ task PreprocessPLs {
 
         if [ "$num_samples" -ne 1 ]; then
             echo "ERROR: GVCF must contain exactly one sample, but found $num_samples samples in ~{input_vcf}" >&2
-            [ "$num_samples" -eq 0 ] && echo "No samples found in the GVCF header" >&2 || cat sample_name.txt >&2
             exit 1
         fi
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
     String pipeline_version = "0.0.13"
-    String multi_level_paste_pipeline_version = "0.0.7"
+    String multi_level_paste_pipeline_version = "0.0.8"
     input {
         File input_gvcf_manifest
 

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22.json
@@ -10,11 +10,6 @@
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz.tbi",
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz.tbi"
     ],
-    "Glimpse2SVImputation.sample_ids": [
-        "NA21106", 
-        "NA21110",
-        "NA21144"
-    ],
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
     "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22_info_filter.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/3_samples_hgsvc_hprc_50_chr19-22_info_filter.json
@@ -10,11 +10,6 @@
     "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz.tbi",
     "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz.tbi"
   ],
-  "Glimpse2SVImputation.sample_ids": [
-    "NA21106",
-    "NA21110",
-    "NA21144"
-  ],
   "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
   "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
   "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/6_samples_hgsvc_hprc_50_chr19-22_batched.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Plumbing/6_samples_hgsvc_hprc_50_chr19-22_batched.json
@@ -16,14 +16,6 @@
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00408.haplotypeCalls.er.raw.vcf.gz.tbi",
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/HG00418.haplotypeCalls.er.raw.vcf.gz.tbi"
     ],
-    "Glimpse2SVImputation.sample_ids": [
-        "NA21106", 
-        "NA21110",
-        "NA21144",
-        "HG00405",
-        "HG00408",
-        "HG00418"
-    ],
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
     "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],

--- a/pipelines/wdl/glimpse/sv_imputation/test_inputs/Scientific/3_samples_hgsvc_hprc_50_chr19-22.json
+++ b/pipelines/wdl/glimpse/sv_imputation/test_inputs/Scientific/3_samples_hgsvc_hprc_50_chr19-22.json
@@ -10,11 +10,6 @@
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21110.hard-filtered.vcf.gz.tbi",
         "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/gvcfs/NA21144.hard-filtered.vcf.gz.tbi"
     ],
-    "Glimpse2SVImputation.sample_ids": [
-        "NA21106", 
-        "NA21110",
-        "NA21144"
-    ],
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
     "Glimpse2SVImputation.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
     "Glimpse2SVImputation.paste_regions": ["chr19,chr20", "chr21,chr22"],

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -317,7 +317,7 @@ task SplitVcfManifestIntoBatches {
 
         df = pd.read_csv("~{gvcf_manifest}", sep='\t')
 
-        required_cols = ['sample_id', 'gvcf_path', 'gvcf_index_path']
+        required_cols = ['gvcf_path', 'gvcf_index_path']
         missing_cols = [col for col in required_cols if col not in df.columns]
         if missing_cols:
             print(f"Missing required columns in the VCF manifest: {', '.join(missing_cols)}.", file=sys.stderr)

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -358,7 +358,6 @@ task SplitVcfManifestIntoBatches {
 
 task ConvertInputArraysToManifest {
     input {
-        Array[String] sample_ids
         Array[String] gvcf_paths
         Array[String] gvcf_index_paths
         String output_filename = "manifest.tsv"
@@ -370,21 +369,20 @@ task ConvertInputArraysToManifest {
         python3 << 'EOF'
         import sys
 
-        sample_ids = ['~{sep="', '" sample_ids}']
         gvcf_paths = ['~{sep="', '" gvcf_paths}']
         gvcf_index_paths = ['~{sep="', '" gvcf_index_paths}']
 
-        if not (len(sample_ids) == len(gvcf_paths) == len(gvcf_index_paths)):
+        if not (len(gvcf_paths) == len(gvcf_index_paths)):
             print(
-                f"ERROR: Input arrays have different lengths: sample_ids={len(sample_ids)}, gvcf_paths={len(gvcf_paths)}, gvcf_index_paths={len(gvcf_index_paths)}",
+                f"ERROR: Input arrays have different lengths: gvcf_paths={len(gvcf_paths)}, gvcf_index_paths={len(gvcf_index_paths)}",
                 file=sys.stderr,
             )
             sys.exit(1)
 
         with open('~{output_filename}', 'w') as f:
-            f.write("sample_id\tgvcf_path\tgvcf_index_path\n")
-            for sample_id, gvcf_path, gvcf_index_path in zip(sample_ids, gvcf_paths, gvcf_index_paths):
-                f.write(f"{sample_id}\t{gvcf_path}\t{gvcf_index_path}\n")
+            f.write("gvcf_path\tgvcf_index_path\n")
+            for gvcf_path, gvcf_index_path in zip(gvcf_paths, gvcf_index_paths):
+                f.write(f"{gvcf_path}\t{gvcf_index_path}\n")
         EOF
     >>>
 
@@ -417,7 +415,7 @@ task ParseVcfManifestIntoArrays {
 
         df = pd.read_csv("~{gvcf_manifest}", sep='\t')
 
-        required_cols = ['sample_id', 'gvcf_path', 'gvcf_index_path']
+        required_cols = ['gvcf_path', 'gvcf_index_path']
         missing_cols = [col for col in required_cols if col not in df.columns]
         if missing_cols:
             print(f"Missing required columns in the VCF manifest: {', '.join(missing_cols)}.", file=sys.stderr)
@@ -429,7 +427,6 @@ task ParseVcfManifestIntoArrays {
 
         df['gvcf_path'].to_csv('gvcf_paths.txt', index=False, header=False)
         df['gvcf_index_path'].to_csv('gvcf_index_paths.txt', index=False, header=False)
-        df['sample_id'].to_csv('sample_ids.txt', index=False, header=False)
         EOF
         python3 script.py
     >>>
@@ -447,7 +444,6 @@ task ParseVcfManifestIntoArrays {
     output {
         Array[File] input_gvcfs = read_lines("gvcf_paths.txt")
         Array[File] input_gvcf_idxs = read_lines("gvcf_index_paths.txt")
-        Array[String] sample_ids = read_lines("sample_ids.txt")
     }
 }
 

--- a/verification/test-wdls/TestGlimpse2SVImputation.wdl
+++ b/verification/test-wdls/TestGlimpse2SVImputation.wdl
@@ -10,7 +10,6 @@ workflow TestGlimpse2SVImputation {
     input {
         Array[File]? input_gvcfs
         Array[File]? input_gvcf_idxs
-        Array[String]? sample_ids
         File? gvcf_manifest
 
         Int sample_batch_size = 500
@@ -55,7 +54,6 @@ workflow TestGlimpse2SVImputation {
       input:
         input_gvcfs = input_gvcfs,
         input_gvcf_idxs = input_gvcf_idxs,
-        sample_ids = sample_ids,
         gvcf_manifest = gvcf_manifest,
         sample_batch_size = sample_batch_size,
         output_prefix = output_prefix,


### PR DESCRIPTION
### Description

Jira - https://broadworkbench.atlassian.net/browse/TSPS-1147

This PR removes sample_ids input from pipeline. Instead, it extracts the sample name from gvcf file in PreProcessPLs task.

Warp automated testing submissions:
- https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/job_history/6f7084dc-14ac-40c5-a8a6-fa26862a8e77
- https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/job_history/4a89bbc7-a0d8-4192-9361-7bb1c19df60a
- https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/job_history/b9c4ee9c-81a2-4a1d-924b-29b3abd8e02f
- https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/job_history/d66b2d66-8669-4c88-b51f-ae4233d3a746

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
