### PR TITLE
TSPS-1185 add vcf 4.X version header check to sv inputQC wdl

### DIFF
--- a/pipeline_versions.txt
+++ b/pipeline_versions.txt
@@ -9,9 +9,9 @@ Glimpse2LowPassImputation	 1.1.0	2026-08-26
 Glimpse2LowPassImputationBatch	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQC	 1.1.0	2026-08-26 
 Glimpse2LowPassImputationQuotaConsumed	 1.0.1	2026-08-24 
-Glimpse2SVImputation	 0.0.28	2026-09-03 
+Glimpse2SVImputation	 0.0.29	2026-09-08 
 Glimpse2SVImputationBatch	 0.0.20	2026-08-31 
-Glimpse2SVImputationQC	 0.0.2	2026-08-26 
+Glimpse2SVImputationQC	 0.0.3	2026-09-08 
 Glimpse2SVImputationQuotaConsumed	 0.0.2	2026-08-26 
 IlluminaGenotypingArray	 1.12.27	2026-01-21 
 Imputation	 1.1.23	2025-10-03 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.29
+2026-09-08 (Date of Last Commit)
+
+* Update linked `input_qc_version` to 0.0.3.
+
 # 0.0.28
 2026-09-03 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/Glimpse2SVImputation.wdl
@@ -5,11 +5,11 @@ import "./Glimpse2SVImputationBatch.wdl" as Glimpse2SVImputationBatch
 import "../../../../tasks/wdl/Glimpse2SVImputationTasks.wdl" as Glimpse2SVImputationTasks
 
 workflow Glimpse2SVImputation {
-    String pipeline_version = "0.0.28"
+    String pipeline_version = "0.0.29"
     String preprocess_pls_gvcf_pipeline_version = "0.0.16"
     String batch_pipeline_version = "0.0.20"
     String quota_consumed_version = "0.0.2"
-    String input_qc_version = "0.0.2"
+    String input_qc_version = "0.0.3"
 
     input {
         # if both array inputs and gvcf_manifest are provided, array inputs take precedence

--- a/pipelines/wdl/glimpse/sv_imputation/input_qc/Glimpse2SVImputationQC.changelog.md
+++ b/pipelines/wdl/glimpse/sv_imputation/input_qc/Glimpse2SVImputationQC.changelog.md
@@ -1,3 +1,8 @@
+# 0.0.3
+2026-09-08 (Date of Last Commit)
+
+* Add GVCF header fileformat validation in `ValidateGvcfInput` and fail the task when any input header is not VCFv4.x.
+
 # 0.0.2
 2026-08-26 (Date of Last Commit)
 

--- a/pipelines/wdl/glimpse/sv_imputation/input_qc/Glimpse2SVImputationQC.wdl
+++ b/pipelines/wdl/glimpse/sv_imputation/input_qc/Glimpse2SVImputationQC.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 workflow InputQC {
     # if this changes, update the input_qc_version value in Glimpse2SVImputation.wdl
-    String pipeline_version = "0.0.2"
+    String pipeline_version = "0.0.3"
 
     input {
         # service expects only gvcf_manifest even though main wdl can alternatively take input arrays
@@ -308,6 +308,7 @@ task ValidateGvcfInput {
             local worker_id="$2"
 
             local gvcfs_with_incompatible_contigs=()
+            local gvcfs_with_invalid_vcf_version=()
             local gvcfs_with_missing_format_fields=()
             local gvcfs_with_multiple_samples=()
             local gvcf_sample_ids=()
@@ -317,6 +318,15 @@ task ValidateGvcfInput {
                 echo "[worker $worker_id] Validating GVCF file: $gvcf"
 
                 bcftools view -Ov -h "$gvcf" > "header_${worker_id}.vcf"
+
+                # Ensure the header declares a VCFv4.x fileformat.
+                fileformat_line=$(grep -m1 '^##fileformat=' "header_${worker_id}.vcf" || true)
+                if ! echo "$fileformat_line" | grep -Eq '^##fileformat=VCFv4(\.[0-9]+)?$'; then
+                    echo "[worker $worker_id] GVCF file $gvcf has unsupported fileformat header '${fileformat_line:-<missing>}' (expected VCFv4.x)."
+                    gvcfs_with_invalid_vcf_version+=("$gvcf")
+                else
+                    echo "[worker $worker_id] GVCF file $gvcf declares supported fileformat header: $fileformat_line"
+                fi
 
                 # check that the GVCF contains data for exactly one sample, and record its sample
                 # ID so we can check for sample IDs duplicated across GVCFs once all workers finish
@@ -363,7 +373,7 @@ task ValidateGvcfInput {
                 fi
 
                 # stop early once this worker's own chunk already has enough issues to fill a truncated message
-                total_issue_count=$(( ${#gvcfs_with_incompatible_contigs[@]} + ${#gvcfs_with_missing_format_fields[@]} + ${#gvcfs_with_multiple_samples[@]} ))
+                total_issue_count=$(( ${#gvcfs_with_incompatible_contigs[@]} + ${#gvcfs_with_invalid_vcf_version[@]} + ${#gvcfs_with_missing_format_fields[@]} + ${#gvcfs_with_multiple_samples[@]} ))
                 if [ "$total_issue_count" -gt "$MAX_ITEMS_IN_ERROR_MESSAGES" ]; then
                     echo "[worker $worker_id] found more than $MAX_ITEMS_IN_ERROR_MESSAGES GVCF files with issues in this chunk; skipping the rest of this worker's chunk"
                     break
@@ -377,6 +387,11 @@ task ValidateGvcfInput {
                 printf '%s\n' "${gvcfs_with_incompatible_contigs[@]}" > "results/${worker_id}_incompatible_contigs.txt"
             else
                 : > "results/${worker_id}_incompatible_contigs.txt"
+            fi
+            if [ ${#gvcfs_with_invalid_vcf_version[@]} -gt 0 ]; then
+                printf '%s\n' "${gvcfs_with_invalid_vcf_version[@]}" > "results/${worker_id}_invalid_vcf_version.txt"
+            else
+                : > "results/${worker_id}_invalid_vcf_version.txt"
             fi
             if [ ${#gvcfs_with_missing_format_fields[@]} -gt 0 ]; then
                 printf '%s\n' "${gvcfs_with_missing_format_fields[@]}" > "results/${worker_id}_missing_format.txt"
@@ -405,6 +420,7 @@ task ValidateGvcfInput {
         # Merge every worker's partial results back into single lists before applying the final,
         # truncated aggregate message
         mapfile -t gvcfs_with_incompatible_contigs < <(cat results/*_incompatible_contigs.txt 2>/dev/null)
+        mapfile -t gvcfs_with_invalid_vcf_version < <(cat results/*_invalid_vcf_version.txt 2>/dev/null)
         mapfile -t gvcfs_with_missing_format_fields < <(cat results/*_missing_format.txt 2>/dev/null)
         mapfile -t gvcfs_with_multiple_samples < <(cat results/*_multi_sample.txt 2>/dev/null)
         mapfile -t all_gvcf_sample_ids < <(cat results/*_sample_ids.txt 2>/dev/null)
@@ -433,6 +449,10 @@ task ValidateGvcfInput {
             "All checked GVCF files have contigs compatible with the expected reference dictionary." \
             "${gvcfs_with_incompatible_contigs[@]}"
 
+        report_check_result "GVCF file" "with a VCF header version other than 4.x" \
+            "All checked GVCF files declare a supported VCFv4.x header version." \
+            "${gvcfs_with_invalid_vcf_version[@]}"
+
         report_check_result "GVCF file" "missing the required PL and/or GT FORMAT/ID annotation(s) in its header" \
             "All checked GVCF files declare the expected PL and GT FORMAT/ID annotations in their headers." \
             "${gvcfs_with_missing_format_fields[@]}"
@@ -445,7 +465,7 @@ task ValidateGvcfInput {
             "All GVCF sample IDs are unique across the provided GVCFs." \
             "${duplicate_sample_ids[@]}"
 
-        # passes_qc is true if qc_messages is empty
+        # passes_qc is true only when qc_messages is empty.
         if [ ! -s qc_messages.txt ]; then
             echo "true" > passes_qc.txt
         else

--- a/pipelines/wdl/glimpse/sv_imputation/input_qc/test_inputs/Plumbing/fail_gvcf_version_3_7.json
+++ b/pipelines/wdl/glimpse/sv_imputation/input_qc/test_inputs/Plumbing/fail_gvcf_version_3_7.json
@@ -1,0 +1,13 @@
+{
+  "Glimpse2SVImputationQC.output_basename": "fail_gvcf_version_3_7",
+  "Glimpse2SVImputationQC.gvcf_manifest": "gs://pd-test-storage-public/Glimpse2SVImputationQC/input/plumbing/manifests/gvcfManfiestVersion_3_7.tsv",
+  "Glimpse2SVImputationQC.preprocess_panel_bubble_split_sites_only_vcf": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf",
+  "Glimpse2SVImputationQC.preprocess_panel_bubble_split_sites_only_vcf_idx": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/auxiliary_files/hgsvc-hprc-50.panel.reduced_panel_bubble_split_simple_sites.sorted.bcf.csi",
+  "Glimpse2SVImputationQC.paste_regions": ["chr19,chr20", "chr21,chr22"],
+  "Glimpse2SVImputationQC.chromosomes": ["chr19", "chr20", "chr21", "chr22"],
+  "Glimpse2SVImputationQC.genetic_maps_tsv": "gs://pd-test-storage-public/Glimpse2SVImputation/inputs/b38_genetic_map.tsv",
+  "Glimpse2SVImputationQC.ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "Glimpse2SVImputationQC.chunked_panel_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.chunked_panel.json",
+  "Glimpse2SVImputationQC.pop_glimpse2_panel_resources_json": "gs://pd-test-storage-public/Glimpse2SVImputation/ref_panels/hgsvc_hprc_50/json/hgsvc-hprc-50.panel.pop_panel_resources.json",
+  "Glimpse2SVImputationQC.billing_project_for_rp": "terra-f8e3de20"
+}

--- a/website/docs/Pipelines/Glimpse2SVImputation_Pipeline/README.md
+++ b/website/docs/Pipelines/Glimpse2SVImputation_Pipeline/README.md
@@ -183,7 +183,7 @@ The `InputQC` workflow validates manifest-level and GVCF-level readiness before 
 - each GVCF contains exactly one sample
 - sample IDs are unique across all provided GVCFs
 - PL and GT FORMAT IDs are present in each GVCF header
-- GVCF have vcf format 4.x
+- each GVCF is vcf version 4.x
 
 ### InputQC outputs
 

--- a/website/docs/Pipelines/Glimpse2SVImputation_Pipeline/README.md
+++ b/website/docs/Pipelines/Glimpse2SVImputation_Pipeline/README.md
@@ -183,6 +183,7 @@ The `InputQC` workflow validates manifest-level and GVCF-level readiness before 
 - each GVCF contains exactly one sample
 - sample IDs are unique across all provided GVCFs
 - PL and GT FORMAT IDs are present in each GVCF header
+- GVCF have vcf format 4.x
 
 ### InputQC outputs
 


### PR DESCRIPTION
### Description

We want to make sure any inputs supplied to the pipeline through teaspoons are vcf format 4.x, otherwise qc will fail

jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-1185

GHA: https://github.com/broadinstitute/warp/actions/runs/34277897210/job/102235341726?pr=1954

all tests passed except the one added in this pr
failing submission -  https://app.terra.bio/#workspaces/warp-pipelines/WARP%20Tests/submission_history/59de2377-bd5a-4ad7-8607-bed21bc98b04 

qc_messages from failing submission
<img width="1276" height="763" alt="Screenshot 2026-09-08 at 7 08 33 PM" src="https://github.com/user-attachments/assets/39b60132-6adf-45dd-bc09-2a78218e872c" /> 

----

### Checklist 
If you can answer "yes" to the following items, please add a checkmark next to the appropriate checklist item(s) **and** notify our WARP team by tagging @broadinstitute/warp-admins in a comment on this PR.

- [ ] Did you add inputs, outputs, or tasks to a workflow?
- [ ] Did you modify, delete or move: file paths, file names, input names, output names, or task names?
- [ ] If you made a changelog update, did you update the pipeline version number?
