### PR TITLE
develop -> staging: update to 582.0.0-slim (#1945)

### DIFF
--- a/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
+++ b/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl
@@ -43,7 +43,7 @@ task TerraCopyFilesFromCloudToCloud {
     memory: "16 GiB"
     cpu: "1"
     disks: "local-disk 32 HDD"
-    docker: "gcr.io/google.com/cloudsdktool/google-cloud-cli:499.0.0-slim"
+    docker: "gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-slim"
     preemptible: 3
   }
 }


### PR DESCRIPTION
### Description

Test failures:
- Optimus: task CompareH5adFilesOptimus, [log](https://console.cloud.google.com/batch/jobsDetail/regions/us-central1/jobs/job-5f2f2bd6-verifyoptimuscompareh5adfilesoptimus-1-e83c16dc/logs?project=terra-f8e3de20) contains: `Cell Metric emptydrops_PValue sums differ by 1.1310%, exceeds 1% tolerance`

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
