### PR TITLE
TSPS-1037 updates made while scale testing

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.1.0	2026-08-26
 Glimpse2LowPassImputationBatch	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQC	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.1	2026-08-24 
-Glimpse2SVImputation	 0.0.25	2026-08-27 
-Glimpse2SVImputationBatch	 0.0.18	2026-08-27 
+Glimpse2SVImputation	 0.0.26	2026-08-28 
+Glimpse2SVImputationBatch	 0.0.19	2026-08-28 
 Glimpse2SVImputationQC	 0.0.2	2026-08-26 
 Glimpse2SVImputationQuotaConsumed	 0.0.2	2026-08-26 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
@@ -18,12 +18,12 @@ Imputation	 1.1.23	2025-10-03
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.9	2026-08-27 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.10	2026-08-28 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
-PreprocessPLsGVCF	 0.0.14	2026-08-27 
+PreprocessPLsGVCF	 0.0.15	2026-08-28 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -2,6 +2,7 @@
 2026-08-28 (Date of Last Commit)
 
 * Update `Glimpse2SVImputationBatch` to optionally use base glimpse phase memory from chunk panel json.
+* remove `boot_disk_gb` from tasks
 
 # 0.0.25
 2026-08-27 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.26
+2026-08-28 (Date of Last Commit)
+
+* Update `Glimpse2SVImputationBatch` to optionally use base glimpse phase memory from chunk panel json.
+
 # 0.0.25
 2026-08-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,9 +5,9 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.25"
+    String pipeline_version = "0.0.26"
     String preprocess_pls_gvcf_pipeline_version = "0.0.14"
