### PR TITLE
adding updates for calculate genotype wdl

### DIFF
--- a/website/docs/All_of_Us/RNA_Seq_QTL/overview.md
+++ b/website/docs/All_of_Us/RNA_Seq_QTL/overview.md
@@ -30,7 +30,7 @@ The table below reflects the original end-to-end run order, including steps that
 | Order | Stage | Workflow / Component | Documentation | WDL | Run next |
 | :--: | --- | --- | --- | --- | --- |
 | 0 | Cohort setup | Ancestry grouping and sample lists | No dedicated WDL page (notebook/table prep) | N/A | Use ancestry/sample partitions as inputs to genotype and phenotype prep. |
-| 1 | Genotype prep | Prepare genotypes (pruning + PLINK + PCs) | No dedicated page yet | [PrepareGenotypes.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/PrepareGenotypes.wdl) | Run dosage generation per ancestry/population. |
+| 1 | Genotype prep | Prepare genotypes (pruning + PLINK + PCs) | [Genotype Preparation Tools](#genotype-preparation-tools) | [PrepareGenotypes.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/PrepareGenotypes.wdl) | Run dosage generation per ancestry/population. |
 | 2 | Genotype prep | Calculate genotype dosage | No dedicated page yet | [calculateGenotypeDosage.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/prepare_QTL/calculateGenotypeDosage.wdl) | Feed dosages into TensorQTL and SuSiE inputs later. |
 | 3 | RNA processing | RNA-seq AoU processing (alignment/quant/QC) | [RNA-seq AoU Processing](./rnaseq_aou) | [rnaseq_aou.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/GTEx/rnaseq_aou.wdl) | Branch into eQTL phenotype prep and/or sQTL junction extraction. |
 | 4 | RNA processing | Aggregate cohort-level RNA outputs (RSEM in WARP; RNA-SeQC2 external for now) | No dedicated page yet | [aggregate_rsem_results.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/GTEx/aggregate_rsem_results.wdl) | Use aggregated expression/QC summaries for downstream phenotype prep and cohort QC review. |
@@ -41,7 +41,7 @@ The table below reflects the original end-to-end run order, including steps that
 | 9 | sQTL metadata | Calculate phenotype groups | [Calculate Phenotype Groups](./calculate_phenotype_groups) | [CalculatePhenotypeGroups.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl) | Merge covariates for sQTL TensorQTL run. |
 | 10 | Covariates | Merge covariates (genotype PCs + phenotype PCs ± groups) | No dedicated page yet | [MergeCovariates.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/prepare_QTL/MergeCovariates.wdl) | Run TensorQTL cis permutations for eQTL/sQTL. |
 | 11 | Association | TensorQTL cis permutations | No dedicated page yet | [tensorqtl_cis_permutations.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/tensorQTL_cis_permutations/tensorqtl_cis_permutations.wdl) | Recalculate FDR and prepare significant loci for fine-mapping. |
-| 12 | Fine-mapping prep | FDR recalculation + SuSiE input preparation, including required AF calculation and genotype dosage checks for downstream aggregation/annotation | No dedicated page yet | [calculateAF.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl) | Run SuSiE per phenotype window. |
+| 12 | Fine-mapping prep | FDR recalculation + SuSiE input preparation, including required AF calculation for downstream aggregation/annotation | No dedicated page yet | [calculateAF.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/prepare_QTL/calculateAF.wdl) | Run SuSiE per phenotype window. |
 | 13 | Fine-mapping | SuSiE fine-mapping | [SuSiE Fine-Mapping Workflow](./susieR_workflow) | [susieR_workflow.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/susieR_workflow.wdl) | Aggregate SuSiE outputs across phenotypes. |
 | 14 | Aggregation | Aggregate SuSiE outputs and annotate | [Aggregate SuSiE Workflow](./aggregate_susie_workflow) | [AggregateSusieWorkflow.wdl](https://github.com/broadinstitute/warp/blob/develop/all_of_us/rna_seq/AggregateSusieWorkflow.wdl) | Consume required AF outputs from step 12 for interpretation/reporting. |
 
@@ -51,6 +51,18 @@ The table below reflects the original end-to-end run order, including steps that
 * **sQTL path:** 0 → 1 → 2 → 3 → 4 → 6 → 7 → 8 → 9 (if required) → 10 → 11 → 12 → 13 → 14.
 * **Key dependency:** `susieR_workflow` expects TensorQTL-derived significant loci plus dosage inputs from earlier genotype steps.
 * **Phenotype groups:** required for many sQTL TensorQTL configurations; for eQTL they are typically not required.
+
+## Genotype Preparation Tools
+
+The genotype preparation stage (Step 1) uses tools available in the [warp-tools](https://github.com/broadinstitute/warp-tools) repository:
+
+* **`compute_genotype_PCS.R`** — Located in `3rd-party-tools/aou_qtl_prepare_genotypes/`. This R script calculates genetic principal components (PCs) from a VCF file. It performs:
+  - VCF to GDS conversion
+  - LD-based pruning (LD threshold = 0.2, MAF = 0.01)
+  - PCA analysis using SNPRelate
+  - Automatic PC selection via the Gavish-Donoho method to determine the optimal number of significant PCs
+  
+  The script outputs a table with sample IDs and genetic PC values for downstream covariate preparation.
 
 ## Additional Processing Notes
 


### PR DESCRIPTION
This PR adds information to the All of Us RNA QTL  overview in warp docs about the R script used to calculate phenotype PCs for CDRv9. This script was used to calculate genotype PCs for both eQTL and pQTL analysis. 