### PR TITLE
TSPS-1154 update sv pipeline task variables

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,8 +9,8 @@ Glimpse2LowPassImputation	 1.1.0	2026-08-26
 Glimpse2LowPassImputationBatch	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQC	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.1	2026-08-24 
-Glimpse2SVImputation	 0.0.26	2026-08-28 
-Glimpse2SVImputationBatch	 0.0.19	2026-08-28 
+Glimpse2SVImputation	 0.0.27	2026-08-31 
+Glimpse2SVImputationBatch	 0.0.20	2026-08-31 
 Glimpse2SVImputationQC	 0.0.2	2026-08-26 
 Glimpse2SVImputationQuotaConsumed	 0.0.2	2026-08-26 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
@@ -18,12 +18,12 @@ Imputation	 1.1.23	2025-10-03
 ImputationBeagle	 3.0.1	2026-02-23 
 JointGenotyping	 1.7.3	2025-08-11 
 MultiSampleSmartSeq2SingleNucleus	 2.2.8	2026-07-10 
-MultilevelHierarchicallyPasteVcfsStreaming	 0.0.10	2026-08-28 
+MultilevelHierarchicallyPasteVcfsStreaming	 0.0.11	2026-08-31 
 Multiome	 7.0.2	2026-07-10 
 Optimus	 9.2.0	2026-07-10 
 PairedTag	 3.0.2	2026-07-10 
 PeakCalling	 1.0.1	2025-08-11 
-PreprocessPLsGVCF	 0.0.15	2026-08-28 
+PreprocessPLsGVCF	 0.0.16	2026-08-31 
 RNAWithUMIsPipeline	 1.0.20	2026-01-21 
 ReblockGVCF	 2.4.4	2026-01-29 
 SlideSeq	 3.6.8	2026-07-10 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.27