-    String batch_pipeline_version = "0.0.18"
+    String batch_pipeline_version = "0.0.19"
     String quota_consumed_version = "0.0.2"
     String input_qc_version = "0.0.2"
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow Glimpse2SVImputation {
     String pipeline_version = "0.0.26"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.14"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.15"
     String batch_pipeline_version = "0.0.19"
     String quota_consumed_version = "0.0.2"
     String input_qc_version = "0.0.2"

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.19
+2026-08-28 (Date of Last Commit)
+
+* optionally use base glimpse phase memory from chunk panel json if available, otherwise default to 16 GB.
+
 # 0.0.18
 2026-08-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -2,6 +2,7 @@
 2026-08-28 (Date of Last Commit)
 
 * optionally use base glimpse phase memory from chunk panel json if available, otherwise default to 16 GB.
+* remove `boot_disk_gb` from tasks
 
 # 0.0.18
 2026-08-27 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.18"
+    String pipeline_version = "0.0.19"
 
     input {
         File input_preprocessed_joint_vcf
@@ -30,6 +30,8 @@ workflow Glimpse2SVImputationBatch {
         String glimpse2_docker
     }
 
+    Map[String, ChunkedPanelChromosome] chunked_panel = read_json(chunked_panel_json)
+
     Map[String, String] genetic_maps_dict = read_map(genetic_maps_tsv)
     Map[String, PopAndMarginalizePanelResourcesChromosome] pop_glimpse2_panel_resources = read_json(pop_glimpse2_panel_resources_json)
 
@@ -41,10 +43,10 @@ workflow Glimpse2SVImputationBatch {
     scatter (chromosome in chromosomes) {
         String genetic_map = genetic_maps_dict[chromosome]
 
-        Map[String, ChunkedPanelChromosome] chunked_panel = read_json(chunked_panel_json)
         Array[String] input_regions = chunked_panel[chromosome].input_regions
         Array[String] output_regions = chunked_panel[chromosome].output_regions
         Array[File] panel_split_chunk_bins = chunked_panel[chromosome].panel_split_chunk_bins
+        Array[Int] defined_phase_base_mem_values = select_first([chunked_panel[chromosome].phase_base_mem, []])
 
         File panel_bubble_split_sites_only_vcf = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf
         File panel_bubble_split_sites_only_vcf_idx = pop_glimpse2_panel_resources[chromosome].panel_bubble_split_sites_only_vcf_idx
@@ -53,6 +55,8 @@ workflow Glimpse2SVImputationBatch {
         Array[String] pop_regions = select_first([pop_glimpse2_panel_resources[chromosome].pop_regions, output_regions])
 
         scatter (k in range(length(output_regions))) {
+            Int phase_mem_gb = if (k < length(defined_phase_base_mem_values)) then defined_phase_base_mem_values[k] else 16
+
             call GLIMPSE2Phase as ChunkedGLIMPSE2Phase {
                 input:
                     input_vcf = input_preprocessed_joint_vcf,
@@ -64,6 +68,7 @@ workflow Glimpse2SVImputationBatch {
                     output_basename = output_basename + ".shard-" + k + ".glimpse2.phased",
                     extra_phase_args = extra_phase_args,
                     docker = glimpse2_docker,
+                    mem_gb = phase_mem_gb,
                     threads = defined_glimpse_phase_cpu_override
             }
         }
@@ -133,6 +138,7 @@ struct ChunkedPanelChromosome {
     Array[String] input_regions
     Array[String] output_regions
     Array[String] panel_split_chunk_bins
+    Array[Int]? phase_base_mem
 }
 
 struct PopAndMarginalizePanelResourcesChromosome {
@@ -154,6 +160,7 @@ task GLIMPSE2Phase {
         File genetic_map
         String output_basename
         Int seed = 15052011
+        Int mem_gb = 16
         Int threads = 4
         String? extra_phase_args
 
@@ -171,7 +178,7 @@ task GLIMPSE2Phase {
         }
     }
 
-    Int disk_size_gb = ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 40)
+    Int disk_size_gb = 2*ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 30)
 
     command <<<
         set -euxo pipefail
@@ -213,9 +220,8 @@ task GLIMPSE2Phase {
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          threads,
-        mem_gb:             16,
+        mem_gb:             mem_gb,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  30,
         max_retries:        3,
@@ -226,7 +232,6 @@ task GLIMPSE2Phase {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + if select_first([runtime_attr.use_ssd, default_attr.use_ssd]) then " SSD" else " HDD"
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
@@ -268,7 +273,6 @@ task GLIMPSE2Ligate {
         cpu_cores:          cpu,
         mem_gb:             18,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  0,
         max_retries:        1,
@@ -279,7 +283,6 @@ task GLIMPSE2Ligate {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + if select_first([runtime_attr.use_ssd, default_attr.use_ssd]) then " SSD" else " HDD"
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
@@ -324,9 +327,8 @@ task PopAndMarginalizeCollisions {
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          2,
-        mem_gb:             8,
+        mem_gb:             10,
         disk_gb:            disk_gb,
-        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  2,
         max_retries:        1,
@@ -337,7 +339,6 @@ task PopAndMarginalizeCollisions {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + if select_first([runtime_attr.use_ssd, default_attr.use_ssd]) then " SSD" else " HDD"
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
@@ -395,7 +396,6 @@ task UpdateHeader {
     runtime {
         docker: docker
         disks: "local-disk " + disk_size_gb + " SSD"
-        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         maxRetries: max_retries

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.10
+2026-08-28 (Date of Last Commit)
+
+* remove `boot_disk_gb` from tasks
+
 # 0.0.9
 2026-08-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.9"
+    String pipeline_version = "0.0.10"
 
     input {
         Array[String]? vcfs_array

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -191,7 +191,6 @@ task CreateBatches {
         cpu_cores:          1,
         mem_gb:             2,
         disk_gb:            10,
-        boot_disk_gb:       0,
         disk_type:          "HDD",
         preemptible_tries:  2,
         max_retries:        1,
@@ -202,7 +201,6 @@ task CreateBatches {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " " + select_first([runtime_attr.disk_type, default_attr.disk_type])
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
@@ -341,7 +339,6 @@ task MergeVcfs {
         cpu_cores:          cpu,
         mem_gb:             4,
         disk_gb:            disk_gb,
-        boot_disk_gb:       0,
         disk_type:          "SSD",
         preemptible_tries:  3,
         max_retries:        0,
@@ -352,7 +349,6 @@ task MergeVcfs {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " " + select_first([runtime_attr.disk_type, default_attr.disk_type])
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.15
+2026-08-28 (Date of Last Commit)
+
+* remove `boot_disk_gb` from tasks
+
 # 0.0.14
 2026-08-27 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -5,8 +5,8 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.14"
-    String multi_level_paste_pipeline_version = "0.0.9"
+    String pipeline_version = "0.0.15"
+    String multi_level_paste_pipeline_version = "0.0.10"
     input {
         File input_gvcf_manifest
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -117,7 +117,6 @@ task PreprocessPLs {
         cpu_cores:          cpu,
         mem_gb:             2,
         disk_gb:            disk_size_gb,
-        boot_disk_gb:       0,
         use_ssd:            true,
         preemptible_tries:  4,
         max_retries:        1,
@@ -128,7 +127,6 @@ task PreprocessPLs {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + if select_first([runtime_attr.use_ssd, default_attr.use_ssd]) then " SSD" else " HDD"
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -75,7 +75,6 @@ task MergeSampleChunksVcfsWithPaste {
     runtime {
         docker: "us.gcr.io/broad-dsde-methods/bcftools_bgzip:beagle_imputation_v1.0.0"
         disks: "local-disk " + disk_size_gb + " HDD"
-        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -98,7 +97,7 @@ task ExtractAnnotations {
         Int disk_size_gb = ceil(2 * size(imputed_vcf, "GiB") + 50)
         Int mem_gb = 2
         Int cpu = 1
-        Int preemptible = 1
+        Int preemptible = 3
     }
 
     command <<<
@@ -118,7 +117,6 @@ task ExtractAnnotations {
     runtime {
         docker: docker_extract_annotations
         disks: "local-disk " + disk_size_gb + " HDD"
-        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -212,7 +210,6 @@ EOF
     runtime {
         docker: docker_merge
         disks: "local-disk " + disk_size_gb + " HDD"
-        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -254,7 +251,6 @@ task CreateVcfIndexAndMd5 {
     runtime {
         docker: gatk_docker
         disks: "local-disk ${disk_size_gb} SSD"
-        bootDiskSizeGb: 0
         memory: "${memory_mb} MiB"
         cpu: cpu
         preemptible: preemptible
@@ -290,7 +286,6 @@ task FilterVcfByInfo {
     runtime {
         docker: docker
         disks: "local-disk " + disk_size_gb + " HDD"
-        bootDiskSizeGb: 0
         memory: mem_gb + " GiB"
         cpu: cpu
         preemptible: preemptible
@@ -345,7 +340,6 @@ task SplitVcfManifestIntoBatches {
         docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
         cpu: 1
         disks: "local-disk 10 HDD"
-        bootDiskSizeGb: 0
         memory: "1 GiB"
         preemptible: 3
         noAddress: true
@@ -391,7 +385,6 @@ task ConvertInputArraysToManifest {
         cpu: 1
         memory: "1 GiB"
         disks: "local-disk 10 HDD"
-        bootDiskSizeGb: 0
         preemptible: 3
         noAddress: true
     }
@@ -436,7 +429,6 @@ task ParseVcfManifestIntoArrays {
         cpu: 1
         memory: "1 GiB"
         disks: "local-disk 10 HDD"
-        bootDiskSizeGb: 0
         preemptible: 3
         noAddress: true
     }
@@ -476,7 +468,6 @@ task ConcatBcfs {
         cpu: 1
         memory: "4 GiB"
         disks: "local-disk " + disk_gb + " SSD"
-        bootDiskSizeGb: 0
         preemptible: 3
         maxRetries: 0
         docker: "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"


### PR DESCRIPTION
### Description

These are changes we made while trying to scale test the workflow to 20k samples.  These changes include

* add the ability to optionally provide shard specific glimpse phase memory
* increase memory for pop collisions task
* remove bootDiskSize runtime field because it wasnt doing anythign being set to 0

Doc detailing the different scaling attempts and some background info relevant to this PR: https://docs.google.com/document/d/1b9wQd3gXkAoidk8znbD3Y4e2lwLEIUIYRudk4ts1K5Q/edit?tab=t.0#heading=h.brrk3enbqt6g

We successfully ran 10k samples and failed at 20k samples

Jira ticket:
https://broadworkbench.atlassian.net/browse/TSPS-1037

Submission with shard specific memory specified: 
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/aa50d3f1-b965-4d89-8a94-d56ca107f76d

Submission with shard specific memory not specified:
https://app.terra.bio/#workspaces/allofus-drc-imputation/aou_sv_imputation_tsps_testing/submission_history/8a59dcc5-86db-42ee-9551-7ee2a2578f37

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