+2026-08-31 (Date of Last Commit)
+
+* Update `ConvertInputArraysToManifest` output wiring to use `output_gvcf_manifest`.
+* Switch `PreProcessGVCFsBatch` outputs consumed by `Glimpse2SVImputationBatch` from `preprocessed_pls_vcf` to `preprocessed_pls_bcf` naming.
+* Update linked `preprocess_pls_gvcf_pipeline_version` to 0.0.16 and `batch_pipeline_version` to 0.0.20.
+
 # 0.0.26
 2026-08-28 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -82,8 +82,8 @@ workflow Glimpse2SVImputation {
 
         call Glimpse2SVImputationBatch.Glimpse2SVImputationBatch as RunBatch {
             input:
-                input_preprocessed_joint_vcf = PreProcessGVCFsBatch.preprocessed_pls_bcf,
-                input_preprocessed_joint_vcf_idx = PreProcessGVCFsBatch.preprocessed_pls_bcf_idx,
+                input_preprocessed_joint_vcf_or_bcf = PreProcessGVCFsBatch.preprocessed_pls_bcf,
+                input_preprocessed_joint_vcf_or_bcf_idx = PreProcessGVCFsBatch.preprocessed_pls_bcf_idx,
                 chromosomes = chromosomes,
                 genetic_maps_tsv = genetic_maps_tsv,
                 ref_dict = ref_dict,
@@ -105,8 +105,8 @@ workflow Glimpse2SVImputation {
             scatter (batch_annot_idx in range(length(popped_bcfs_for_contig))) {
                 call Glimpse2SVImputationTasks.ExtractAnnotations as ExtractPoppedAnnotations {
                     input:
-                        imputed_vcf = popped_bcfs_for_contig[batch_annot_idx],
-                        imputed_vcf_index = popped_bcf_idxs_for_contig[batch_annot_idx],
+                        imputed_vcf_or_bcf = popped_bcfs_for_contig[batch_annot_idx],
+                        imputed_vcf_or_bcf_index = popped_bcf_idxs_for_contig[batch_annot_idx],
                         batch_index = batch_annot_idx,
                         docker_extract_annotations = gatk_docker
                 }
@@ -114,13 +114,13 @@ workflow Glimpse2SVImputation {
 
             call Glimpse2SVImputationTasks.MergeSampleChunksVcfsWithPaste as MergePoppedContigVcfs {
                 input:
-                    input_vcfs = popped_bcfs_for_contig,
+                    input_vcfs_or_bcfs = popped_bcfs_for_contig,
                     output_vcf_basename = output_basename + "." + chromosomes[contig_idx] + ".glimpse2.popped.merged"
             }
 
             call Glimpse2SVImputationTasks.RecomputeAndAnnotate as RecomputePoppedAfInfo {
                 input:
-                    merged_vcf = MergePoppedContigVcfs.output_vcf,
+                    merged_vcf_or_bcf = MergePoppedContigVcfs.output_vcf,
                     annotations = ExtractPoppedAnnotations.annotations,
                     num_samples = PreProcessGVCFsBatch.num_samples,
                     output_basename = output_basename + "." + chromosomes[contig_idx] + ".glimpse2.popped.merged.reannotated",
@@ -133,7 +133,7 @@ workflow Glimpse2SVImputation {
         if (info_filter_for_inclusion > 0.0) {
             call Glimpse2SVImputationTasks.FilterVcfByInfo as FilterPoppedContigByInfo {
                 input:
-                    vcf = final_popped_contig_vcf,
+                    vcf_or_bcf = final_popped_contig_vcf,
                     info_threshold = info_filter_for_inclusion,
                     output_basename = output_basename + "." + chromosomes[contig_idx] + ".glimpse2.popped.info_filtered"
             }
@@ -143,7 +143,7 @@ workflow Glimpse2SVImputation {
 
         call Glimpse2SVImputationTasks.CreateVcfIndexAndMd5 as IndexFinalPoppedContig {
             input:
-                vcf_input = final_filtered_popped_contig_vcf,
+                vcf_input_or_bcf = final_filtered_popped_contig_vcf,
                 output_basename = output_basename + "." + chromosomes[contig_idx],
                 gatk_docker = gatk_docker,
                 preemptible = 0

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,9 +5,9 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.26"
-    String preprocess_pls_gvcf_pipeline_version = "0.0.15"
-    String batch_pipeline_version = "0.0.19"
+    String pipeline_version = "0.0.27"
+    String preprocess_pls_gvcf_pipeline_version = "0.0.16"
+    String batch_pipeline_version = "0.0.20"
     String quota_consumed_version = "0.0.2"
     String input_qc_version = "0.0.2"
 
@@ -62,7 +62,7 @@ workflow Glimpse2SVImputation {
     }
 
     # if neither the full array input set nor gvcf_manifest is provided the workflow will fail at runtime
-    File gvcf_manifest_to_use = select_first([ConvertInputArraysToManifest.output_manifest, gvcf_manifest])
+    File gvcf_manifest_to_use = select_first([ConvertInputArraysToManifest.output_gvcf_manifest, gvcf_manifest])
 
     call Glimpse2SVImputationTasks.SplitVcfManifestIntoBatches as SplitIntoSampleBatches {
         input:
@@ -82,8 +82,8 @@ workflow Glimpse2SVImputation {
 
         call Glimpse2SVImputationBatch.Glimpse2SVImputationBatch as RunBatch {
             input:
-                input_preprocessed_joint_vcf = PreProcessGVCFsBatch.preprocessed_pls_vcf,
-                input_preprocessed_joint_vcf_idx = PreProcessGVCFsBatch.preprocessed_pls_vcf_idx,
+                input_preprocessed_joint_vcf = PreProcessGVCFsBatch.preprocessed_pls_bcf,
+                input_preprocessed_joint_vcf_idx = PreProcessGVCFsBatch.preprocessed_pls_bcf_idx,
                 chromosomes = chromosomes,
                 genetic_maps_tsv = genetic_maps_tsv,
                 ref_dict = ref_dict,

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -3,6 +3,7 @@
 
 * Rename local task outputs and workflow wiring from `*_vcf` to `*_bcf` for phase, ligate, pop, and concat steps.
 * Rename `UpdateHeader` inputs to `source_header_vcf` and `to_be_reheadered_bcf` and propagate the new names through command usage.
+* update variable names to vcf_or_bcf for any variable that can be either
 
 # 0.0.19
 2026-08-28 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.20
+2026-08-31 (Date of Last Commit)
+
+* Rename local task outputs and workflow wiring from `*_vcf` to `*_bcf` for phase, ligate, pop, and concat steps.
+* Rename `UpdateHeader` inputs to `source_header_vcf` and `to_be_reheadered_bcf` and propagate the new names through command usage.
+
 # 0.0.19
 2026-08-28 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -85,7 +85,7 @@ workflow Glimpse2SVImputationBatch {
         call UpdateHeader {
             input:
                 to_be_reheadered_bcf = GLIMPSE2Ligate.ligated_bcf,
-                source_header_vcf = input_preprocessed_joint_vcf_or_bcf,
+                source_header_vcf_or_bcf = input_preprocessed_joint_vcf_or_bcf,
                 ref_dict = ref_dict,
                 output_basename = output_basename +  "." + chromosome + ".glimpse2.bubble.updated_header",
                 docker = glimpse2_docker,
@@ -348,7 +348,7 @@ task PopAndMarginalizeCollisions {
 
 task UpdateHeader {
     input {
-        File source_header_vcf
+        File source_header_vcf_or_bcf
         File to_be_reheadered_bcf
         File ref_dict
         String output_basename
@@ -362,7 +362,7 @@ task UpdateHeader {
     }
 
     parameter_meta {
-        source_header_vcf : {
+        source_header_vcf_or_bcf : {
             localization_optional : true
         }
     }
@@ -375,7 +375,7 @@ task UpdateHeader {
         # Set correct reference dictionary
 
         # take input VCF header and add GLIMPSE INFO and FORMAT lines (GLIMPSE header only contains a single chromosome and breaks bcftools concat --naive)
-        bcftools view --no-version -h ~{source_header_vcf} | grep '^##' > input.header.txt
+        bcftools view --no-version -h ~{source_header_vcf_or_bcf} | grep '^##' > input.header.txt
         bcftools view --no-version -h ~{to_be_reheadered_bcf} | grep -E '^##INFO|^##FORMAT|^##NMAIN|^##FPLOIDY' > glimpse2.header.txt
         bcftools view --no-version -h ~{to_be_reheadered_bcf} | grep '^#CHROM' > glimpse2.columns.txt
         cat input.header.txt glimpse2.header.txt glimpse2.columns.txt > header.vcf

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -7,8 +7,8 @@ workflow Glimpse2SVImputationBatch {
     String pipeline_version = "0.0.20"
 
     input {
-        File input_preprocessed_joint_vcf
-        File input_preprocessed_joint_vcf_idx
+        File input_preprocessed_joint_vcf_or_bcf
+        File input_preprocessed_joint_vcf_or_bcf_idx
 
         Array[String] chromosomes
         File genetic_maps_tsv
@@ -59,8 +59,8 @@ workflow Glimpse2SVImputationBatch {
 
             call GLIMPSE2Phase as ChunkedGLIMPSE2Phase {
                 input:
-                    input_vcf = input_preprocessed_joint_vcf,
-                    input_vcf_idx = input_preprocessed_joint_vcf_idx,
+                    input_vcf_or_bcf = input_preprocessed_joint_vcf_or_bcf,
+                    input_vcf_or_bcf_idx = input_preprocessed_joint_vcf_or_bcf_idx,
                     panel_split_chunk_bin = panel_split_chunk_bins[k],
                     input_region = input_regions[k],
                     output_region = output_regions[k],
@@ -75,8 +75,8 @@ workflow Glimpse2SVImputationBatch {
 
         call GLIMPSE2Ligate {
             input:
-                phased_vcfs = ChunkedGLIMPSE2Phase.phased_bcf,
-                phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_bcf_idx,
+                phased_vcfs_or_bcfs = ChunkedGLIMPSE2Phase.phased_bcf,
+                phased_vcf_or_bcf_idxs = ChunkedGLIMPSE2Phase.phased_bcf_idx,
                 output_basename = output_basename + ".glimpse2.bubble",
                 docker = glimpse2_docker
         }
@@ -85,7 +85,7 @@ workflow Glimpse2SVImputationBatch {
         call UpdateHeader {
             input:
                 to_be_reheadered_bcf = GLIMPSE2Ligate.ligated_bcf,
-                source_header_vcf = input_preprocessed_joint_vcf,
+                source_header_vcf = input_preprocessed_joint_vcf_or_bcf,
                 ref_dict = ref_dict,
                 output_basename = output_basename +  "." + chromosome + ".glimpse2.bubble.updated_header",
                 docker = glimpse2_docker,
@@ -95,8 +95,8 @@ workflow Glimpse2SVImputationBatch {
         scatter (k in range(length(pop_regions))) {
             call PopAndMarginalizeCollisions {
                 input:
-                    posteriors_vcf = UpdateHeader.output_bcf,
-                    posteriors_vcf_idx = UpdateHeader.output_bcf_index,
+                    posteriors_vcf_or_bcf = UpdateHeader.output_bcf,
+                    posteriors_vcf_or_bcf_idx = UpdateHeader.output_bcf_index,
                     panel_bubble_split_sites_only_vcf = panel_bubble_split_sites_only_vcf,
                     panel_bubble_split_sites_only_vcf_idx = panel_bubble_split_sites_only_vcf_idx,
                     panel_id_split_vcf_gz = panel_id_split_vcf_gz,
@@ -152,8 +152,8 @@ struct PopAndMarginalizePanelResourcesChromosome {
 # checkpoint implementation borrowed from https://github.com/broadinstitute/palantir-workflows/blob/main/GlimpseImputationPipeline/Glimpse2Imputation.wdl
 task GLIMPSE2Phase {
     input {
-        File input_vcf
-        File input_vcf_idx
+        File input_vcf_or_bcf
+        File input_vcf_or_bcf_idx
         File panel_split_chunk_bin
         String input_region
         String output_region
@@ -170,15 +170,15 @@ task GLIMPSE2Phase {
     }
 
     parameter_meta {
-        input_vcf: {
+        input_vcf_or_bcf: {
             localization_optional: true
         }
-        input_vcf_idx: {
+        input_vcf_or_bcf_idx: {
             localization_optional: true
         }
     }
 
-    Int disk_size_gb = 2*ceil(size(input_vcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 30)
+    Int disk_size_gb = 2*ceil(size(input_vcf_or_bcf, "GiB") + size(panel_split_chunk_bin, "GiB") + size(genetic_map, "GiB") + 30)
 
     command <<<
         set -euxo pipefail
@@ -186,7 +186,7 @@ task GLIMPSE2Phase {
         export GCS_OAUTH_TOKEN=$(/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
 
         cmd="/bin/GLIMPSE2_phase \
-                --input-gl ~{input_vcf} \
+                --input-gl ~{input_vcf_or_bcf} \
                 -R ~{panel_split_chunk_bin} \
                 ~{extra_phase_args} \
                 --output ~{output_basename}.bcf \
@@ -242,8 +242,8 @@ task GLIMPSE2Phase {
 
 task GLIMPSE2Ligate {
     input {
-        Array[File] phased_vcfs
-        Array[File] phased_vcf_idxs
+        Array[File] phased_vcfs_or_bcfs
+        Array[File] phased_vcf_or_bcf_idxs
         String output_basename
         Int cpu = 2
 
@@ -252,12 +252,12 @@ task GLIMPSE2Ligate {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size_gb = ceil(2.1*size(phased_vcfs, "GB")) + 10
+    Int disk_size_gb = ceil(2.1*size(phased_vcfs_or_bcfs, "GB")) + 10
 
     command <<<
         set -euox pipefail
 
-        /bin/GLIMPSE2_ligate --input ~{write_lines(phased_vcfs)} --output ~{output_basename}.bcf --threads ~{cpu}
+        /bin/GLIMPSE2_ligate --input ~{write_lines(phased_vcfs_or_bcfs)} --output ~{output_basename}.bcf --threads ~{cpu}
 
         # the index generated by ligate appears to be corrupt for both bcf and vcf.gz output (possibly due to https://github.com/samtools/htslib/issues/1740), so we regenerate with bcftools
         bcftools index -f ~{output_basename}.bcf
@@ -293,8 +293,8 @@ task GLIMPSE2Ligate {
 task PopAndMarginalizeCollisions {
     input {
         # all VCFs should be split to biallelic
-        File posteriors_vcf
-        File posteriors_vcf_idx
+        File posteriors_vcf_or_bcf
+        File posteriors_vcf_or_bcf_idx
         File panel_bubble_split_sites_only_vcf          # for annotation of INFO fields
         File panel_bubble_split_sites_only_vcf_idx
         File panel_id_split_vcf_gz           # panel popping script currently requires vcf.gz, so we also use that here
@@ -306,7 +306,7 @@ task PopAndMarginalizeCollisions {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_gb = ceil(3*size(posteriors_vcf, "GB")) + ceil(size([panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB")) + 10
+    Int disk_gb = ceil(3*size(posteriors_vcf_or_bcf, "GB")) + ceil(size([panel_bubble_split_sites_only_vcf, panel_id_split_vcf_gz], "GB")) + 10
 
     command <<<
         set -euox pipefail
@@ -314,7 +314,7 @@ task PopAndMarginalizeCollisions {
         # this now only works for pop-glimpse2-joint-opt.rs;
         # the sort may also be extraneous, but we keep it in to guard against getting out of sync with the popped panel
         bcftools view -r ~{region} --regions-overlap 0 ~{panel_bubble_split_sites_only_vcf} -Oz -o panel.bubble.split.sites.shard.vcf.gz
-        bcftools view -r ~{region} --regions-overlap 0 ~{posteriors_vcf} | \
+        bcftools view -r ~{region} --regions-overlap 0 ~{posteriors_vcf_or_bcf} | \
             /usr/local/bin/pop-glimpse2 ~{panel_id_split_vcf_gz} panel.bubble.split.sites.shard.vcf.gz | \
             bcftools sort --max-mem=2G -W -Ob -o ~{output_basename}.bcf
     >>>

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputationBatch.wdl
@@ -4,7 +4,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow Glimpse2SVImputationBatch {
     # if this changes, update the batch_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.19"
+    String pipeline_version = "0.0.20"
 
     input {
         File input_preprocessed_joint_vcf
@@ -75,8 +75,8 @@ workflow Glimpse2SVImputationBatch {
 
         call GLIMPSE2Ligate {
             input:
-                phased_vcfs = ChunkedGLIMPSE2Phase.phased_vcf,
-                phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_vcf_idx,
+                phased_vcfs = ChunkedGLIMPSE2Phase.phased_bcf,
+                phased_vcf_idxs = ChunkedGLIMPSE2Phase.phased_bcf_idx,
                 output_basename = output_basename + ".glimpse2.bubble",
                 docker = glimpse2_docker
         }
@@ -84,8 +84,8 @@ workflow Glimpse2SVImputationBatch {
         # Update VCF header with reference dictionary
         call UpdateHeader {
             input:
-                bcf_to_reheader = GLIMPSE2Ligate.ligated_vcf,
-                bcf_to_get_header_from = input_preprocessed_joint_vcf,
+                to_be_reheadered_bcf = GLIMPSE2Ligate.ligated_bcf,
+                source_header_vcf = input_preprocessed_joint_vcf,
                 ref_dict = ref_dict,
                 output_basename = output_basename +  "." + chromosome + ".glimpse2.bubble.updated_header",
                 docker = glimpse2_docker,
@@ -108,8 +108,8 @@ workflow Glimpse2SVImputationBatch {
 
         call Glimpse2SVImputationTasks.ConcatBcfs as ConcatPopAndMarginalizeCollisions {
             input:
-                bcfs = PopAndMarginalizeCollisions.popped_vcf,
-                bcf_idxs = PopAndMarginalizeCollisions.popped_vcf_idx,
+                bcfs = PopAndMarginalizeCollisions.popped_bcf,
+                bcf_idxs = PopAndMarginalizeCollisions.popped_bcf_idx,
                 output_basename = output_basename + "." + chromosome + ".glimpse2.popped",
                 extra_args = "--naive",
         }
@@ -213,8 +213,8 @@ task GLIMPSE2Phase {
     >>>
 
     output {
-        File phased_vcf = "~{output_basename}.bcf"
-        File phased_vcf_idx = "~{output_basename}.bcf.csi"
+        File phased_bcf = "~{output_basename}.bcf"
+        File phased_bcf_idx = "~{output_basename}.bcf.csi"
     }
 
     #########################
@@ -264,8 +264,8 @@ task GLIMPSE2Ligate {
     >>>
 
     output {
-        File ligated_vcf = "~{output_basename}.bcf"
-        File ligated_vcf_idx = "~{output_basename}.bcf.csi"
+        File ligated_bcf = "~{output_basename}.bcf"
+        File ligated_bcf_idx = "~{output_basename}.bcf.csi"
     }
 
     #########################
@@ -320,8 +320,8 @@ task PopAndMarginalizeCollisions {
     >>>
 
     output {
-        File popped_vcf = "~{output_basename}.bcf"
-        File popped_vcf_idx = "~{output_basename}.bcf.csi"
+        File popped_bcf = "~{output_basename}.bcf"
+        File popped_bcf_idx = "~{output_basename}.bcf.csi"
     }
 
     #########################
@@ -348,21 +348,21 @@ task PopAndMarginalizeCollisions {
 
 task UpdateHeader {
     input {
-        File bcf_to_reheader
-        File bcf_to_get_header_from
+        File source_header_vcf
+        File to_be_reheadered_bcf
         File ref_dict
         String output_basename
         String? pipeline_header_line
 
         Int mem_gb = 2
         Int cpu = 1
-        Int disk_size_gb = ceil(2.1 * size(bcf_to_reheader, "GiB")) + 10
+        Int disk_size_gb = ceil(2.1 * size(to_be_reheadered_bcf, "GiB")) + 10
         Int max_retries = 1
         String docker
     }
 
     parameter_meta {
-        bcf_to_get_header_from : {
+        source_header_vcf : {
             localization_optional : true
         }
     }
@@ -375,9 +375,9 @@ task UpdateHeader {
         # Set correct reference dictionary
 
         # take input VCF header and add GLIMPSE INFO and FORMAT lines (GLIMPSE header only contains a single chromosome and breaks bcftools concat --naive)
-        bcftools view --no-version -h ~{bcf_to_get_header_from} | grep '^##' > input.header.txt
-        bcftools view --no-version -h ~{bcf_to_reheader} | grep -E '^##INFO|^##FORMAT|^##NMAIN|^##FPLOIDY' > glimpse2.header.txt
-        bcftools view --no-version -h ~{bcf_to_reheader} | grep '^#CHROM' > glimpse2.columns.txt
+        bcftools view --no-version -h ~{source_header_vcf} | grep '^##' > input.header.txt
+        bcftools view --no-version -h ~{to_be_reheadered_bcf} | grep -E '^##INFO|^##FORMAT|^##NMAIN|^##FPLOIDY' > glimpse2.header.txt
+        bcftools view --no-version -h ~{to_be_reheadered_bcf} | grep '^#CHROM' > glimpse2.columns.txt
         cat input.header.txt glimpse2.header.txt glimpse2.columns.txt > header.vcf
 
         # Add pipeline_header_line if provided
@@ -389,7 +389,7 @@ task UpdateHeader {
 
         java -jar /picard.jar UpdateVcfSequenceDictionary -I header.vcf --SD ~{ref_dict} -O updated_header.vcf
 
-        bcftools reheader -h updated_header.vcf ~{bcf_to_reheader} -o ~{output_basename}.bcf
+        bcftools reheader -h updated_header.vcf ~{to_be_reheadered_bcf} -o ~{output_basename}.bcf
         bcftools index ~{output_basename}.bcf
     >>>
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -3,6 +3,7 @@
 
 * Rename merge outputs from `merged_vcf`/`merged_vcf_idx` to `merged_bcf`/`merged_bcf_idx`.
 * Propagate BCF naming through all hierarchical merge levels and final concat wiring.
+* update variable names to vcf_or_bcf for any variable that can be either
 
 # 0.0.10
 2026-08-28 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.changelog.md
@@ -1,3 +1,9 @@
+# 0.0.11
+2026-08-31 (Date of Last Commit)
+
+* Rename merge outputs from `merged_vcf`/`merged_vcf_idx` to `merged_bcf`/`merged_bcf_idx`.
+* Propagate BCF naming through all hierarchical merge levels and final concat wiring.
+
 # 0.0.10
 2026-08-28 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -6,7 +6,7 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow MultilevelHierarchicallyMergeVcfs {
     # if this changes, update the multi_level_paste_pipeline_version value in PreprocessPLsGVCF.wdl
-    String pipeline_version = "0.0.10"
+    String pipeline_version = "0.0.11"
 
     input {
         Array[String]? vcfs_array
@@ -56,8 +56,8 @@ workflow MultilevelHierarchicallyMergeVcfs {
             }
         }
 
-        Array[File] l0_vcfs = L0_Merge.merged_vcf
-        Array[File] l0_idxs = L0_Merge.merged_vcf_idx
+        Array[File] l0_bcfs = L0_Merge.merged_bcf
+        Array[File] l0_idxs = L0_Merge.merged_bcf_idx
 
         # ==========================================
         # LEVEL 1
@@ -65,7 +65,7 @@ workflow MultilevelHierarchicallyMergeVcfs {
         if (length(batch_sizes) > 1) {
             call CreateBatches as L1_Batches {
                 input:
-                    vcfs = l0_vcfs,
+                    vcfs = l0_bcfs,
                     vcf_idxs = l0_idxs,
                     batch_size = batch_sizes[1]
             }
@@ -85,8 +85,8 @@ workflow MultilevelHierarchicallyMergeVcfs {
             }
         }
 
-        Array[File] l1_vcfs = select_first([L1_Merge.merged_vcf, l0_vcfs])
-        Array[File] l1_idxs = select_first([L1_Merge.merged_vcf_idx, l0_idxs])
+        Array[File] l1_bcfs = select_first([L1_Merge.merged_bcf, l0_bcfs])
+        Array[File] l1_idxs = select_first([L1_Merge.merged_bcf_idx, l0_idxs])
 
         # ==========================================
         # LEVEL 2
@@ -94,7 +94,7 @@ workflow MultilevelHierarchicallyMergeVcfs {
         if (length(batch_sizes) > 2) {
             call CreateBatches as L2_Batches {
                 input:
-                    vcfs = l1_vcfs,
+                    vcfs = l1_bcfs,
                     vcf_idxs = l1_idxs,
                     batch_size = batch_sizes[2]
             }
@@ -114,17 +114,17 @@ workflow MultilevelHierarchicallyMergeVcfs {
             }
         }
 
-        Array[File] l2_vcfs = select_first([L2_Merge.merged_vcf, l1_vcfs])
-        Array[File] l2_idxs = select_first([L2_Merge.merged_vcf_idx, l1_idxs])
+        Array[File] l2_bcfs = select_first([L2_Merge.merged_bcf, l1_bcfs])
+        Array[File] l2_idxs = select_first([L2_Merge.merged_bcf_idx, l1_idxs])
 
         # ==========================================
         # FINAL REGION COLLAPSE
         # ==========================================
         # Safety Net: Defaults to localizing workspace intermediate files, no timeout applied (0).
-        if (length(l2_vcfs) > 1) {
+        if (length(l2_bcfs) > 1) {
             call MergeVcfs as FinalRegionMerge {
                 input:
-                    vcfs_localize = l2_vcfs,
+                    vcfs_localize = l2_bcfs,
                     vcf_idxs_localize = l2_idxs,
                     timeout_min = 0,
                     region = region,
@@ -134,22 +134,22 @@ workflow MultilevelHierarchicallyMergeVcfs {
         }
 
         # Select exactly 1 file for this region to pass to the final concat step
-        File final_region_vcf = select_first([FinalRegionMerge.merged_vcf, l2_vcfs[0]])
-        File final_region_idx = select_first([FinalRegionMerge.merged_vcf_idx, l2_idxs[0]])
+        File final_region_bcf = select_first([FinalRegionMerge.merged_bcf, l2_bcfs[0]])
+        File final_region_idx = select_first([FinalRegionMerge.merged_bcf_idx, l2_idxs[0]])
     }
 
     # concatenate all regions together
     call Glimpse2SVImputationTasks.ConcatBcfs {
         input:
-            bcfs = final_region_vcf,
+            bcfs = final_region_bcf,
             bcf_idxs = final_region_idx,
             output_basename = output_basename,
             extra_args = extra_concat_args
     }
 
     output {
-        File merged_vcf = ConcatBcfs.concatenated_bcf
-        File merged_vcf_idx = ConcatBcfs.concatenated_bcf_idx
+        File merged_bcf = ConcatBcfs.concatenated_bcf
+        File merged_bcf_idx = ConcatBcfs.concatenated_bcf_idx
     }
 }
 
@@ -330,8 +330,8 @@ task MergeVcfs {
     >>>
 
     output {
-        File merged_vcf = "~{output_basename}.bcf"
-        File merged_vcf_idx = "~{output_basename}.bcf.csi"
+        File merged_bcf = "~{output_basename}.bcf"
+        File merged_bcf_idx = "~{output_basename}.bcf.csi"
     }
 
     #########################

--- a/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/MultilevelHierarchicallyPasteVcfsStreaming.wdl
@@ -9,10 +9,10 @@ workflow MultilevelHierarchicallyMergeVcfs {
     String pipeline_version = "0.0.11"
 
     input {
-        Array[String]? vcfs_array
-        Array[String]? vcf_idxs_array
-        File? vcfs_fofn
-        File? vcf_idxs_fofn
+        Array[String]? vcfs_or_bcfs_array
+        Array[String]? vcf_or_bcf_idxs_array
+        File? vcfs_or_bcfs_fofn
+        File? vcf_or_bcf_idxs_fofn
         Array[String] regions   # bcftools regions, e.g. ["chr1,chr2,chr3", "chr4,chr5,chr6", ...]
         Array[Int] batch_sizes  # Parameterizable hierarchical levels, e.g., [100, 50]
         Array[Boolean] do_localization # Whether to localize at each corresponding level
@@ -24,13 +24,13 @@ workflow MultilevelHierarchicallyMergeVcfs {
         String extra_concat_args = "--naive"
     }
 
-    Array[String] vcfs_in = if defined(vcfs_array) then select_first([vcfs_array]) else read_lines(select_first([vcfs_fofn]))
-    Array[String] vcf_idxs_in = if defined(vcf_idxs_array) then select_first([vcf_idxs_array]) else read_lines(select_first([vcf_idxs_fofn]))
+    Array[String] vcfs_in = if defined(vcfs_or_bcfs_array) then select_first([vcfs_or_bcfs_array]) else read_lines(select_first([vcfs_or_bcfs_fofn]))
+    Array[String] vcf_idxs_in = if defined(vcf_or_bcf_idxs_array) then select_first([vcf_or_bcf_idxs_array]) else read_lines(select_first([vcfs_or_bcfs_fofn]))
 
     call CreateBatches as L0_Batches {
         input:
-            vcfs = vcfs_in,
-            vcf_idxs = vcf_idxs_in,
+            vcfs_or_bcfs = vcfs_in,
+            vcf_or_bcf_idxs = vcf_idxs_in,
             batch_size = batch_sizes[0]
     }
 
@@ -42,13 +42,13 @@ workflow MultilevelHierarchicallyMergeVcfs {
         # ==========================================
         # LEVEL 0
         # ==========================================
-        scatter (i in range(length(L0_Batches.vcf_batch_fofns))) {
+        scatter (i in range(length(L0_Batches.vcf_or_bcf_batch_fofns))) {
             call MergeVcfs as L0_Merge {
                 input:
-                    vcfs_localize = if do_localization[0] then read_lines(L0_Batches.vcf_batch_fofns[i]) else [],
-                    vcf_idxs_localize = if do_localization[0] then read_lines(L0_Batches.vcf_idx_batch_fofns[i]) else [],
-                    vcfs_stream = if !do_localization[0] then read_lines(L0_Batches.vcf_batch_fofns[i]) else [],
-                    vcf_idxs_stream = if !do_localization[0] then read_lines(L0_Batches.vcf_idx_batch_fofns[i]) else [],
+                    vcfs_or_bcfs_localize = if do_localization[0] then read_lines(L0_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                    vcf_or_bcf_idxs_localize = if do_localization[0] then read_lines(L0_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
+                    vcfs_or_bcfs_stream = if !do_localization[0] then read_lines(L0_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                    vcf_or_bcf_idxs_stream = if !do_localization[0] then read_lines(L0_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
                     timeout_min = timeouts_min[0],
                     region = region,
                     output_basename = region_prefix + ".L0-" + i,
@@ -65,18 +65,18 @@ workflow MultilevelHierarchicallyMergeVcfs {
         if (length(batch_sizes) > 1) {
             call CreateBatches as L1_Batches {
                 input:
-                    vcfs = l0_bcfs,
-                    vcf_idxs = l0_idxs,
+                    vcfs_or_bcfs = l0_bcfs,
+                    vcf_or_bcf_idxs = l0_idxs,
                     batch_size = batch_sizes[1]
             }
 
-            scatter (i in range(length(L1_Batches.vcf_batch_fofns))) {
+            scatter (i in range(length(L1_Batches.vcf_or_bcf_batch_fofns))) {
                 call MergeVcfs as L1_Merge {
                     input:
-                        vcfs_localize = if do_localization[1] then read_lines(L1_Batches.vcf_batch_fofns[i]) else [],
-                        vcf_idxs_localize = if do_localization[1] then read_lines(L1_Batches.vcf_idx_batch_fofns[i]) else [],
-                        vcfs_stream = if !do_localization[1] then read_lines(L1_Batches.vcf_batch_fofns[i]) else [],
-                        vcf_idxs_stream = if !do_localization[1] then read_lines(L1_Batches.vcf_idx_batch_fofns[i]) else [],
+                        vcfs_or_bcfs_localize = if do_localization[1] then read_lines(L1_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                        vcf_or_bcf_idxs_localize = if do_localization[1] then read_lines(L1_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
+                        vcfs_or_bcfs_stream = if !do_localization[1] then read_lines(L1_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                        vcf_or_bcf_idxs_stream = if !do_localization[1] then read_lines(L1_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
                         timeout_min = timeouts_min[1],
                         region = region,
                         output_basename = region_prefix + ".L1-" + i,
@@ -94,18 +94,18 @@ workflow MultilevelHierarchicallyMergeVcfs {
         if (length(batch_sizes) > 2) {
             call CreateBatches as L2_Batches {
                 input:
-                    vcfs = l1_bcfs,
-                    vcf_idxs = l1_idxs,
+                    vcfs_or_bcfs = l1_bcfs,
+                    vcf_or_bcf_idxs = l1_idxs,
                     batch_size = batch_sizes[2]
             }
 
-            scatter (i in range(length(L2_Batches.vcf_batch_fofns))) {
+            scatter (i in range(length(L2_Batches.vcf_or_bcf_batch_fofns))) {
                 call MergeVcfs as L2_Merge {
                     input:
-                        vcfs_localize = if do_localization[2] then read_lines(L2_Batches.vcf_batch_fofns[i]) else [],
-                        vcf_idxs_localize = if do_localization[2] then read_lines(L2_Batches.vcf_idx_batch_fofns[i]) else [],
-                        vcfs_stream = if !do_localization[2] then read_lines(L2_Batches.vcf_batch_fofns[i]) else [],
-                        vcf_idxs_stream = if !do_localization[2] then read_lines(L2_Batches.vcf_idx_batch_fofns[i]) else [],
+                        vcfs_or_bcfs_localize = if do_localization[2] then read_lines(L2_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                        vcf_or_bcf_idxs_localize = if do_localization[2] then read_lines(L2_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
+                        vcfs_or_bcfs_stream = if !do_localization[2] then read_lines(L2_Batches.vcf_or_bcf_batch_fofns[i]) else [],
+                        vcf_or_bcf_idxs_stream = if !do_localization[2] then read_lines(L2_Batches.vcf_or_bcf_idx_batch_fofns[i]) else [],
                         timeout_min = timeouts_min[2],
                         region = region,
                         output_basename = region_prefix + ".L2-" + i,
@@ -124,8 +124,8 @@ workflow MultilevelHierarchicallyMergeVcfs {
         if (length(l2_bcfs) > 1) {
             call MergeVcfs as FinalRegionMerge {
                 input:
-                    vcfs_localize = l2_bcfs,
-                    vcf_idxs_localize = l2_idxs,
+                    vcfs_or_bcfs_localize = l2_bcfs,
+                    vcf_or_bcf_idxs_localize = l2_idxs,
                     timeout_min = 0,
                     region = region,
                     output_basename = region_prefix + ".final",
@@ -166,8 +166,8 @@ struct RuntimeAttr {
 
 task CreateBatches {
     input {
-        Array[String] vcfs
-        Array[String] vcf_idxs
+        Array[String] vcfs_or_bcfs
+        Array[String] vcf_or_bcf_idxs
         Int batch_size
 
         RuntimeAttr? runtime_attr_override
@@ -177,13 +177,13 @@ task CreateBatches {
         set -euox pipefail
 
         # Split with -a 4 guarantees strict alphanumeric ordering up to 456,976 batches
-        cat ~{write_lines(vcfs)} | split -a 4 -l ~{batch_size} - vcf_batch_
-        cat ~{write_lines(vcf_idxs)} | split -a 4 -l ~{batch_size} - vcf_idx_batch_
+        cat ~{write_lines(vcfs_or_bcfs)} | split -a 4 -l ~{batch_size} - vcf_batch_
+        cat ~{write_lines(vcf_or_bcf_idxs)} | split -a 4 -l ~{batch_size} - vcf_idx_batch_
     >>>
 
     output {
-        Array[File] vcf_batch_fofns = glob("vcf_batch_*")
-        Array[File] vcf_idx_batch_fofns = glob("vcf_idx_batch_*")
+        Array[File] vcf_or_bcf_batch_fofns = glob("vcf_batch_*")
+        Array[File] vcf_or_bcf_idx_batch_fofns = glob("vcf_idx_batch_*")
     }
 
     #########################
@@ -210,10 +210,10 @@ task CreateBatches {
 
 task MergeVcfs {
     input {
-        Array[File] vcfs_localize = []
-        Array[File] vcf_idxs_localize = []
-        Array[String] vcfs_stream = []
-        Array[String] vcf_idxs_stream = []
+        Array[File] vcfs_or_bcfs_localize = []
+        Array[File] vcf_or_bcf_idxs_localize = []
+        Array[String] vcfs_or_bcfs_stream = []
+        Array[String] vcf_or_bcf_idxs_stream = []
 
         Int timeout_min
         String? region
@@ -225,14 +225,14 @@ task MergeVcfs {
     }
 
     # Dynamically sizes disk if localizing, defaults to 50GB if streaming
-    Int disk_gb = if length(vcfs_localize) > 0 then ceil(2.1*size(vcfs_localize, "GiB")) + 10 else ceil(1.1*size(vcfs_localize, "GiB")) + 10
+    Int disk_gb = if length(vcfs_or_bcfs_localize) > 0 then ceil(2.1*size(vcfs_or_bcfs_localize, "GiB")) + 10 else ceil(1.1*size(vcfs_or_bcfs_stream, "GiB")) + 10
 
     command <<<
         set -euox pipefail
 
-        if [ ~{length(vcfs_localize)} -gt 0 ]; then
+        if [ ~{length(vcfs_or_bcfs_localize)} -gt 0 ]; then
             echo "Localizing files natively via Cromwell..."
-            cat ~{write_lines(vcfs_localize)} > merge_list.txt
+            cat ~{write_lines(vcfs_or_bcfs_localize)} > merge_list.txt
         else
             echo "Slice-and-downloading regions via bcftools view..."
             export GCS_OAUTH_TOKEN=$(gcloud auth application-default print-access-token)
@@ -241,8 +241,8 @@ task MergeVcfs {
 
             # Stitch the VCF and IDX strings together using htslib's explicit index syntax
             paste \
-                ~{write_lines(vcfs_stream)} \
-                ~{write_lines(vcf_idxs_stream)} \
+                ~{write_lines(vcfs_or_bcfs_stream)} \
+                ~{write_lines(vcf_or_bcf_idxs_stream)} \
                 | awk '{print $1"##idx##"$2}' > remote_list.txt
 
             # Prepend the line number (NR) using awk, separated by a pipe, and pass to xargs

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -1,3 +1,10 @@
+# 0.0.16
+2026-08-31 (Date of Last Commit)
+
+* Rename `PreprocessPLs` outputs from `preprocessed_pls_vcf` to `preprocessed_pls_bcf` and update downstream workflow wiring.
+* Switch top-level outputs from `preprocessed_pls_vcf`/`preprocessed_pls_vcf_idx` to `preprocessed_pls_bcf`/`preprocessed_pls_bcf_idx`.
+* Update `multi_level_paste_pipeline_version` to 0.0.11.
+
 # 0.0.15
 2026-08-28 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.changelog.md
@@ -3,7 +3,7 @@
 
 * Rename `PreprocessPLs` outputs from `preprocessed_pls_vcf` to `preprocessed_pls_bcf` and update downstream workflow wiring.
 * Switch top-level outputs from `preprocessed_pls_vcf`/`preprocessed_pls_vcf_idx` to `preprocessed_pls_bcf`/`preprocessed_pls_bcf_idx`.
-* Update `multi_level_paste_pipeline_version` to 0.0.11.
+* update variable names to vcf_or_bcf for any variable that can be either
 
 # 0.0.15
 2026-08-28 (Date of Last Commit)

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -5,8 +5,8 @@ import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputa
 
 workflow PreprocessPLsGVCF {
     # if this changes, update the preprocessing_pls_gvcf_pipeline_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.15"
-    String multi_level_paste_pipeline_version = "0.0.10"
+    String pipeline_version = "0.0.16"
+    String multi_level_paste_pipeline_version = "0.0.11"
     input {
         File input_gvcf_manifest
 
@@ -39,8 +39,8 @@ workflow PreprocessPLsGVCF {
     # two-level localized hierarchical merge over entire chromosome
     call MultilevelHierarchicallyPasteVcfsStreaming.MultilevelHierarchicallyMergeVcfs as PastePreprocessPLsGVCFs {
         input:
-            vcfs_array = PreprocessPLsGVCF.preprocessed_pls_vcf,
-            vcf_idxs_array = PreprocessPLsGVCF.preprocessed_pls_vcf_idx,
+            vcfs_array = PreprocessPLsGVCF.preprocessed_pls_bcf,
+            vcf_idxs_array = PreprocessPLsGVCF.preprocessed_pls_bcf_idx,
             regions = paste_regions,
             batch_sizes = [50, 50],
             do_localization = [true, true],
@@ -51,8 +51,8 @@ workflow PreprocessPLsGVCF {
     }
 
     output {
-        File preprocessed_pls_vcf = PastePreprocessPLsGVCFs.merged_vcf
-        File preprocessed_pls_vcf_idx = PastePreprocessPLsGVCFs.merged_vcf_idx
+        File preprocessed_pls_bcf = PastePreprocessPLsGVCFs.merged_bcf
+        File preprocessed_pls_bcf_idx = PastePreprocessPLsGVCFs.merged_bcf_idx
         Int num_samples = length(ParseInputManifest.input_gvcfs)
     }
 }
@@ -108,8 +108,8 @@ task PreprocessPLs {
     >>>
 
     output {
-        File preprocessed_pls_vcf = "~{output_basename}.bcf"
-        File preprocessed_pls_vcf_idx = "~{output_basename}.bcf.csi"
+        File preprocessed_pls_bcf = "~{output_basename}.bcf"
+        File preprocessed_pls_bcf_idx = "~{output_basename}.bcf.csi"
     }
 
     #########################

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -26,8 +26,8 @@ workflow PreprocessPLsGVCF {
     scatter (j in range(length(ParseInputManifest.input_gvcfs))) {
         call PreprocessPLs as PreprocessPLsGVCF {
             input:
-                input_gvcf_or_vcf = ParseInputManifest.input_gvcfs[j],
-                input_gvcf_or_vcf_idx = ParseInputManifest.input_gvcf_idxs[j],
+                input_vcf_or_bcf = ParseInputManifest.input_gvcfs[j],
+                input_vcf_or_bcf_idx = ParseInputManifest.input_gvcf_idxs[j],
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
@@ -70,8 +70,8 @@ struct RuntimeAttr {
 
 task PreprocessPLs {
     input {
-        File input_gvcf_or_vcf
-        File input_gvcf_or_vcf_idx
+        File input_vcf_or_bcf
+        File input_vcf_or_bcf_idx
         String mode     # joint or gvcf
         File panel_bubble_split_sites_only_vcf
         File panel_bubble_split_sites_only_vcf_idx
@@ -84,17 +84,17 @@ task PreprocessPLs {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size_gb = ceil(2*size([input_gvcf_or_vcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
+    Int disk_size_gb = ceil(2*size([input_vcf_or_bcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
 
     command <<<
         set -euxo pipefail
 
         # Extract sample name from GVCF header and write to file for extract-bubble-PLs tool
-        bcftools query -l ~{input_gvcf_or_vcf} > sample_name.txt
+        bcftools query -l ~{input_vcf_or_bcf} > sample_name.txt
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
-            ~{input_gvcf_or_vcf}##idx##~{input_gvcf_or_vcf_idx} \
+            ~{input_vcf_or_bcf}##idx##~{input_vcf_or_bcf_idx} \
             ~{output_basename}.bcf \
             ~{"--region " + output_region} \
             --samples sample_name.txt \

--- a/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/PreprocessPLsGVCF.wdl
@@ -26,8 +26,8 @@ workflow PreprocessPLsGVCF {
     scatter (j in range(length(ParseInputManifest.input_gvcfs))) {
         call PreprocessPLs as PreprocessPLsGVCF {
             input:
-                input_vcf = ParseInputManifest.input_gvcfs[j],
-                input_vcf_idx = ParseInputManifest.input_gvcf_idxs[j],
+                input_gvcf_or_vcf = ParseInputManifest.input_gvcfs[j],
+                input_gvcf_or_vcf_idx = ParseInputManifest.input_gvcf_idxs[j],
                 mode = "gvcf",
                 panel_bubble_split_sites_only_vcf = preprocess_panel_bubble_split_sites_only_vcf,
                 panel_bubble_split_sites_only_vcf_idx = preprocess_panel_bubble_split_sites_only_vcf_idx,
@@ -39,8 +39,8 @@ workflow PreprocessPLsGVCF {
     # two-level localized hierarchical merge over entire chromosome
     call MultilevelHierarchicallyPasteVcfsStreaming.MultilevelHierarchicallyMergeVcfs as PastePreprocessPLsGVCFs {
         input:
-            vcfs_array = PreprocessPLsGVCF.preprocessed_pls_bcf,
-            vcf_idxs_array = PreprocessPLsGVCF.preprocessed_pls_bcf_idx,
+            vcfs_or_bcfs_array = PreprocessPLsGVCF.preprocessed_pls_bcf,
+            vcf_or_bcf_idxs_array = PreprocessPLsGVCF.preprocessed_pls_bcf_idx,
             regions = paste_regions,
             batch_sizes = [50, 50],
             do_localization = [true, true],
@@ -70,8 +70,8 @@ struct RuntimeAttr {
 
 task PreprocessPLs {
     input {
-        File input_vcf
-        File input_vcf_idx
+        File input_gvcf_or_vcf
+        File input_gvcf_or_vcf_idx
         String mode     # joint or gvcf
         File panel_bubble_split_sites_only_vcf
         File panel_bubble_split_sites_only_vcf_idx
@@ -84,17 +84,17 @@ task PreprocessPLs {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size_gb = ceil(2*size([input_vcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
+    Int disk_size_gb = ceil(2*size([input_gvcf_or_vcf, panel_bubble_split_sites_only_vcf], "GB")) + 10
 
     command <<<
         set -euxo pipefail
 
         # Extract sample name from GVCF header and write to file for extract-bubble-PLs tool
-        bcftools query -l ~{input_vcf} > sample_name.txt
+        bcftools query -l ~{input_gvcf_or_vcf} > sample_name.txt
 
         /usr/local/bin/extract-bubble-PLs ~{mode} \
             ~{panel_bubble_split_sites_only_vcf}##idx##~{panel_bubble_split_sites_only_vcf_idx} \
-            ~{input_vcf}##idx##~{input_vcf_idx} \
+            ~{input_gvcf_or_vcf}##idx##~{input_gvcf_or_vcf_idx} \
             ~{output_basename}.bcf \
             ~{"--region " + output_region} \
             --samples sample_name.txt \

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -390,7 +390,7 @@ task ConvertInputArraysToManifest {
     }
 
     output {
-        File output_manifest = "~{output_filename}"
+        File output_gvcf_manifest = "~{output_filename}"
     }
 }
 

--- a/tasks/wdl/Glimpse2SVImputationTasks.wdl
+++ b/tasks/wdl/Glimpse2SVImputationTasks.wdl
@@ -2,10 +2,10 @@ version 1.0
 
 task MergeSampleChunksVcfsWithPaste {
     input {
-        Array[File] input_vcfs
+        Array[File] input_vcfs_or_bcfs
         String output_vcf_basename
 
-        Int disk_size_gb = ceil(2.2 * size(input_vcfs, "GiB") + 50)
+        Int disk_size_gb = ceil(2.2 * size(input_vcfs_or_bcfs, "GiB") + 50)
         Int mem_gb = 8
         Int cpu = 4
         Int preemptible = 0
@@ -14,7 +14,7 @@ task MergeSampleChunksVcfsWithPaste {
     command <<<
         set -euo pipefail
 
-        vcfs=(~{sep=" " input_vcfs})
+        vcfs=(~{sep=" " input_vcfs_or_bcfs})
 
         mkfifo fifo_0
         mkfifo fifo_to_paste_0
@@ -89,12 +89,12 @@ task MergeSampleChunksVcfsWithPaste {
 
 task ExtractAnnotations {
     input {
-        File imputed_vcf
-        File imputed_vcf_index
+        File imputed_vcf_or_bcf
+        File imputed_vcf_or_bcf_index
         Int batch_index
 
         String docker_extract_annotations
-        Int disk_size_gb = ceil(2 * size(imputed_vcf, "GiB") + 50)
+        Int disk_size_gb = ceil(2 * size(imputed_vcf_or_bcf, "GiB") + 50)
         Int mem_gb = 2
         Int cpu = 1
         Int preemptible = 3
@@ -104,12 +104,12 @@ task ExtractAnnotations {
         set -euo pipefail
 
         # Ensure index is localized so bcftools can use it for random access if needed
-        ls ~{imputed_vcf_index} > /dev/null
+        ls ~{imputed_vcf_or_bcf_index} > /dev/null
 
         printf 'CHROM\tPOS\tREF\tALT\tAF\tINFO\n' > annotations_batch_~{batch_index}.tsv
         bcftools query \
         -f '%CHROM\t%POS\t%REF\t%ALT\t%INFO/AF\t%INFO/INFO\n' \
-        ~{imputed_vcf} >> annotations_batch_~{batch_index}.tsv
+        ~{imputed_vcf_or_bcf} >> annotations_batch_~{batch_index}.tsv
 
         bgzip annotations_batch_~{batch_index}.tsv
     >>>
@@ -130,7 +130,7 @@ task ExtractAnnotations {
 
 task RecomputeAndAnnotate {
     input {
-        File merged_vcf
+        File merged_vcf_or_bcf
         Array[File] annotations
 
         Array[Int] num_samples
@@ -138,7 +138,7 @@ task RecomputeAndAnnotate {
         String output_basename
 
         String docker_merge
-        Int disk_size_gb = ceil(2.2 * size(merged_vcf, "GiB") + size(annotations, "GiB") + 50)
+        Int disk_size_gb = ceil(2.2 * size(merged_vcf_or_bcf, "GiB") + size(annotations, "GiB") + 50)
         Int mem_gb = 6
         Int cpu = 1
         Int preemptible = 0
@@ -204,7 +204,7 @@ EOF
         bgzip aggregated_annotations.tsv
         tabix -s1 -b2 -e2 aggregated_annotations.tsv.gz
 
-        bcftools annotate -a aggregated_annotations.tsv.gz -c CHROM,POS,REF,ALT,AF,INFO -O z -o ~{output_basename}.vcf.gz ~{merged_vcf}
+        bcftools annotate -a aggregated_annotations.tsv.gz -c CHROM,POS,REF,ALT,AF,INFO -O z -o ~{output_basename}.vcf.gz ~{merged_vcf_or_bcf}
     >>>
 
     runtime {
@@ -224,10 +224,10 @@ EOF
 
 task CreateVcfIndexAndMd5 {
     input {
-        File vcf_input
+        File vcf_input_or_bcf
         String output_basename
 
-        Int disk_size_gb = ceil(2.1*size(vcf_input, "GiB")) + 10
+        Int disk_size_gb = ceil(2.1*size(vcf_input_or_bcf, "GiB")) + 10
         Int cpu = 1
         Int memory_mb = 6000
         String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
@@ -237,11 +237,11 @@ task CreateVcfIndexAndMd5 {
     command <<<
         set -euo pipefail
 
-        if [[ "~{vcf_input}" == *.bcf ]]; then
+        if [[ "~{vcf_input_or_bcf}" == *.bcf ]]; then
             # Normalize BCF input to a bgzipped VCF for downstream compatibility.
-            bcftools view -O z -o ~{output_basename}.vcf.gz ~{vcf_input}
+            bcftools view -O z -o ~{output_basename}.vcf.gz ~{vcf_input_or_bcf}
         else
-            ln -sf ~{vcf_input} ~{output_basename}.vcf.gz
+            ln -sf ~{vcf_input_or_bcf} ~{output_basename}.vcf.gz
         fi
 
         bcftools index -t ~{output_basename}.vcf.gz
@@ -266,12 +266,12 @@ task CreateVcfIndexAndMd5 {
 
 task FilterVcfByInfo {
     input {
-        File vcf
+        File vcf_or_bcf
         Float info_threshold
         String output_basename
 
         String docker = "us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943"
-        Int disk_size_gb = ceil(2.2 * size(vcf, "GiB") + 20)
+        Int disk_size_gb = ceil(2.2 * size(vcf_or_bcf, "GiB") + 20)
         Int mem_gb = 4
         Int cpu = 1
         Int preemptible = 3
@@ -280,7 +280,7 @@ task FilterVcfByInfo {
     command <<<
         set -euo pipefail
 
-        bcftools filter -i 'INFO/INFO >= ~{info_threshold}' -O z -o ~{output_basename}.vcf.gz ~{vcf}
+        bcftools filter -i 'INFO/INFO >= ~{info_threshold}' -O z -o ~{output_basename}.vcf.gz ~{vcf_or_bcf}
     >>>
 
     runtime {


### PR DESCRIPTION
### Description

There a number of task input/output variable names that require a bcf vs a vcf or can take either.  This pr is trying to align what a task command is doing with the variable names.  So if a task outputs a bcf file then the output variable name should have `*bcf*` in it.  If a task requires a bcf file then the input variable name should have `*bcf*` in it.  If a variable can take a vcf or a bcf then the variable was updated to  `*vcf_or_bcf*`

Jira Ticket:  https://broadworkbench.atlassian.net/browse/TSPS-1154

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
